### PR TITLE
fix: relax dbt version constraint in company dummy

### DIFF
--- a/dbt_company_dummy/generate_data.py
+++ b/dbt_company_dummy/generate_data.py
@@ -717,7 +717,7 @@ def scaffold_dbt_project():
 version: '1.0.0'
 config-version: 2
 
-require-dbt-version: "1.10.0"
+require-dbt-version: ">=1.10.0"
 
 profile: 'company_dummy'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.14.0"
+version = "0.14.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Relax dbt version constraint from exact match `"1.10.0"` to range `">=1.10.0"` in `dbt_company_dummy/generate_data.py`
- Allows any dbt 1.10.x version to work with the company dummy project
- Fixes version conflict when users have dbt-core >1.10.0 installed

## Testing
- Validated locally: `dbt run` passes with dbt 1.10.15 (37 models)
- Deprecation warning about `arguments:` syntax in tests remains but doesn't break functionality