### PR TITLE
[BUG] Fix duplicate relationship tests when converting old syntax to new arguments syntax

### DIFF
--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -358,13 +358,14 @@ class YamlHandler:
         rel_test = CommentedMap()
         rel_body = CommentedMap()
 
-        # Preserve existing tags (or any other metadata except arguments) on the relationships block
+        # Preserve existing tags (or any other metadata except arguments, to, and field) on the relationships block
+        # Skip "to" and "field" as they are old-style syntax that should be replaced by the new "arguments" block
         if existing_relationship and isinstance(
             existing_relationship.get("relationships"), dict
         ):
             for key, value in existing_relationship["relationships"].items():
-                if key == "arguments":
-                    continue  # arguments will be rebuilt with the new ref/field
+                if key in ("arguments", "to", "field"):
+                    continue  # arguments/to/field will be rebuilt with the new ref/field syntax
                 rel_body[key] = value
 
         # Always set arguments with the latest reference targets


### PR DESCRIPTION
## Problem

When dbt schema files contain relationship tests using the old syntax (`to:` and `field:` at the top level of the `relationships` block), and trellis-datamodel writes back to dbt, it was preserving both the old syntax keys AND adding the new `arguments:` block, causing duplicate relationship tests.

## Solution

Updated `add_relationship_test()` in `yaml_handler.py` to skip `to:` and `field:` keys when preserving metadata from existing relationship tests, just like it already skips `arguments:`. This ensures that when converting old-style syntax to the new `arguments:` syntax, only the new format is written.

## Changes

- Modified `trellis_datamodel/utils/yaml_handler.py` to skip `to` and `field` keys when preserving relationship test metadata
- Added comment explaining why these keys are skipped (they're old-style syntax that should be replaced)

## Testing

Verified that relationship tests with old syntax (like `supervisor_id` in `employee.yml`) are now correctly converted to the new `arguments:` syntax without duplication.

Fixes #24