### PR TITLE
fix: relationship label readability + connection handle visual clarity (v0.13.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-04-13
+
+### Fixed
+- **Relationship label text visible again**: the label name input in the edge editor was inheriting `color: transparent` from the canvas pane, making typed text invisible (white-on-white). An explicit `text-gray-900` now ensures the text is always readable.
+- **Connection handles vs. resize handles disambiguated**: connection handles (top/bottom of entity) now show a teal `mdi:arrow-up` / `mdi:arrow-down` icon on hover with a matching teal background, clearly distinguishing them from the resize handles (right/bottom edge) which keep their existing teal glow. Arrows are invisible at rest and only appear on hover. Left/right connection handles removed — connections are created from the top and bottom edges only. Tooltip updated to "Drag to other entity to create relationship".
+
 ## [0.13.2] - 2026-04-13
 
 ### Fixed

--- a/frontend/src/lib/components/CustomEdge.svelte
+++ b/frontend/src/lib/components/CustomEdge.svelte
@@ -549,7 +549,7 @@
           value={label}
           oninput={onLabelChange}
           onchange={onLabelChange}
-          class="text-xs font-medium focus:outline-none bg-white flex-1 border border-slate-200 rounded px-1.5 py-0.5 focus:border-[#26A69A] min-w-[100px]"
+          class="text-xs font-medium text-gray-900 focus:outline-none bg-white flex-1 border border-slate-200 rounded px-1.5 py-0.5 focus:border-[#26A69A] min-w-[100px]"
           placeholder="relationship..."
         />
         <button 

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1951,13 +1951,12 @@
         display: flex !important;
         align-items: center !important;
         justify-content: center !important;
-        transition: color 0.15s, background-color 0.15s, transform 0.15s;
+        transition: color 0.15s, background-color 0.15s;
     }
 
     :global(.connection-handle:hover) {
         color: rgb(59 130 246) !important; /* blue-500 */
         background-color: rgb(239 246 255) !important; /* blue-50 */
-        transform: scale(1.2);
     }
 
     .height-resize-handle {

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1061,22 +1061,6 @@
         <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
     </Handle>
 
-    <!-- Left -->
-    <Handle type="target" position={Position.Left} id="left-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
-    </Handle>
-    <Handle type="source" position={Position.Left} id="left-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
-    </Handle>
-
-    <!-- Right -->
-    <Handle type="target" position={Position.Right} id="right-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
-    </Handle>
-    <Handle type="source" position={Position.Right} id="right-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
-    </Handle>
-
     <!-- Bottom -->
     <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
         <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1054,20 +1054,20 @@
 >
     <!-- Handles on all 4 sides for flexible edge routing -->
     <!-- Top -->
-    <Handle type="target" position={Position.Top} id="top-target" class="!bg-gray-400 !w-2 !h-2" />
-    <Handle type="source" position={Position.Top} id="top-source" class="!bg-gray-400 !w-2 !h-2" />
-    
+    <Handle type="target" position={Position.Top} id="top-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="source" position={Position.Top} id="top-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+
     <!-- Left -->
-    <Handle type="target" position={Position.Left} id="left-target" class="!bg-gray-400 !w-2 !h-2" />
-    <Handle type="source" position={Position.Left} id="left-source" class="!bg-gray-400 !w-2 !h-2" />
-    
+    <Handle type="target" position={Position.Left} id="left-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="source" position={Position.Left} id="left-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+
     <!-- Right -->
-    <Handle type="target" position={Position.Right} id="right-target" class="!bg-gray-400 !w-2 !h-2" />
-    <Handle type="source" position={Position.Right} id="right-source" class="!bg-gray-400 !w-2 !h-2" />
-    
+    <Handle type="target" position={Position.Right} id="right-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="source" position={Position.Right} id="right-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+
     <!-- Bottom -->
-    <Handle type="target" position={Position.Bottom} id="bottom-target" class="!bg-gray-400 !w-2 !h-2" />
-    <Handle type="source" position={Position.Bottom} id="bottom-source" class="!bg-gray-400 !w-2 !h-2" />
+    <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="source" position={Position.Bottom} id="bottom-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
 
     <!-- Header -->
     <div
@@ -1944,6 +1944,12 @@
     .width-resize-handle:hover,
     .height-resize-handle:hover {
         background: rgba(38, 166, 154, 0.2);
+    }
+
+    :global(.connection-handle:hover) {
+        background-color: rgb(59 130 246) !important; /* blue-500 */
+        transform: scale(1.3);
+        transition: background-color 0.15s, transform 0.15s;
     }
 
     .height-resize-handle {

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1955,8 +1955,8 @@
     }
 
     :global(.connection-handle:hover) {
-        color: rgb(59 130 246) !important; /* blue-500 */
-        background-color: rgb(239 246 255) !important; /* blue-50 */
+        color: rgb(38 166 154) !important; /* teal #26A69A */
+        background-color: rgb(224 242 241) !important; /* teal-50 */
     }
 
     .height-resize-handle {

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1947,7 +1947,7 @@
     }
 
     :global(.connection-handle) {
-        color: rgb(209 213 219); /* gray-300 — icon default */
+        color: transparent;
         display: flex !important;
         align-items: center !important;
         justify-content: center !important;

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1054,20 +1054,36 @@
 >
     <!-- Handles on all 4 sides for flexible edge routing -->
     <!-- Top -->
-    <Handle type="target" position={Position.Top} id="top-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
-    <Handle type="source" position={Position.Top} id="top-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="target" position={Position.Top} id="top-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
+    <Handle type="source" position={Position.Top} id="top-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
 
     <!-- Left -->
-    <Handle type="target" position={Position.Left} id="left-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
-    <Handle type="source" position={Position.Left} id="left-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="target" position={Position.Left} id="left-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
+    <Handle type="source" position={Position.Left} id="left-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
 
     <!-- Right -->
-    <Handle type="target" position={Position.Right} id="right-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
-    <Handle type="source" position={Position.Right} id="right-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="target" position={Position.Right} id="right-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
+    <Handle type="source" position={Position.Right} id="right-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
 
     <!-- Bottom -->
-    <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
-    <Handle type="source" position={Position.Bottom} id="bottom-source" class="connection-handle !w-2.5 !h-2.5 !rounded-full !bg-gray-300 !border-0" title="Drag to create relationship" />
+    <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
+    <Handle type="source" position={Position.Bottom} id="bottom-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    </Handle>
 
     <!-- Header -->
     <div
@@ -1946,10 +1962,18 @@
         background: rgba(38, 166, 154, 0.2);
     }
 
+    :global(.connection-handle) {
+        color: rgb(209 213 219); /* gray-300 — icon default */
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        transition: color 0.15s, background-color 0.15s, transform 0.15s;
+    }
+
     :global(.connection-handle:hover) {
-        background-color: rgb(59 130 246) !important; /* blue-500 */
-        transform: scale(1.3);
-        transition: background-color 0.15s, transform 0.15s;
+        color: rgb(59 130 246) !important; /* blue-500 */
+        background-color: rgb(239 246 255) !important; /* blue-50 */
+        transform: scale(1.2);
     }
 
     .height-resize-handle {

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -1054,18 +1054,18 @@
 >
     <!-- Handles on all 4 sides for flexible edge routing -->
     <!-- Top -->
-    <Handle type="target" position={Position.Top} id="top-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    <Handle type="target" position={Position.Top} id="top-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to other entity to create relationship">
+        <Icon icon="mdi:arrow-up" class="w-3 h-3 pointer-events-none" />
     </Handle>
-    <Handle type="source" position={Position.Top} id="top-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
-        <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
+    <Handle type="source" position={Position.Top} id="top-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to other entity to create relationship">
+        <Icon icon="mdi:arrow-up" class="w-3 h-3 pointer-events-none" />
     </Handle>
 
     <!-- Bottom -->
-    <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+    <Handle type="target" position={Position.Bottom} id="bottom-target" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to other entity to create relationship">
         <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
     </Handle>
-    <Handle type="source" position={Position.Bottom} id="bottom-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to create relationship">
+    <Handle type="source" position={Position.Bottom} id="bottom-source" class="connection-handle !w-5 !h-5 !rounded-full !bg-transparent !border-0" title="Drag to other entity to create relationship">
         <Icon icon="mdi:arrow-down" class="w-3 h-3 pointer-events-none" />
     </Handle>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.13.2"
+version = "0.13.3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- **White-on-white relationship label text**: the label name input in the edge editor was inheriting `color: transparent` from the canvas pane, making typed text invisible. Fixed with explicit `text-gray-900`.
- **Connection vs. resize handle disambiguation**: connection handles (top/bottom) now show a teal `mdi:arrow-up` / `mdi:arrow-down` icon on hover, clearly distinct from the resize handles (right/bottom edge) which keep their teal glow. Arrows are hidden at rest, visible on hover. Left/right connection handles removed. Tooltip updated to "Drag to other entity to create relationship".
- Version bumped to **0.13.3**.

## Test plan

- [x] 315 tests passing (`uv run pytest`)
- [ ] Hover over top/bottom edge of an entity — teal arrow appears
- [ ] Hover over right/bottom edge of an entity — teal resize glow appears (no arrow)
- [ ] Select a relationship edge, type a label name — text is readable (not invisible)
- [ ] Verify no connection handles on left/right sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)