### PR TITLE
fix: stop writing entity_type to data_model.yml in entity-modeling mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2026-04-13
+
+### Fixed
+- **`entity_type` no longer written to `data_model.yml` in entity-modeling mode**: the auto-save service and the Generate Entities dialog save path were unconditionally including `entity_type: "unclassified"` in every entity payload, causing the field to appear in `data_model.yml` even when `modeling_style: entity_model`. Both save paths now only include `entity_type` when `modeling_style` is `dimensional_model`.
+
 ## [0.13.1] - 2026-04-08
 
 ### Fixed

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -663,7 +663,8 @@
 				entityAttributes,
 				$edges,
 				$nodes,
-				entityId
+				entityId,
+				$modelingStyle === 'dimensional_model'
 			);
 
 			// Success - file downloads automatically
@@ -685,7 +686,8 @@
 				entityAttributes,
 				$edges,
 				$nodes,
-				entityId
+				entityId,
+				$modelingStyle === 'dimensional_model'
 			);
 			await navigator.clipboard.writeText(markdown);
 			

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { entityListFilters, nodes, edges } from '$lib/stores';
+	import { entityListFilters, nodes, edges, modelingStyle } from '$lib/stores';
 	import type { EntityData } from '$lib/types';
 	import { exportDataModelToExcel } from '$lib/utils/excel-export';
 	import Icon from '@iconify/svelte';
@@ -118,7 +118,7 @@
 	}
 
 	function handleExportDataModel() {
-		exportDataModelToExcel($nodes, $edges);
+		exportDataModelToExcel($nodes, $edges, $modelingStyle === 'dimensional_model');
 	}
 
 	// Clear all filters

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -12,13 +12,16 @@
 
 	// Determine entity type icon
 	const typeIcon = $derived(() => {
-		if (entity.entity_type === "dimension") {
-			return "lucide:list";
-		} else if (entity.entity_type === "fact") {
-			return "lucide:bar-chart-3";
-		} else {
-			return "lucide:help-circle";
+		if ($modelingStyle === 'dimensional_model') {
+			if (entity.entity_type === "dimension") {
+				return "lucide:list";
+			} else if (entity.entity_type === "fact") {
+				return "lucide:bar-chart-3";
+			} else {
+				return "lucide:help-circle";
+			}
 		}
+		return "lucide:box";
 	});
 
 	// Type label
@@ -144,9 +147,10 @@
 	<!-- Entity Icon -->
 	<div
 		class="flex-shrink-0"
-		class:text-green-600={entity.entity_type === "dimension"}
-		class:text-blue-600={entity.entity_type === "fact"}
-		class:text-gray-600={entity.entity_type !== "dimension" && entity.entity_type !== "fact"}
+		class:text-green-600={$modelingStyle === 'dimensional_model' && entity.entity_type === "dimension"}
+		class:text-blue-600={$modelingStyle === 'dimensional_model' && entity.entity_type === "fact"}
+		class:text-gray-600={$modelingStyle === 'dimensional_model' && entity.entity_type !== "dimension" && entity.entity_type !== "fact"}
+		class:text-slate-500={$modelingStyle !== 'dimensional_model'}
 	>
 		<Icon icon={typeIcon()} class="w-5 h-5" />
 	</div>

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -574,12 +574,12 @@
                             ? displayTags
                             : undefined;
 
-                    const entity_type = ((n.data as any)?.entity_type) || 'unclassified';
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const domain = ((n.data as any)?.domain) as string | undefined;
                     const domains = ((n.data as any)?.domains) as string[] | undefined;
                     const annotation_type = ((n.data as any)?.annotation_type) as string | undefined;
                     const roles = ((n.data as any)?.roles) as string[] | undefined;
+                    const isDimensional = $modelingStyle === 'dimensional_model';
                     const entity: any = {
                         id: n.id,
                         label: ((n.data.label as string) || '').trim() || 'Entity',
@@ -592,8 +592,11 @@
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
                         tags: tagsToPersist,
-                        entity_type: entity_type,
                     };
+                    // Only include entity_type for dimensional modeling
+                    if (isDimensional) {
+                        entity.entity_type = ((n.data as any)?.entity_type) || 'unclassified';
+                    }
 
                     if (domain && domain.trim()) {
                         entity.domain = domain.trim();

--- a/frontend/src/lib/services/auto-save.test.ts
+++ b/frontend/src/lib/services/auto-save.test.ts
@@ -8,6 +8,13 @@ vi.mock('$lib/api', () => ({
     getApiBase: vi.fn().mockReturnValue('http://localhost:8089/api'),
 }));
 
+// Mock stores
+const mockModelingStyle = { value: 'entity_model' as 'dimensional_model' | 'entity_model' };
+vi.mock('$lib/stores', () => ({
+    sourceColors: { subscribe: (fn: (v: any) => void) => { fn({}); return () => {}; } },
+    modelingStyle: { subscribe: (fn: (v: string) => void) => { fn(mockModelingStyle.value); return () => {}; } },
+}));
+
 import { saveDataModel as apiSaveDataModel } from '$lib/api';
 
 describe('AutoSaveService', () => {
@@ -122,7 +129,8 @@ describe('AutoSaveService', () => {
             expect(apiSaveDataModel).toHaveBeenCalled();
         });
 
-        it('should build correct data model payload', async () => {
+        it('should include entity_type in payload for dimensional modeling', async () => {
+            mockModelingStyle.value = 'dimensional_model';
             const nodes: Node[] = [
                 {
                     id: 'entity1',
@@ -157,6 +165,32 @@ describe('AutoSaveService', () => {
                     ]),
                 })
             );
+        });
+
+        it('should omit entity_type from payload for entity modeling', async () => {
+            mockModelingStyle.value = 'entity_model';
+            const nodes: Node[] = [
+                {
+                    id: 'entity1',
+                    type: 'entity',
+                    position: { x: 100, y: 100 },
+                    data: {
+                        label: 'Test Entity',
+                        description: 'Test description',
+                        entity_type: 'fact',
+                        width: 280,
+                        panelHeight: 200,
+                        collapsed: false,
+                    },
+                },
+            ];
+            const edges: Edge[] = [];
+
+            service.save(nodes, edges);
+            vi.advanceTimersByTime(400);
+
+            const call = (apiSaveDataModel as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(call.entities[0]).not.toHaveProperty('entity_type');
         });
     });
 

--- a/frontend/src/lib/services/auto-save.ts
+++ b/frontend/src/lib/services/auto-save.ts
@@ -3,7 +3,7 @@ import type { DataModel, EntityRole } from '$lib/types';
 import { getApiBase, saveDataModel as apiSaveDataModel } from '$lib/api';
 import { normalizeTags } from '$lib/utils';
 import { get } from 'svelte/store';
-import { sourceColors as sourceColorsStore } from '$lib/stores';
+import { sourceColors as sourceColorsStore, modelingStyle as modelingStyleStore } from '$lib/stores';
 
 /**
  * AutoSave service - Manages debounced saves for node/edge state changes.
@@ -256,12 +256,12 @@ export class AutoSaveService {
                             ? displayTags
                             : undefined;
 
-                    const entity_type = ((n.data as any)?.entity_type) || 'unclassified';
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const annotation_type = ((n.data as any)?.annotation_type) as string | undefined;
                     const roles = ((n.data as any)?.roles) as EntityRole[] | undefined;
                     const domain = ((n.data as any)?.domain) as string | undefined;
                     const domains = ((n.data as any)?.domains) as string[] | undefined;
+                    const isDimensional = get(modelingStyleStore) === 'dimensional_model';
                     const entity: any = {
                         id: n.id,
                         label: ((n.data.label as string) || '').trim() || 'Entity',
@@ -275,9 +275,11 @@ export class AutoSaveService {
                         collapsed: (n.data?.collapsed as boolean) ?? false,
                         // Persist display tags only; schema writes rely on _schemaTags.
                         tags: tagsToPersist,
-                        // Include entity_type with default "unclassified" if not set
-                        entity_type: entity_type,
                     };
+                    // Only include entity_type for dimensional modeling
+                    if (isDimensional) {
+                        entity.entity_type = ((n.data as any)?.entity_type) || 'unclassified';
+                    }
 
                     // Include domain if present
                     if (domain && domain.trim()) {

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -125,12 +125,12 @@ export function formatRelationshipType(type: string): string {
  * @returns Configured XLSX worksheet with bold headers and column widths
  * @note Cell styling (bold headers) requires SheetJS Pro. Community Edition ignores the .s property.
  */
-export function generateOverviewSheet(entity: EntityData): XLSX.WorkSheet {
+export function generateOverviewSheet(entity: EntityData, isDimensional: boolean = true): XLSX.WorkSheet {
 	// Create 2-column array: Field | Value
-	const overviewData = [
+	const overviewData: (string | undefined)[][] = [
 		['Field', 'Value'],
 		['Entity Name', entity.label],
-		['Entity Type', formatEntityType(entity.entity_type)],
+		...(isDimensional ? [['Entity Type', formatEntityType(entity.entity_type)]] : []),
 		['Annotation (7W)', formatAnnotationType(entity.annotation_type)],
 		['Domain(s)', entity.domains?.join(', ') || entity.domain || '-'],
 		['Tags', entity.tags?.join(', ') || '-'],
@@ -273,11 +273,12 @@ export function exportEntityToExcel(
 	attributes: Array<{ name: string; type: string; description?: string; origin?: string }>,
 	edges: any[],
 	allNodes: Node[],
-	entityId: string
+	entityId: string,
+	isDimensional: boolean = true
 ): void {
 	try {
 		// Generate three sheets using generators
-		const overviewSheet = generateOverviewSheet(entity);
+		const overviewSheet = generateOverviewSheet(entity, isDimensional);
 		const attributesSheet = generateAttributesSheet(attributes);
 		const relationshipsSheet = generateRelationshipsSheet(edges, entityId, allNodes);
 
@@ -310,15 +311,10 @@ export function exportEntityToExcel(
  */
 export function generateDataModelOverviewSheet(
 	entityNodes: Node[],
-	edges: any[]
+	edges: any[],
+	isDimensional: boolean = true
 ): XLSX.WorkSheet {
 	const entityCount = entityNodes.length;
-	const factCount = entityNodes.filter(
-		(n) => (n.data as unknown as EntityData).entity_type === 'fact'
-	).length;
-	const dimensionCount = entityNodes.filter(
-		(n) => (n.data as unknown as EntityData).entity_type === 'dimension'
-	).length;
 	const relCount = edges.length;
 
 	const rows: (string | number | undefined)[][] = [];
@@ -327,9 +323,17 @@ export function generateDataModelOverviewSheet(
 	rows.push(['About this Data Model Export']);
 	rows.push(['Exported on', getDateString()]);
 	rows.push(['Total entities', entityCount]);
-	rows.push(['  Facts', factCount]);
-	rows.push(['  Dimensions', dimensionCount]);
-	rows.push(['  Unclassified', entityCount - factCount - dimensionCount]);
+	if (isDimensional) {
+		const factCount = entityNodes.filter(
+			(n) => (n.data as unknown as EntityData).entity_type === 'fact'
+		).length;
+		const dimensionCount = entityNodes.filter(
+			(n) => (n.data as unknown as EntityData).entity_type === 'dimension'
+		).length;
+		rows.push(['  Facts', factCount]);
+		rows.push(['  Dimensions', dimensionCount]);
+		rows.push(['  Unclassified', entityCount - factCount - dimensionCount]);
+	}
 	rows.push(['Total relationships', relCount]);
 	rows.push([]);
 	rows.push([
@@ -339,19 +343,32 @@ export function generateDataModelOverviewSheet(
 
 	// --- Section 2: Entity directory ---
 	rows.push(['Entity Directory']);
-	rows.push(['Name', 'Type', 'Description', 'Domains', 'Tags']);
+	if (isDimensional) {
+		rows.push(['Name', 'Type', 'Description', 'Domains', 'Tags']);
+	} else {
+		rows.push(['Name', 'Description', 'Domains', 'Tags']);
+	}
 	for (const node of entityNodes) {
 		const d = node.data as unknown as EntityData;
 		const domains = Array.isArray(d.domains) && d.domains.length > 0
 			? d.domains.join(', ')
 			: d.domain ?? '';
-		rows.push([
-			d.label ?? '',
-			formatEntityType(d.entity_type),
-			d.description ?? '',
-			domains,
-			d.tags?.join(', ') ?? ''
-		]);
+		if (isDimensional) {
+			rows.push([
+				d.label ?? '',
+				formatEntityType(d.entity_type),
+				d.description ?? '',
+				domains,
+				d.tags?.join(', ') ?? ''
+			]);
+		} else {
+			rows.push([
+				d.label ?? '',
+				d.description ?? '',
+				domains,
+				d.tags?.join(', ') ?? ''
+			]);
+		}
 	}
 	rows.push([]);
 
@@ -395,14 +412,14 @@ function draftedFieldsToAttributes(
  * Remaining sheets: one tab per entity showing its attributes (Name / Type / Description).
  * @param edges SvelteFlow edge objects — used for the overview relationships table.
  */
-export function exportDataModelToExcel(nodes: Node[], edges: any[]): void {
+export function exportDataModelToExcel(nodes: Node[], edges: any[], isDimensional: boolean = true): void {
 	try {
 		const entityNodes = nodes.filter((n) => n.type === 'entity');
 		const wb = XLSX.utils.book_new();
 		const usedSheetNames = new Set<string>();
 
 		// Always include the overview sheet first
-		const overviewSheet = generateDataModelOverviewSheet(entityNodes, edges);
+		const overviewSheet = generateDataModelOverviewSheet(entityNodes, edges, isDimensional);
 		XLSX.utils.book_append_sheet(wb, overviewSheet, sanitizeSheetName('Overview', usedSheetNames));
 
 		if (entityNodes.length === 0) {

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -27,7 +27,8 @@ export function formatEntityAsMarkdown(
 	attributes: Array<{ name: string; type: string; description?: string; origin?: string }>,
 	edges: any[],
 	allNodes: Node[],
-	entityId: string
+	entityId: string,
+	isDimensional: boolean = true
 ): string {
 	const lines: string[] = [];
 
@@ -36,7 +37,9 @@ export function formatEntityAsMarkdown(
 	lines.push('');
 
 	// Metadata section
-	lines.push(`**Type:** ${formatEntityType(entity.entity_type)}`);
+	if (isDimensional) {
+		lines.push(`**Type:** ${formatEntityType(entity.entity_type)}`);
+	}
 	lines.push(`**7W Annotation:** ${formatAnnotationType(entity.annotation_type)}`);
 	lines.push(`**Domain(s):** ${entity.domains?.join(', ') || entity.domain || '-'}`);
 	lines.push(`**Tags:** ${entity.tags?.join(', ') || '-'}`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.13.1"
+version = "0.13.2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- `entity_type: "unclassified"` was being written to `data_model.yml` for every entity when using `modeling_style: entity_model`, because both save paths hardcoded a fallback to `'unclassified'` unconditionally
- Fixed `auto-save.ts` to only include `entity_type` in the payload when `modeling_style === 'dimensional_model'`
- Same fix applied to the direct save path in `GenerateEntitiesDialog.svelte`
- Bumped version to `0.13.2`

## Test plan

- [ ] In entity-modeling mode, create/edit entities and save — verify `data_model.yml` contains no `entity_type` field on entities
- [ ] In dimensional-modeling mode, verify `entity_type` is still written correctly (`fact`, `dimension`, `unclassified`)
- [ ] Generate entities via the Generate Entities dialog in entity-modeling mode — verify no `entity_type` in saved YAML