### PR TITLE
fix: entity-model generate dialog, canvas topology, and edge labels (0.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-04-17
+
+### Added
+- **Generate Entities (entity model) — topology in one group**: relationship endpoints from the preview (e.g. Employee, Account) appear under **“From this generation”** together with the derived preview entity, instead of only under “Available in this event”.
+- **Create All — stub nodes for relationship endpoints**: when an endpoint is not yet on the canvas, Create All adds a lightweight dimension stub so edges can be created and the filtered canvas shows the full topology.
+
+### Fixed
+- **Generate preview dialog**: in-flight preview requests are aborted when the dialog closes; a server timeout avoids an endless spinner; the preview-loading effect no longer retriggered in a tight loop (which could freeze the browser); `loading` resets when the dialog closes.
+- **Relationship edge labels**: filler labels that only repeat the target entity’s name or id (as emitted by the generator) are cleared on the canvas; regenerating overwrites stale filler text on existing edges.
+
 ## [0.14.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.1] - 2026-04-17
+## [0.14.3] - 2026-04-17
 
 ### Added
 - **Generate Entities (entity model) — topology in one group**: relationship endpoints from the preview (e.g. Employee, Account) appear under **“From this generation”** together with the derived preview entity, instead of only under “Available in this event”.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -833,6 +833,28 @@ export async function removeAnnotation(
     }
 }
 
+/** Abort fetch if the server never responds (avoids an endless “Generating preview…” spinner). */
+function previewGenerateTimeoutSignal(ms: number): AbortSignal {
+    if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+        return AbortSignal.timeout(ms);
+    }
+    const c = new AbortController();
+    setTimeout(() => c.abort(), ms);
+    return c.signal;
+}
+
+function combinePreviewSignals(user: AbortSignal | undefined, timeoutMs: number): AbortSignal {
+    const t = previewGenerateTimeoutSignal(timeoutMs);
+    if (!user) {
+        return t;
+    }
+    const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+    if (typeof anyFn === 'function') {
+        return anyFn([user, t]);
+    }
+    return t;
+}
+
 /**
  * Generate entities from a business event.
  * Supports both annotation-based and 7 Ws-based entity generation.
@@ -840,11 +862,14 @@ export async function removeAnnotation(
  * @returns Promise containing GeneratedEntitiesResult
  */
 export async function generateEntitiesFromEvent(
-    eventId: string
+    eventId: string,
+    options?: { signal?: AbortSignal }
 ): Promise<GeneratedEntitiesResult> {
+    const signal = combinePreviewSignals(options?.signal, 120_000);
     try {
         const res = await fetch(`${API_BASE}/business-events/${eventId}/generate-entities`, {
             method: 'POST',
+            signal,
         });
         if (!res.ok) {
             const error = await res.json();
@@ -854,6 +879,12 @@ export async function generateEntitiesFromEvent(
         // Handle both direct response and wrapped response formats
         return Array.isArray(data?.entities) ? data : { entities: [], relationships: [], errors: [] };
     } catch (e) {
+        const name = e instanceof Error ? e.name : '';
+        if (name === 'AbortError' || name === 'TimeoutError') {
+            throw new Error(
+                'Error generating entities: request timed out or was cancelled (check that the API is running).'
+            );
+        }
         const message = e instanceof Error ? e.message : String(e);
         throw new Error(`Error generating entities: ${message}`);
     }
@@ -866,11 +897,14 @@ export async function generateEntitiesFromEvent(
  * @returns Promise containing GeneratedEntitiesResult
  */
 export async function generateEntitiesFromProcess(
-    processId: string
+    processId: string,
+    options?: { signal?: AbortSignal }
 ): Promise<GeneratedEntitiesResult> {
+    const signal = combinePreviewSignals(options?.signal, 120_000);
     try {
         const res = await fetch(`${API_BASE}/processes/${processId}/generate-entities`, {
             method: 'POST',
+            signal,
         });
         if (!res.ok) {
             const error = await res.json();
@@ -880,6 +914,12 @@ export async function generateEntitiesFromProcess(
         // Handle both direct response and wrapped response formats
         return Array.isArray(data?.entities) ? data : { entities: [], relationships: [], errors: [] };
     } catch (e) {
+        const name = e instanceof Error ? e.name : '';
+        if (name === 'AbortError' || name === 'TimeoutError') {
+            throw new Error(
+                'Error generating entities from process: request timed out or was cancelled (check that the API is running).'
+            );
+        }
         const message = e instanceof Error ? e.message : String(e);
         throw new Error(`Error generating entities from process: ${message}`);
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -617,7 +617,7 @@ export async function updateBusinessEventAnnotations(
  * @param filterByType - Optional annotation type filter (annotation_type)
  * @returns Promise containing array of Dimension objects
  */
-export async function getDimensions(filterByType?: AnnotationType): Promise<Dimension[]> {
+export async function getDimensions(filterByType?: AnnotationType, includeAllEntities = false): Promise<Dimension[]> {
     try {
         let url = `${API_BASE}/data-model`;
         const params = new URLSearchParams();
@@ -637,13 +637,12 @@ export async function getDimensions(filterByType?: AnnotationType): Promise<Dime
         }
 
         const data = await res.json();
-        // Filter entities to return only dimensions
         const entities = data.entities || [];
         return entities
-            .filter((e: Dimension) => e.entity_type === 'dimension')
+            .filter((e: Dimension) => includeAllEntities || e.entity_type === 'dimension')
             .filter((e: Dimension) => {
-                // If annotation_type filter specified, only return matching dimensions
-                if (filterByType) {
+                // annotation_type filter only applies for dimensional mode
+                if (!includeAllEntities && filterByType) {
                     return e.annotation_type === filterByType;
                 }
                 return true;

--- a/frontend/src/lib/businessEventCanvasFilter.ts
+++ b/frontend/src/lib/businessEventCanvasFilter.ts
@@ -1,0 +1,69 @@
+import type { BusinessEvent, BusinessEventAnnotations, BusinessEventProcess } from './types';
+
+/** All dimension_id values linked from 7 Ws annotations. */
+export function collectDimensionIdsFromAnnotations(
+    ann: BusinessEventAnnotations | undefined
+): string[] {
+    if (!ann) return [];
+    const buckets = [ann.who, ann.what, ann.when, ann.where, ann.how, ann.why, ann.how_many];
+    const ids: string[] = [];
+    for (const bucket of buckets) {
+        for (const entry of bucket || []) {
+            if (entry.dimension_id) ids.push(entry.dimension_id);
+        }
+    }
+    return ids;
+}
+
+/**
+ * Entity IDs to show when opening the canvas filtered for one business event:
+ * derived entities plus every canvas entity referenced via annotation links.
+ */
+export function getCanvasFilterEntityIdsForEvent(event: BusinessEvent): string[] {
+    const ids = new Set<string>();
+    for (const entry of event.derived_entities ?? []) {
+        const id = typeof entry === 'string' ? entry : entry.entity_id;
+        if (id) ids.add(id);
+    }
+    for (const id of collectDimensionIdsFromAnnotations(event.annotations)) {
+        ids.add(id);
+    }
+    return Array.from(ids);
+}
+
+/** Union of filter IDs for all events in a process group (for fallback when process has no derived_entities). */
+export function getCanvasFilterEntityIdsForEvents(events: BusinessEvent[]): string[] {
+    const ids = new Set<string>();
+    for (const event of events) {
+        for (const id of getCanvasFilterEntityIdsForEvent(event)) {
+            ids.add(id);
+        }
+    }
+    return Array.from(ids);
+}
+
+/**
+ * Process-level canvas filter: derived process entities plus dimensions linked in annotations_superset.
+ */
+export function getCanvasFilterEntityIdsForProcess(process: BusinessEventProcess): string[] {
+    const ids = new Set<string>();
+    for (const entry of process.derived_entities ?? []) {
+        const id = typeof entry === 'string' ? entry : entry.entity_id;
+        if (id) ids.add(id);
+    }
+    for (const id of collectDimensionIdsFromAnnotations(process.annotations_superset)) {
+        ids.add(id);
+    }
+    return Array.from(ids);
+}
+
+/** Full set for “view on canvas” from a process group: process + every member event (deduped). */
+export function getCanvasFilterEntityIdsForProcessGroup(
+    process: BusinessEventProcess,
+    memberEvents: BusinessEvent[]
+): string[] {
+    const ids = new Set<string>();
+    for (const id of getCanvasFilterEntityIdsForProcess(process)) ids.add(id);
+    for (const id of getCanvasFilterEntityIdsForEvents(memberEvents)) ids.add(id);
+    return Array.from(ids);
+}

--- a/frontend/src/lib/components/BusinessEvents.svelte
+++ b/frontend/src/lib/components/BusinessEvents.svelte
@@ -14,6 +14,7 @@ import type {
     BusinessEventAnnotations,
 } from '$lib/types';
 import { toTitleCase } from '$lib/utils';
+import { getCanvasFilterEntityIdsForProcessGroup } from '$lib/businessEventCanvasFilter';
 import { modelingStyle } from '$lib/stores';
     import { onMount } from 'svelte';
     import { goto } from '$app/navigation';
@@ -810,21 +811,6 @@ let dropIndicatorPosition = $state<'before' | 'after' | null>(null);
         showProcessGroupModal = false;
     }
 
-    function getDerivedEntityIds(events: BusinessEvent[]): string[] {
-        const ids = events
-            .flatMap((event) => event.derived_entities ?? [])
-            .map((entry) => (typeof entry === "string" ? entry : entry.entity_id))
-            .filter((id): id is string => Boolean(id));
-        return Array.from(new Set(ids));
-    }
-
-    function getProcessDerivedEntityIds(process: BusinessEventProcess): string[] {
-        const ids = (process.derived_entities ?? [])
-            .map((entry) => (typeof entry === "string" ? entry : entry.entity_id))
-            .filter((id): id is string => Boolean(id));
-        return Array.from(new Set(ids));
-    }
-
 </script>
 
 <div class="h-full w-full overflow-auto bg-gray-50">
@@ -1065,7 +1051,10 @@ let dropIndicatorPosition = $state<'before' | 'after' | null>(null);
                                         </div>
                                     {/if}
                                     {#each domainGroup.processes as processGroup (processGroup.process.id)}
-                                        {@const derivedIds = getProcessDerivedEntityIds(processGroup.process).length > 0 ? getProcessDerivedEntityIds(processGroup.process) : getDerivedEntityIds(processGroup.events)}
+                                        {@const derivedIds = getCanvasFilterEntityIdsForProcessGroup(
+                                            processGroup.process,
+                                            processGroup.events
+                                        )}
                                         <div
                                             class="space-y-2 rounded-lg border border-gray-200 bg-gray-50 shadow-sm"
                                             class:border-primary-300={dragOverProcessId === processGroup.process.id}

--- a/frontend/src/lib/components/Canvas.svelte
+++ b/frontend/src/lib/components/Canvas.svelte
@@ -98,7 +98,6 @@
         displayNodes = filteredNodes();
     });
 
-
     // Sync changes from displayNodes back to $nodes store when users interact
     // This ensures drag operations and other changes are persisted
     $effect(() => {

--- a/frontend/src/lib/components/CustomEntitySelect.svelte
+++ b/frontend/src/lib/components/CustomEntitySelect.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+    import Icon from "@iconify/svelte";
+
+    type Option = { id: string; label: string };
+    type Group = { label: string; options: Option[] };
+
+    type Props = {
+        value: string;
+        groups: Group[];
+        onChange: (value: string) => void;
+        class?: string;
+    };
+
+    let { value, groups, onChange, class: className = "" }: Props = $props();
+
+    let isOpen = $state(false);
+    let containerRef = $state<HTMLDivElement>();
+
+    const selectedOption = $derived(
+        groups.flatMap((g) => g.options).find((o) => o.id === value)
+    );
+
+    function toggle() {
+        isOpen = !isOpen;
+    }
+
+    function selectOption(id: string) {
+        onChange(id);
+        isOpen = false;
+    }
+
+    $effect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (containerRef && !containerRef.contains(event.target as Node)) {
+                isOpen = false;
+            }
+        }
+
+        if (isOpen) {
+            document.addEventListener("click", handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener("click", handleClickOutside);
+        };
+    });
+</script>
+
+<div class="relative w-full {className}" bind:this={containerRef}>
+    <button
+        type="button"
+        onclick={toggle}
+        class="flex w-full min-w-[11rem] items-center justify-between rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-3 text-sm font-medium text-gray-800 shadow-sm transition-colors hover:border-gray-300 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+    >
+        <span class="truncate pr-4">{selectedOption?.label || "Select entity..."}</span>
+        <Icon
+            icon="lucide:chevron-down"
+            class="h-4 w-4 shrink-0 text-gray-500 transition-transform {isOpen ? 'rotate-180' : ''}"
+        />
+    </button>
+
+    {#if isOpen}
+        <div
+            class="absolute left-0 z-50 mt-1 max-h-60 w-full min-w-[14rem] overflow-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5"
+        >
+            <ul role="listbox" class="focus:outline-none">
+                {#each groups as group}
+                    {#if group.options.length > 0}
+                        <li
+                            class="bg-gray-50/80 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-gray-500"
+                        >
+                            {group.label}
+                        </li>
+                        {#each group.options as opt}
+                            {@const isSelected = opt.id === value}
+                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                            <li
+                                role="option"
+                                aria-selected={isSelected}
+                                class="relative cursor-pointer select-none py-2 pl-3 pr-9 text-sm text-gray-900 hover:bg-primary-50 hover:text-primary-700 {isSelected
+                                    ? 'bg-primary-50 font-medium text-primary-700'
+                                    : ''}"
+                                onclick={() => selectOption(opt.id)}
+                            >
+                                <span class="block truncate">{opt.label}</span>
+                                {#if isSelected}
+                                    <span
+                                        class="absolute inset-y-0 right-0 flex items-center pr-3 text-primary-600"
+                                    >
+                                        <Icon icon="lucide:check" class="h-4 w-4" />
+                                    </span>
+                                {/if}
+                            </li>
+                        {/each}
+                    {/if}
+                {/each}
+            </ul>
+        </div>
+    {/if}
+</div>

--- a/frontend/src/lib/components/EventCard.svelte
+++ b/frontend/src/lib/components/EventCard.svelte
@@ -198,7 +198,7 @@
 
         <!-- Status badges -->
         <div class="flex items-center gap-2 flex-shrink-0">
-            {#if annotationsFilledCount > 0}
+            {#if annotationsFilledCount > 0 && $modelingStyle === 'dimensional_model'}
                 <span
                     class="px-2 py-1 rounded text-xs font-medium border {annotationsBadgeColor()} flex items-center gap-1"
                     title="Annotations completion status"

--- a/frontend/src/lib/components/EventCard.svelte
+++ b/frontend/src/lib/components/EventCard.svelte
@@ -2,6 +2,7 @@
     import Icon from "@iconify/svelte";
     import type { BusinessEvent, BusinessEventProcess } from "$lib/types";
     import { deleteBusinessEvent } from "$lib/api";
+    import { modelingStyle } from "$lib/stores";
     type Props = {
         event: BusinessEvent;
         process?: BusinessEventProcess;
@@ -76,7 +77,9 @@
         annotations.how.length > 0 || 
         annotations.why.length > 0
     );
-    const canGenerateEntities = $derived(hasDimensionEntries && hasHowManyEntries);
+    const canGenerateEntities = $derived(
+        $modelingStyle === 'entity_model' ? hasDimensionEntries : hasDimensionEntries && hasHowManyEntries
+    );
     const hasDerivedEntities = $derived(event.derived_entities.length > 0);
 
     // Type badge colors
@@ -256,10 +259,14 @@
                 class:cursor-pointer={canGenerateEntities}
                 title={
                     canGenerateEntities
-                        ? "Generate dimensional entities from annotations"
-                        : !hasHowManyEntries
-                            ? "Add 'How Many' entries to generate fact table"
-                            : "Add dimension entries (Who, What, When, Where, How, or Why) to generate entities"
+                        ? $modelingStyle === 'entity_model'
+                            ? "Generate entities and relationships from annotations"
+                            : "Generate dimensional entities from annotations"
+                        : $modelingStyle === 'entity_model'
+                            ? "Add entries (Who, What, When, Where, How, or Why) to generate entities"
+                            : !hasHowManyEntries
+                                ? "Add 'How Many' entries to generate fact table"
+                                : "Add dimension entries (Who, What, When, Where, How, or Why) to generate entities"
                 }
             >
                 <Icon icon="lucide:sparkles" class="w-4 h-4" />

--- a/frontend/src/lib/components/EventCard.svelte
+++ b/frontend/src/lib/components/EventCard.svelte
@@ -2,6 +2,7 @@
     import Icon from "@iconify/svelte";
     import type { BusinessEvent, BusinessEventProcess } from "$lib/types";
     import { deleteBusinessEvent } from "$lib/api";
+    import { getCanvasFilterEntityIdsForEvent } from "$lib/businessEventCanvasFilter";
     import { modelingStyle } from "$lib/stores";
     type Props = {
         event: BusinessEvent;
@@ -82,6 +83,9 @@
     );
     const hasDerivedEntities = $derived(event.derived_entities.length > 0);
 
+    /** Derived + annotation-linked dimensions — used for canvas deep-link */
+    const canvasFilterEntityIds = $derived(getCanvasFilterEntityIdsForEvent(event));
+
     // Type badge colors
     const typeBadgeClass = $derived(() => {
         switch (event.type) {
@@ -127,13 +131,6 @@
         if (event.target === event.currentTarget) {
             handleDeleteCancel();
         }
-    }
-
-    function getDerivedEntityIds() {
-        const derivedEntities = event.derived_entities ?? [];
-        return derivedEntities
-            .map((entry) => (typeof entry === "string" ? entry : entry.entity_id))
-            .filter((id) => !!id);
     }
 
 </script>
@@ -272,11 +269,11 @@
                 <Icon icon="lucide:sparkles" class="w-4 h-4" />
             </button>
 
-            {#if hasDerivedEntities}
+            {#if canvasFilterEntityIds.length > 0}
                 <a
-                    href="/canvas?entities={getDerivedEntityIds().join(',')}&eventText={encodeURIComponent(event.text)}"
+                    href="/canvas?entities={canvasFilterEntityIds.map(encodeURIComponent).join(',')}&eventText={encodeURIComponent(event.text)}"
                     class="p-1.5 text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
-                    title="View entities on canvas"
+                    title="View related entities on canvas"
                 >
                     <Icon icon="lucide:layout-dashboard" class="w-4 h-4" />
                 </a>

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -364,7 +364,7 @@
                     }
                     // Entity already exists - merge drafted_fields (preserve manually added fields)
                     // and update description if provided
-                    if (edited.entity_type === 'fact' && ((original as any).drafted_fields || original.description)) {
+                    if ((edited.entity_type === 'fact' || edited.entity_type === 'entity') && ((original as any).drafted_fields || original.description)) {
                         nodesToUse = nodesToUse.map((n) => {
                             if (n.id === normalizedEditedId) {
                                 const existingDraftedFields: any[] = Array.isArray((n.data as any)?.drafted_fields)
@@ -810,6 +810,11 @@
                     {/if}
 
                     <!-- Entities Table -->
+                    {#if $modelingStyle === 'entity_model'}
+                        <p class="text-xs text-gray-500">
+                            Rename the central entity to the core concept (e.g. the verb or transaction, not the full sentence).
+                        </p>
+                    {/if}
                     <div class="border border-gray-200 rounded-lg overflow-hidden">
                         <table class="w-full">
                             <thead class="bg-gray-50 border-b border-gray-200">
@@ -897,6 +902,32 @@
                             </tbody>
                         </table>
                     </div>
+
+                    <!-- Drafted Fields (entity_model only) -->
+                    {#if $modelingStyle === 'entity_model'}
+                        {@const allDraftedFields = previewData.entities.flatMap((e) => (e as any).drafted_fields || [])}
+                        {#if allDraftedFields.length > 0}
+                            <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                                <div class="flex items-start gap-2 mb-2">
+                                    <Icon icon="lucide:list" class="w-4 h-4 text-amber-700 mt-0.5 flex-shrink-0" />
+                                    <div>
+                                        <h3 class="text-sm font-medium text-amber-800">Attributes (drafted fields)</h3>
+                                        <p class="text-xs text-amber-700 mt-0.5">
+                                            Unlinked annotations become attributes on the central entity.
+                                            To make one a separate entity instead, link it via "Link to entity" in the annotations form.
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="flex flex-wrap gap-1.5 mt-2">
+                                    {#each allDraftedFields as field}
+                                        <span class="px-2 py-0.5 bg-white border border-amber-300 rounded text-xs font-mono text-amber-900">
+                                            {field.name}
+                                        </span>
+                                    {/each}
+                                </div>
+                            </div>
+                        {/if}
+                    {/if}
 
                     <!-- Relationships Section -->
                     {#if previewData.relationships && previewData.relationships.length > 0}

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import { generateEntitiesFromEvent, generateEntitiesFromProcess, updateBusinessEvent, updateBusinessEventProcess, saveDataModel, getBusinessEvents } from '$lib/api';
-    import type { BusinessEvent, BusinessEventProcess, GeneratedEntitiesResult } from '$lib/types';
+    import type {
+        BusinessEvent,
+        BusinessEventAnnotations,
+        BusinessEventProcess,
+        GeneratedEntitiesResult,
+    } from '$lib/types';
     import { nodes, edges, modelingStyle, sourceColors, dimensionPrefixes, factPrefixes } from '$lib/stores';
     import { formatModelNameForLabel, generateEntityId, generateSlug, mergeRelationshipIntoEdges, normalizeTags, shouldAutoSyncGeneratedEntityLabel } from '$lib/utils';
     import { DimensionalModelPositioner } from '$lib/services/position-calculator';
@@ -33,31 +38,98 @@
     let validationErrors = $state<string[]>([]);
     let creating = $state(false);
     let success = $state(false);
+    /** When false, "existing canvas" options are limited to entities referenced by this event/process. */
+    let topologyShowAllCanvasEntities = $state(false);
 
     const positioner = new DimensionalModelPositioner();
 
-    const allEntityOptions = $derived(
+    /** IDs referenced by preview, annotations (dimension links), relationships, and derived entities. */
+    function collectScopedCanvasEntityIds(
+        pd: GeneratedEntitiesResult,
+        evt: BusinessEvent | null,
+        proc: BusinessEventProcess | null,
+        rels: EditedRelationship[]
+    ): Set<string> {
+        const ids = new Set<string>();
+        for (const e of pd.entities) {
+            ids.add(e.id);
+        }
+        const relList = rels.length > 0 ? rels : (pd.relationships || []);
+        for (const rel of relList) {
+            ids.add(rel.source);
+            ids.add(rel.target);
+        }
+        const scanAnnotations = (ann: BusinessEventAnnotations | undefined) => {
+            if (!ann) return;
+            const buckets = [
+                ann.who,
+                ann.what,
+                ann.when,
+                ann.where,
+                ann.how,
+                ann.why,
+                ann.how_many,
+            ];
+            for (const bucket of buckets) {
+                for (const entry of bucket || []) {
+                    if (entry.dimension_id) ids.add(entry.dimension_id);
+                }
+            }
+        };
+        scanAnnotations(evt?.annotations);
+        scanAnnotations(proc?.annotations_superset);
+        for (const d of evt?.derived_entities ?? []) {
+            const id = typeof d === 'string' ? d : d.entity_id;
+            if (id) ids.add(id);
+        }
+        for (const d of proc?.derived_entities ?? []) {
+            if (d.entity_id) ids.add(d.entity_id);
+        }
+        return ids;
+    }
+
+    const previewEntityIdSet = $derived(new Set((previewData?.entities || []).map((e) => e.id)));
+
+    const scopedCanvasEntityIds = $derived(
+        $modelingStyle === 'entity_model' && previewData
+            ? collectScopedCanvasEntityIds(previewData, event, process, editedRelationships)
+            : new Set<string>()
+    );
+
+    const dialogEntityOptions = $derived(
         $modelingStyle === 'entity_model'
-            ? [
-                  ...(previewData?.entities || []).map((e, i) => ({
-                      id: e.id,
-                      label: editedEntities[i]?.label || e.label,
-                      isNew: true,
-                  })),
-                  ...$nodes
-                      .filter(
-                          (n) =>
-                              n.type === 'entity' &&
-                              !(previewData?.entities || []).some((pe) => pe.id === n.id)
-                      )
-                      .map((n) => ({
-                          id: n.id,
-                          label: String((n.data as any)?.label || n.id),
-                          isNew: false,
-                      })),
-              ]
+            ? (previewData?.entities || []).map((e, i) => ({
+                  id: e.id,
+                  label: editedEntities[i]?.label || e.label,
+                  isNew: true as const,
+              }))
             : []
     );
+
+    const fullExistingCanvasEntityOptions = $derived(
+        $modelingStyle === 'entity_model' && previewData
+            ? $nodes
+                  .filter(
+                      (n) =>
+                          n.type === 'entity' &&
+                          !previewEntityIdSet.has(n.id)
+                  )
+                  .map((n) => ({
+                      id: n.id,
+                      label: String((n.data as any)?.label || n.id),
+                      isNew: false as const,
+                  }))
+            : []
+    );
+
+    const existingCanvasEntityOptions = $derived(
+        topologyShowAllCanvasEntities
+            ? fullExistingCanvasEntityOptions
+            : fullExistingCanvasEntityOptions.filter((o) => scopedCanvasEntityIds.has(o.id))
+    );
+
+    const topologySelectClass =
+        'w-full min-w-[11rem] rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-10 text-sm font-medium text-gray-800 shadow-sm transition-colors placeholder:text-gray-400 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20 hover:border-gray-300 appearance-none cursor-pointer';
 
     // Load preview data when dialog opens
     $effect(() => {
@@ -70,6 +142,7 @@
                 editedEntities = [];
                 editedRelationships = [];
                 editedDraftedFields = [];
+                topologyShowAllCanvasEntities = false;
                 validationErrors = [];
                 error = null;
                 success = false;
@@ -1002,52 +1075,85 @@
                         </table>
                     </div>
 
+                    {#if $modelingStyle === 'entity_model' && fullExistingCanvasEntityOptions.length > 0}
+                        <label
+                            class="flex cursor-pointer items-start gap-3 rounded-xl border border-gray-200/90 bg-gradient-to-r from-gray-50/90 to-white px-4 py-3 text-sm text-gray-600 shadow-sm"
+                        >
+                            <input
+                                type="checkbox"
+                                class="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                                bind:checked={topologyShowAllCanvasEntities}
+                            />
+                            <span>
+                                <span class="font-medium text-gray-800">Show all entities on the canvas</span>
+                                <span class="mt-0.5 block text-xs text-gray-500">
+                                    Off by default: only entities linked in this {mode === 'process' ? 'process' : 'event'}
+                                    (annotations, relationships, derived) appear in the lists below.
+                                </span>
+                            </span>
+                        </label>
+                    {/if}
+
                     <!-- Drafted Fields (entity_model only) -->
                     {#if $modelingStyle === 'entity_model' && editedDraftedFields.length > 0}
-                        <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                            <div class="flex items-start gap-2 mb-3">
-                                <Icon icon="lucide:list" class="w-4 h-4 text-amber-700 mt-0.5 flex-shrink-0" />
+                        <div
+                            class="rounded-xl border border-amber-200/80 bg-gradient-to-br from-amber-50/95 to-white p-4 shadow-sm"
+                        >
+                            <div class="mb-3 flex items-start gap-2.5">
+                                <Icon icon="lucide:list" class="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
                                 <div>
-                                    <h3 class="text-sm font-medium text-amber-800">Attributes (drafted fields)</h3>
-                                    <p class="text-xs text-amber-700 mt-0.5">
+                                    <h3 class="text-sm font-semibold text-amber-900">Attributes (drafted fields)</h3>
+                                    <p class="mt-0.5 text-xs text-amber-800/80">
                                         Choose which entity each attribute belongs to.
                                     </p>
                                 </div>
                             </div>
-                            <div class="space-y-1.5">
+                            <div class="space-y-2.5">
                                 {#each editedDraftedFields as field, i}
-                                    <div class="flex items-center gap-2">
+                                    <div
+                                        class="flex flex-wrap items-center gap-2 rounded-lg border border-amber-100/90 bg-white/90 px-3 py-2.5 shadow-sm"
+                                    >
                                         <span
-                                            class="px-2 py-0.5 bg-white border border-amber-300 rounded text-xs font-mono text-amber-900 min-w-0 shrink-0"
+                                            class="min-w-0 shrink-0 rounded-md border border-amber-200 bg-amber-50/80 px-2 py-1 font-mono text-xs font-medium text-amber-950"
                                         >
                                             {field.name}
                                         </span>
-                                        <span class="text-xs text-gray-400 shrink-0">on</span>
-                                        <select
-                                            value={field.targetEntityId}
-                                            onchange={(e) => {
-                                                editedDraftedFields[i] = {
-                                                    ...field,
-                                                    targetEntityId: e.currentTarget.value,
-                                                };
-                                            }}
-                                            class="px-2 py-0.5 border border-gray-300 rounded text-xs bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
-                                        >
-                                            {#if allEntityOptions.length > 0}
-                                                <optgroup label="In this dialog">
-                                                    {#each allEntityOptions.filter((o) => o.isNew) as opt}
-                                                        <option value={opt.id}>{opt.label}</option>
-                                                    {/each}
-                                                </optgroup>
-                                                {#if allEntityOptions.some((o) => !o.isNew)}
-                                                    <optgroup label="Existing entities">
-                                                        {#each allEntityOptions.filter((o) => !o.isNew) as opt}
+                                        <span class="shrink-0 text-xs font-medium text-gray-400">on</span>
+                                        <div class="relative min-w-[12rem] max-w-full flex-1">
+                                            <select
+                                                value={field.targetEntityId}
+                                                onchange={(e) => {
+                                                    editedDraftedFields[i] = {
+                                                        ...field,
+                                                        targetEntityId: e.currentTarget.value,
+                                                    };
+                                                }}
+                                                class={topologySelectClass}
+                                            >
+                                                {#if dialogEntityOptions.length > 0}
+                                                    <optgroup label="From this generation">
+                                                        {#each dialogEntityOptions as opt}
                                                             <option value={opt.id}>{opt.label}</option>
                                                         {/each}
                                                     </optgroup>
                                                 {/if}
-                                            {/if}
-                                        </select>
+                                                {#if existingCanvasEntityOptions.length > 0}
+                                                    <optgroup
+                                                        label={topologyShowAllCanvasEntities
+                                                            ? 'Other entities on canvas'
+                                                            : 'This event — on canvas'}
+                                                    >
+                                                        {#each existingCanvasEntityOptions as opt}
+                                                            <option value={opt.id}>{opt.label}</option>
+                                                        {/each}
+                                                    </optgroup>
+                                                {/if}
+                                            </select>
+                                            <Icon
+                                                icon="lucide:chevron-down"
+                                                class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                                            />
+                                        </div>
                                     </div>
                                 {/each}
                             </div>
@@ -1056,41 +1162,55 @@
 
                     <!-- Relationships Section -->
                     {#if previewData.relationships && previewData.relationships.length > 0}
-                        <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                            <h3 class="text-sm font-medium text-gray-700 mb-2">Relationships:</h3>
+                        <div
+                            class="rounded-xl border border-gray-200/90 bg-gradient-to-b from-white to-gray-50/90 p-4 shadow-sm"
+                        >
+                            <h3 class="mb-3 text-sm font-semibold text-gray-800">Relationships</h3>
                             {#if $modelingStyle === 'entity_model'}
-                                <div class="space-y-1.5">
+                                <div class="space-y-2.5">
                                     {#each editedRelationships as rel, i}
-                                        <div class="flex items-center gap-2 text-sm">
-                                            <select
-                                                value={rel.source}
-                                                onchange={(e) => {
-                                                    editedRelationships[i] = {
-                                                        ...rel,
-                                                        source: e.currentTarget.value,
-                                                    };
-                                                }}
-                                                class="px-2 py-0.5 border border-gray-300 rounded text-xs bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
-                                            >
-                                                {#if allEntityOptions.length > 0}
-                                                    <optgroup label="In this dialog">
-                                                        {#each allEntityOptions.filter((o) => o.isNew) as opt}
-                                                            <option value={opt.id}>{opt.label}</option>
-                                                        {/each}
-                                                    </optgroup>
-                                                    {#if allEntityOptions.some((o) => !o.isNew)}
-                                                        <optgroup label="Existing entities">
-                                                            {#each allEntityOptions.filter((o) => !o.isNew) as opt}
+                                        <div
+                                            class="flex flex-wrap items-center gap-2 rounded-lg border border-gray-100 bg-white/95 px-3 py-2.5 text-sm shadow-sm"
+                                        >
+                                            <div class="relative min-w-[12rem] max-w-full flex-1 sm:max-w-[18rem]">
+                                                <select
+                                                    value={rel.source}
+                                                    onchange={(e) => {
+                                                        editedRelationships[i] = {
+                                                            ...rel,
+                                                            source: e.currentTarget.value,
+                                                        };
+                                                    }}
+                                                    class={topologySelectClass}
+                                                >
+                                                    {#if dialogEntityOptions.length > 0}
+                                                        <optgroup label="From this generation">
+                                                            {#each dialogEntityOptions as opt}
                                                                 <option value={opt.id}>{opt.label}</option>
                                                             {/each}
                                                         </optgroup>
                                                     {/if}
-                                                {/if}
-                                            </select>
-                                            <span class="text-gray-400">→</span>
-                                            <span class="font-mono text-gray-700">{getPreviewDisplayId(rel.target)}</span>
+                                                    {#if existingCanvasEntityOptions.length > 0}
+                                                        <optgroup
+                                                            label={topologyShowAllCanvasEntities
+                                                                ? 'Other entities on canvas'
+                                                                : 'This event — on canvas'}
+                                                        >
+                                                            {#each existingCanvasEntityOptions as opt}
+                                                                <option value={opt.id}>{opt.label}</option>
+                                                            {/each}
+                                                        </optgroup>
+                                                    {/if}
+                                                </select>
+                                                <Icon
+                                                    icon="lucide:chevron-down"
+                                                    class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                                                />
+                                            </div>
+                                            <span class="text-gray-300">→</span>
+                                            <span class="font-mono text-sm text-gray-800">{getPreviewDisplayId(rel.target)}</span>
                                             {#if rel.label}
-                                                <span class="text-gray-400 text-xs">({rel.label})</span>
+                                                <span class="text-xs text-gray-500">({rel.label})</span>
                                             {/if}
                                         </div>
                                     {/each}

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -25,11 +25,39 @@
     let error = $state<string | null>(null);
     let previewData = $state<GeneratedEntitiesResult | null>(null);
     let editedEntities = $state<Array<{ id: string; label: string; entity_type: string; tags?: string[] }>>([]);
+    type EditedRelationship = { source: string; target: string; label: string; type: string };
+    type EditedDraftedField = { name: string; datatype: string; targetEntityId: string };
+
+    let editedRelationships = $state<EditedRelationship[]>([]);
+    let editedDraftedFields = $state<EditedDraftedField[]>([]);
     let validationErrors = $state<string[]>([]);
     let creating = $state(false);
     let success = $state(false);
 
     const positioner = new DimensionalModelPositioner();
+
+    const allEntityOptions = $derived(
+        $modelingStyle === 'entity_model'
+            ? [
+                  ...(previewData?.entities || []).map((e, i) => ({
+                      id: e.id,
+                      label: editedEntities[i]?.label || e.label,
+                      isNew: true,
+                  })),
+                  ...$nodes
+                      .filter(
+                          (n) =>
+                              n.type === 'entity' &&
+                              !(previewData?.entities || []).some((pe) => pe.id === n.id)
+                      )
+                      .map((n) => ({
+                          id: n.id,
+                          label: String((n.data as any)?.label || n.id),
+                          isNew: false,
+                      })),
+              ]
+            : []
+    );
 
     // Load preview data when dialog opens
     $effect(() => {
@@ -40,6 +68,8 @@
             untrack(() => {
                 previewData = null;
                 editedEntities = [];
+                editedRelationships = [];
+                editedDraftedFields = [];
                 validationErrors = [];
                 error = null;
                 success = false;
@@ -110,6 +140,26 @@
                     tags: e.tags || [],
                 };
             });
+
+            if (get(modelingStyle) === 'entity_model' && previewData) {
+                editedRelationships = (previewData.relationships || []).map((rel) => ({
+                    source: rel.source,
+                    target: rel.target,
+                    label: rel.label || '',
+                    type: rel.type || 'many_to_one',
+                }));
+
+                editedDraftedFields = previewData.entities.flatMap((e) =>
+                    ((e as any).drafted_fields || []).map((f: any) => ({
+                        name: f.name,
+                        datatype: f.datatype || 'unknown',
+                        targetEntityId: e.id,
+                    }))
+                );
+            } else {
+                editedRelationships = [];
+                editedDraftedFields = [];
+            }
         } catch (e) {
             error = e instanceof Error ? e.message : 'Failed to generate preview';
             console.error('Error generating preview:', error);
@@ -287,6 +337,22 @@
                 10
             );
 
+            let fieldsByEntity = new Map<string, any[]>();
+            if ($modelingStyle === 'entity_model') {
+                const preliminaryIdMap = new Map(
+                    previewData.entities.map((e, i) => [
+                        e.id,
+                        generateEntityId(editedEntities[i].id.trim(), []),
+                    ])
+                );
+                fieldsByEntity = new Map();
+                for (const f of editedDraftedFields) {
+                    const actualId = preliminaryIdMap.get(f.targetEntityId) ?? f.targetEntityId;
+                    if (!fieldsByEntity.has(actualId)) fieldsByEntity.set(actualId, []);
+                    fieldsByEntity.get(actualId)!.push({ name: f.name, datatype: f.datatype });
+                }
+            }
+
             for (let i = 0; i < editedEntities.length; i++) {
                 const edited = editedEntities[i];
                 const original = previewData.entities[i];
@@ -294,6 +360,13 @@
                 const inheritedDomain =
                     mode === 'event' ? event?.domain?.trim() : process?.domain?.trim();
                 const normalizedEditedId = generateEntityId(trimmedId, []);
+
+                const generatedFieldsForMerge: any[] =
+                    $modelingStyle === 'entity_model'
+                        ? (fieldsByEntity.get(normalizedEditedId) ?? [])
+                        : Array.isArray((original as any).drafted_fields)
+                          ? (original as any).drafted_fields
+                          : [];
 
                 // Check against current nodesToUse (updated in-loop) to avoid duplicates
                 // when the same generation is run more than once
@@ -364,27 +437,27 @@
                     }
                     // Entity already exists - merge drafted_fields (preserve manually added fields)
                     // and update description if provided
-                    if ((edited.entity_type === 'fact' || edited.entity_type === 'entity') && ((original as any).drafted_fields || original.description)) {
+                    if (
+                        (edited.entity_type === 'fact' || edited.entity_type === 'entity') &&
+                        (generatedFieldsForMerge.length > 0 || original.description)
+                    ) {
                         nodesToUse = nodesToUse.map((n) => {
                             if (n.id === normalizedEditedId) {
                                 const existingDraftedFields: any[] = Array.isArray((n.data as any)?.drafted_fields)
                                     ? (n.data as any).drafted_fields
-                                    : [];
-                                const generatedFields: any[] = Array.isArray((original as any).drafted_fields)
-                                    ? (original as any).drafted_fields
                                     : [];
                                 // Keep all existing (manually drafted) fields; add generated fields
                                 // only if no field with the same name already exists
                                 const existingNames = new Set(existingDraftedFields.map((f: any) => f.name));
                                 const mergedFields = [
                                     ...existingDraftedFields,
-                                    ...generatedFields.filter((f: any) => !existingNames.has(f.name)),
+                                    ...generatedFieldsForMerge.filter((f: any) => !existingNames.has(f.name)),
                                 ];
                                 return {
                                     ...n,
                                     data: {
                                         ...n.data,
-                                        ...(generatedFields.length > 0 || existingDraftedFields.length > 0
+                                        ...(generatedFieldsForMerge.length > 0 || existingDraftedFields.length > 0
                                             ? { drafted_fields: mergedFields }
                                             : {}),
                                         ...(original.description ? { description: original.description } : {}),
@@ -422,13 +495,10 @@
                 // the previous node with this ID (captured before the removal step), then
                 // append generated fields that don't already exist by name.
                 const _prevFields: any[] = previousDraftedFieldsMap.get(normalizedEditedId) ?? [];
-                const _genFields: any[] = Array.isArray((original as any).drafted_fields)
-                    ? (original as any).drafted_fields
-                    : [];
                 const _prevNames = new Set(_prevFields.map((f: any) => f.name));
                 const _mergedDraftedFields = [
                     ..._prevFields,
-                    ..._genFields.filter((f: any) => !_prevNames.has(f.name)),
+                    ...generatedFieldsForMerge.filter((f: any) => !_prevNames.has(f.name)),
                 ];
 
                 // Create node (include tags, domain, annotation_type, and drafted_fields from preview data)
@@ -460,11 +530,40 @@
                 createdEntityIds.push(id);
                 entityIdByIndex.push(id);
             }
+
+            if ($modelingStyle === 'entity_model') {
+                for (const [entityId, fields] of fieldsByEntity) {
+                    if (entityIdByIndex.includes(entityId) || createdEntityIds.includes(entityId)) continue;
+                    nodesToUse = nodesToUse.map((n) => {
+                        if (n.id !== entityId || n.type !== 'entity') return n;
+                        const existing: any[] = Array.isArray((n.data as any)?.drafted_fields)
+                            ? (n.data as any).drafted_fields
+                            : [];
+                        const existingNames = new Set(existing.map((f: any) => f.name));
+                        const merged = [
+                            ...existing,
+                            ...fields.filter((f) => !existingNames.has(f.name)),
+                        ];
+                        return {
+                            ...n,
+                            data: {
+                                ...n.data,
+                                drafted_fields: merged.length > 0 ? merged : undefined,
+                            },
+                        };
+                    });
+                }
+            }
+
             // Update nodes store with filtered + new nodes
             $nodes = nodesToUse;
 
             // Create relationships
-            if (previewData.relationships && previewData.relationships.length > 0) {
+            const relsToCreate =
+                $modelingStyle === 'entity_model'
+                    ? editedRelationships
+                    : (previewData.relationships || []);
+            if (relsToCreate.length > 0) {
                 // Map original entity IDs to created entity IDs
                 const idMapping = new Map<string, string>();
                 for (let i = 0; i < previewData.entities.length; i++) {
@@ -478,7 +577,7 @@
 
                 // Create edges for relationships
                 let updatedEdges = edgesToUse;
-                for (const rel of previewData.relationships) {
+                for (const rel of relsToCreate) {
                     const sourceId = idMapping.get(rel.source) || rel.source;
                     const targetId = idMapping.get(rel.target) || rel.target;
 
@@ -491,7 +590,7 @@
                             source: sourceId,
                             target: targetId,
                             label: rel.label || '',
-                            type: rel.type || 'one_to_many',
+                            type: (rel.type || 'one_to_many') as 'one_to_many' | 'many_to_one' | 'one_to_one' | 'many_to_many',
                         };
                         updatedEdges = mergeRelationshipIntoEdges(updatedEdges, relationship);
                     }
@@ -904,47 +1003,110 @@
                     </div>
 
                     <!-- Drafted Fields (entity_model only) -->
-                    {#if $modelingStyle === 'entity_model'}
-                        {@const allDraftedFields = previewData.entities.flatMap((e) => (e as any).drafted_fields || [])}
-                        {#if allDraftedFields.length > 0}
-                            <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                                <div class="flex items-start gap-2 mb-2">
-                                    <Icon icon="lucide:list" class="w-4 h-4 text-amber-700 mt-0.5 flex-shrink-0" />
-                                    <div>
-                                        <h3 class="text-sm font-medium text-amber-800">Attributes (drafted fields)</h3>
-                                        <p class="text-xs text-amber-700 mt-0.5">
-                                            Unlinked annotations become attributes on the central entity.
-                                            To make one a separate entity instead, link it via "Link to entity" in the annotations form.
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="flex flex-wrap gap-1.5 mt-2">
-                                    {#each allDraftedFields as field}
-                                        <span class="px-2 py-0.5 bg-white border border-amber-300 rounded text-xs font-mono text-amber-900">
-                                            {field.name}
-                                        </span>
-                                    {/each}
+                    {#if $modelingStyle === 'entity_model' && editedDraftedFields.length > 0}
+                        <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                            <div class="flex items-start gap-2 mb-3">
+                                <Icon icon="lucide:list" class="w-4 h-4 text-amber-700 mt-0.5 flex-shrink-0" />
+                                <div>
+                                    <h3 class="text-sm font-medium text-amber-800">Attributes (drafted fields)</h3>
+                                    <p class="text-xs text-amber-700 mt-0.5">
+                                        Choose which entity each attribute belongs to.
+                                    </p>
                                 </div>
                             </div>
-                        {/if}
+                            <div class="space-y-1.5">
+                                {#each editedDraftedFields as field, i}
+                                    <div class="flex items-center gap-2">
+                                        <span
+                                            class="px-2 py-0.5 bg-white border border-amber-300 rounded text-xs font-mono text-amber-900 min-w-0 shrink-0"
+                                        >
+                                            {field.name}
+                                        </span>
+                                        <span class="text-xs text-gray-400 shrink-0">on</span>
+                                        <select
+                                            value={field.targetEntityId}
+                                            onchange={(e) => {
+                                                editedDraftedFields[i] = {
+                                                    ...field,
+                                                    targetEntityId: e.currentTarget.value,
+                                                };
+                                            }}
+                                            class="px-2 py-0.5 border border-gray-300 rounded text-xs bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                        >
+                                            {#if allEntityOptions.length > 0}
+                                                <optgroup label="In this dialog">
+                                                    {#each allEntityOptions.filter((o) => o.isNew) as opt}
+                                                        <option value={opt.id}>{opt.label}</option>
+                                                    {/each}
+                                                </optgroup>
+                                                {#if allEntityOptions.some((o) => !o.isNew)}
+                                                    <optgroup label="Existing entities">
+                                                        {#each allEntityOptions.filter((o) => !o.isNew) as opt}
+                                                            <option value={opt.id}>{opt.label}</option>
+                                                        {/each}
+                                                    </optgroup>
+                                                {/if}
+                                            {/if}
+                                        </select>
+                                    </div>
+                                {/each}
+                            </div>
+                        </div>
                     {/if}
 
                     <!-- Relationships Section -->
                     {#if previewData.relationships && previewData.relationships.length > 0}
                         <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
                             <h3 class="text-sm font-medium text-gray-700 mb-2">Relationships:</h3>
-                            <div class="space-y-1">
-                                {#each previewData.relationships as rel}
-                                    <p class="text-sm text-gray-600">
-                                        <span class="font-mono">{getPreviewDisplayId(rel.source)}</span>
-                                        <span class="mx-2">→</span>
-                                        <span class="font-mono">{getPreviewDisplayId(rel.target)}</span>
-                                        {#if rel.label}
-                                            <span class="text-gray-500 ml-2">({rel.label})</span>
-                                        {/if}
-                                    </p>
-                                {/each}
-                            </div>
+                            {#if $modelingStyle === 'entity_model'}
+                                <div class="space-y-1.5">
+                                    {#each editedRelationships as rel, i}
+                                        <div class="flex items-center gap-2 text-sm">
+                                            <select
+                                                value={rel.source}
+                                                onchange={(e) => {
+                                                    editedRelationships[i] = {
+                                                        ...rel,
+                                                        source: e.currentTarget.value,
+                                                    };
+                                                }}
+                                                class="px-2 py-0.5 border border-gray-300 rounded text-xs bg-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                            >
+                                                {#if allEntityOptions.length > 0}
+                                                    <optgroup label="In this dialog">
+                                                        {#each allEntityOptions.filter((o) => o.isNew) as opt}
+                                                            <option value={opt.id}>{opt.label}</option>
+                                                        {/each}
+                                                    </optgroup>
+                                                    {#if allEntityOptions.some((o) => !o.isNew)}
+                                                        <optgroup label="Existing entities">
+                                                            {#each allEntityOptions.filter((o) => !o.isNew) as opt}
+                                                                <option value={opt.id}>{opt.label}</option>
+                                                            {/each}
+                                                        </optgroup>
+                                                    {/if}
+                                                {/if}
+                                            </select>
+                                            <span class="text-gray-400">→</span>
+                                            <span class="font-mono text-gray-700">{getPreviewDisplayId(rel.target)}</span>
+                                            {#if rel.label}
+                                                <span class="text-gray-400 text-xs">({rel.label})</span>
+                                            {/if}
+                                        </div>
+                                    {/each}
+                                </div>
+                            {:else}
+                                <div class="space-y-1">
+                                    {#each previewData.relationships as rel}
+                                        <p class="text-sm text-gray-600">
+                                            <span class="font-mono">{getPreviewDisplayId(rel.source)}</span>
+                                            <span class="mx-2">→</span>
+                                            <span class="font-mono">{getPreviewDisplayId(rel.target)}</span>
+                                            {#if rel.label}<span class="text-gray-500 ml-2">({rel.label})</span>{/if}
+                                        </p>
+                                    {/each}
+                                </div>
+                            {/if}
                         </div>
                     {/if}
 

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -41,6 +41,8 @@
     let success = $state(false);
     /** When false, "existing canvas" options are limited to entities referenced by this event/process. */
     let topologyShowAllCanvasEntities = $state(false);
+    /** Bumps on each preview load so stale async completions do not leave `loading` stuck. */
+    let loadPreviewGeneration = $state(0);
 
     const positioner = new DimensionalModelPositioner();
 
@@ -97,16 +99,6 @@
             : new Set<string>()
     );
 
-    const dialogEntityOptions = $derived(
-        $modelingStyle === 'entity_model'
-            ? (previewData?.entities || []).map((e, i) => ({
-                  id: e.id,
-                  label: editedEntities[i]?.label || e.label,
-                  isNew: true as const,
-              }))
-            : []
-    );
-
     const fullExistingCanvasEntityOptions = $derived(
         $modelingStyle === 'entity_model' && previewData
             ? $nodes
@@ -144,24 +136,61 @@
         return Array.from(options.values());
     });
 
-    const combinedExistingOptions = $derived([
-        ...linkedEntityOptions,
-        ...existingCanvasEntityOptions
-    ].sort((a, b) => a.label.localeCompare(b.label)));
+    /** Preview entities plus relationship endpoints from the API preview (not yet on canvas). Shown under “From this generation”. */
+    const generationTopologyOptions = $derived.by(() => {
+        if ($modelingStyle !== 'entity_model' || !previewData) return [];
+        const byId = new Map<string, { id: string; label: string; isNew: boolean }>();
+        const entities = previewData.entities || [];
+        for (let i = 0; i < entities.length; i++) {
+            const e = entities[i];
+            byId.set(e.id, {
+                id: e.id,
+                label: editedEntities[i]?.label || e.label,
+                isNew: true,
+            });
+        }
+        for (const opt of linkedEntityOptions) {
+            if (!byId.has(opt.id)) {
+                byId.set(opt.id, { id: opt.id, label: opt.label, isNew: false });
+            }
+        }
+        return Array.from(byId.values()).sort((a, b) => a.label.localeCompare(b.label));
+    });
+
+    /** On-canvas entities in scope (second group). */
+    const combinedExistingOptions = $derived(
+        [...existingCanvasEntityOptions].sort((a, b) => a.label.localeCompare(b.label))
+    );
 
     const selectGroups = $derived([
-        ...(dialogEntityOptions.length > 0 ? [{ label: 'From this generation', options: dialogEntityOptions }] : []),
-        ...(combinedExistingOptions.length > 0 ? [{ 
-            label: topologyShowAllCanvasEntities ? 'All available entities' : `Available in this ${mode === 'process' ? 'process' : 'event'}`, 
-            options: combinedExistingOptions 
-        }] : [])
+        ...(generationTopologyOptions.length > 0
+            ? [{ label: 'From this generation', options: generationTopologyOptions }]
+            : []),
+        ...(combinedExistingOptions.length > 0
+            ? [
+                  {
+                      label: topologyShowAllCanvasEntities
+                          ? 'All available entities'
+                          : `Available in this ${mode === 'process' ? 'process' : 'event'}`,
+                      options: combinedExistingOptions,
+                  },
+              ]
+            : []),
     ]);
 
     // Load preview data when dialog opens
     $effect(() => {
         if (open && mode) {
-            loadPreview();
-        } else if (!open) {
+            const ac = new AbortController();
+            // Use untrack so reactive reads/writes inside loadPreview (e.g. the
+            // loadPreviewGeneration counter and preview state) do not make this
+            // effect depend on them and self-retrigger in a loop.
+            untrack(() => {
+                void loadPreview(ac.signal);
+            });
+            return () => ac.abort();
+        }
+        if (!open) {
             // Reset state when dialog closes - use untrack to avoid triggering validation effect
             untrack(() => {
                 previewData = null;
@@ -172,23 +201,30 @@
                 validationErrors = [];
                 error = null;
                 success = false;
+                loading = false;
             });
         }
     });
 
-    async function loadPreview() {
+    async function loadPreview(abortSignal?: AbortSignal) {
         if (!mode) return;
 
+        const gen = ++loadPreviewGeneration;
         try {
             loading = true;
             error = null;
+            let result: GeneratedEntitiesResult | null = null;
             if (mode === 'event' && event) {
-                previewData = await generateEntitiesFromEvent(event.id);
+                result = await generateEntitiesFromEvent(event.id, { signal: abortSignal });
             } else if (mode === 'process' && process) {
-                previewData = await generateEntitiesFromProcess(process.id);
+                result = await generateEntitiesFromProcess(process.id, { signal: abortSignal });
             } else {
                 return;
             }
+            if (gen !== loadPreviewGeneration) {
+                return;
+            }
+            previewData = result;
             const existingDerivedIds =
                 mode === 'event'
                     ? (event?.derived_entities ?? [])
@@ -241,10 +277,22 @@
             });
 
             if (get(modelingStyle) === 'entity_model' && previewData) {
+                // Drop auto-generated relationship labels that are just the target
+                // entity's id or label (filler like “Employee” on employee→booking).
+                const isFillerLabel = (label: string, targetId: string): boolean => {
+                    const l = label.trim().toLowerCase();
+                    if (!l) return true;
+                    if (l === targetId.trim().toLowerCase()) return true;
+                    const targetEntity = previewData?.entities.find((e) => e.id === targetId);
+                    if (targetEntity?.label && l === targetEntity.label.trim().toLowerCase()) {
+                        return true;
+                    }
+                    return false;
+                };
                 editedRelationships = (previewData.relationships || []).map((rel) => ({
                     source: rel.source,
                     target: rel.target,
-                    label: rel.label || '',
+                    label: isFillerLabel(rel.label || '', rel.target) ? '' : (rel.label || ''),
                     type: rel.type || 'many_to_one',
                 }));
 
@@ -260,10 +308,18 @@
                 editedDraftedFields = [];
             }
         } catch (e) {
+            if (abortSignal?.aborted) {
+                return;
+            }
+            if (gen !== loadPreviewGeneration) {
+                return;
+            }
             error = e instanceof Error ? e.message : 'Failed to generate preview';
             console.error('Error generating preview:', error);
         } finally {
-            loading = false;
+            if (gen === loadPreviewGeneration) {
+                loading = false;
+            }
         }
     }
 
@@ -664,14 +720,68 @@
             }
 
             if ($modelingStyle === 'entity_model') {
+                // Create stub entities for relationship endpoints that are neither in the
+                // preview entities nor already on the canvas. These represent entities
+                // referenced by the event/process (e.g. Employee, Account) that must exist
+                // so their relationships can be drawn and they appear on the canvas.
+                const rels = editedRelationships.length > 0
+                    ? editedRelationships
+                    : (previewData.relationships || []);
+                const existingIdSet = new Set(nodesToUse.filter((n) => n.type === 'entity').map((n) => n.id));
+                const previewIdSet = new Set(previewData.entities.map((e) => e.id));
+                const endpointIds = new Set<string>();
+                for (const rel of rels) {
+                    for (const id of [rel.source, rel.target]) {
+                        if (!id) continue;
+                        if (previewIdSet.has(id)) continue;
+                        if (existingIdSet.has(id)) continue;
+                        endpointIds.add(id);
+                    }
+                }
+                const inheritedDomain =
+                    mode === 'event' ? event?.domain?.trim() : process?.domain?.trim();
+                let stubIdx = 0;
+                // Prefer the original preview relationship label when naming stub nodes
+                // (it carries the nice display form e.g. "Employee"); the *edge* label itself
+                // is scrubbed of filler separately at preview-load time.
+                const previewRels = previewData.relationships || [];
+                for (const endpointId of endpointIds) {
+                    const incomingRel = previewRels.find((r) => r.target === endpointId);
+                    const outgoingRel = previewRels.find((r) => r.source === endpointId);
+                    const stubLabel =
+                        incomingRel?.label || outgoingRel?.label || endpointId;
+                    const newNode: Node = {
+                        id: endpointId,
+                        type: 'entity',
+                        position: {
+                            x: 200 + ((stubIdx % 5) * 260),
+                            y: 400 + (Math.floor(stubIdx / 5) * 220),
+                        },
+                        data: {
+                            label: stubLabel,
+                            entity_type: 'dimension',
+                            width: 280,
+                            panelHeight: 200,
+                            collapsed: false,
+                            domain: inheritedDomain || undefined,
+                            domains: inheritedDomain ? [inheritedDomain] : undefined,
+                        },
+                        zIndex: maxZIndex + 5 + stubIdx,
+                    };
+                    nodesToUse = [...nodesToUse, newNode];
+                    existingIdSet.add(endpointId);
+                    createdEntityIds.push(endpointId);
+                    stubIdx += 1;
+                }
+
                 for (const [entityId, fields] of fieldsByEntity) {
                     if (entityIdByIndex.includes(entityId) || createdEntityIds.includes(entityId)) continue;
-                    
+
                     const isOnCanvas = nodesToUse.some(n => n.id === entityId);
                     if (!isOnCanvas) {
                         const rel = previewData.relationships?.find(r => r.target === entityId || r.source === entityId);
                         const stubLabel = rel?.label || entityId;
-                        
+
                         const newNode: Node = {
                             id: entityId,
                             type: 'entity',
@@ -731,7 +841,20 @@
                 }
                 const allEntityIds = new Set(nodesToUse.filter((n) => n.type === 'entity').map((n) => n.id));
 
-                // Create edges for relationships
+                // Treat any label that just restates the target's id/label as filler
+                // (e.g. backend emits "Employee" as the rel label on booking→employee).
+                const isEdgeFillerLabel = (rawLabel: string, targetId: string): boolean => {
+                    const l = (rawLabel || '').trim().toLowerCase();
+                    if (!l) return true;
+                    if (l === targetId.trim().toLowerCase()) return true;
+                    const targetNode = nodesToUse.find((n) => n.id === targetId);
+                    const targetNodeLabel = String((targetNode?.data as any)?.label || '');
+                    if (targetNodeLabel && l === targetNodeLabel.trim().toLowerCase()) {
+                        return true;
+                    }
+                    return false;
+                };
+
                 let updatedEdges = edgesToUse;
                 for (const rel of relsToCreate) {
                     const sourceId = idMapping.get(rel.source) || rel.source;
@@ -742,13 +865,32 @@
                         allEntityIds.has(sourceId) &&
                         allEntityIds.has(targetId)
                     ) {
+                        const cleanLabel = isEdgeFillerLabel(rel.label || '', targetId)
+                            ? ''
+                            : rel.label || '';
                         const relationship = {
                             source: sourceId,
                             target: targetId,
-                            label: rel.label || '',
+                            label: cleanLabel,
                             type: (rel.type || 'one_to_many') as 'one_to_many' | 'many_to_one' | 'one_to_one' | 'many_to_many',
                         };
                         updatedEdges = mergeRelationshipIntoEdges(updatedEdges, relationship);
+                        // mergeRelationshipIntoEdges skips updating the label on an existing
+                        // edge; explicitly overwrite pre-existing filler labels so old runs
+                        // (e.g. "Employee") get cleaned up on regeneration.
+                        updatedEdges = updatedEdges.map((e) => {
+                            const samePair =
+                                (e.source === sourceId && e.target === targetId) ||
+                                (e.source === targetId && e.target === sourceId);
+                            if (!samePair) return e;
+                            const endpointForLabel = e.target;
+                            const existing = String((e.data as any)?.label ?? '');
+                            if (!isEdgeFillerLabel(existing, endpointForLabel)) return e;
+                            return {
+                                ...e,
+                                data: { ...(e.data || {}), label: cleanLabel },
+                            };
+                        });
                     }
                 }
                 $edges = updatedEdges;
@@ -1071,8 +1213,10 @@
 
                     {#if $modelingStyle === 'entity_model'}
                         <p class="text-sm text-gray-600">
-                            Assign each attribute to an entity and choose the source for each relationship. Entities
-                            created in this step appear under “From this generation” in the dropdowns.
+                            Assign each attribute to an entity and choose the source for each relationship. New entities
+                            from this preview and other relationship endpoints from the event appear under “From this
+                            generation”; entities already on the canvas (in scope) appear under “Available in this
+                            {mode === 'process' ? 'process' : 'event'}”.
                         </p>
                     {:else}
                         <!-- Dimensional: editable entity rows -->

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -9,6 +9,7 @@
     import { nodes, edges, modelingStyle, sourceColors, dimensionPrefixes, factPrefixes } from '$lib/stores';
     import { formatModelNameForLabel, generateEntityId, generateSlug, mergeRelationshipIntoEdges, normalizeTags, shouldAutoSyncGeneratedEntityLabel } from '$lib/utils';
     import { DimensionalModelPositioner } from '$lib/services/position-calculator';
+    import CustomEntitySelect from './CustomEntitySelect.svelte';
     import type { Node, Edge } from '@xyflow/svelte';
     import Icon from '@iconify/svelte';
     import { untrack } from 'svelte';
@@ -128,8 +129,33 @@
             : fullExistingCanvasEntityOptions.filter((o) => scopedCanvasEntityIds.has(o.id))
     );
 
-    const topologySelectClass =
-        'w-full min-w-[11rem] rounded-lg border border-gray-200 bg-white py-2 pl-3 pr-10 text-sm font-medium text-gray-800 shadow-sm transition-colors placeholder:text-gray-400 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20 hover:border-gray-300 appearance-none cursor-pointer';
+    const linkedEntityOptions = $derived.by(() => {
+        if ($modelingStyle !== 'entity_model' || !previewData) return [];
+        const options = new Map<string, { id: string; label: string, isNew: false }>();
+        
+        for (const rel of previewData.relationships || []) {
+            if (!previewEntityIdSet.has(rel.target)) {
+                const onCanvas = fullExistingCanvasEntityOptions.find(o => o.id === rel.target);
+                if (!onCanvas) {
+                    options.set(rel.target, { id: rel.target, label: rel.label || rel.target, isNew: false });
+                }
+            }
+        }
+        return Array.from(options.values());
+    });
+
+    const combinedExistingOptions = $derived([
+        ...linkedEntityOptions,
+        ...existingCanvasEntityOptions
+    ].sort((a, b) => a.label.localeCompare(b.label)));
+
+    const selectGroups = $derived([
+        ...(dialogEntityOptions.length > 0 ? [{ label: 'From this generation', options: dialogEntityOptions }] : []),
+        ...(combinedExistingOptions.length > 0 ? [{ 
+            label: topologyShowAllCanvasEntities ? 'All available entities' : `Available in this ${mode === 'process' ? 'process' : 'event'}`, 
+            options: combinedExistingOptions 
+        }] : [])
+    ]);
 
     // Load preview data when dialog opens
     $effect(() => {
@@ -285,12 +311,43 @@
         return collapsedAliasPattern.test(candidateId);
     }
 
+    function removeDraftedField(index: number) {
+        editedDraftedFields.splice(index, 1);
+        validateEntities();
+    }
+
+    function removeRelationship(index: number) {
+        editedRelationships.splice(index, 1);
+        validateEntities();
+    }
+
     function validateEntities(): void {
         validationErrors = [];
 
         if ($modelingStyle === 'entity_model') {
-            if (editedEntities.length === 0) {
-                validationErrors.push('At least one entity is required');
+            // It's okay to have 0 entities if we are just routing relationships/attributes to existing entities
+            // But we must ensure all relationships and drafted fields have valid targets
+            const validIds = new Set([
+                ...editedEntities.map((e) => e.id),
+                ...existingCanvasEntityOptions.map((e) => e.id),
+                ...fullExistingCanvasEntityOptions.map((e) => e.id),
+                ...linkedEntityOptions.map((e) => e.id),
+            ]);
+
+            for (const rel of editedRelationships) {
+                if (rel.source && !validIds.has(rel.source)) {
+                    validationErrors.push(`Relationship source is invalid or missing.`);
+                    break;
+                }
+            }
+            for (const f of editedDraftedFields) {
+                if (f.targetEntityId && !validIds.has(f.targetEntityId)) {
+                    validationErrors.push(`Attribute target is invalid or missing.`);
+                    break;
+                }
+            }
+            if (editedEntities.length === 0 && editedRelationships.length === 0 && editedDraftedFields.length === 0) {
+                validationErrors.push('Nothing to create (no entities, relationships, or attributes).');
             }
         } else {
             const dimensions = editedEntities.filter((e) => e.entity_type === 'dimension');
@@ -304,25 +361,27 @@
             }
         }
 
-        // Check for empty names
-        for (let i = 0; i < editedEntities.length; i++) {
-            if (!editedEntities[i].id || !editedEntities[i].id.trim()) {
-                validationErrors.push(`Entity ${i + 1} name cannot be empty`);
+        if ($modelingStyle !== 'entity_model') {
+            // Check for empty names
+            for (let i = 0; i < editedEntities.length; i++) {
+                if (!editedEntities[i].id || !editedEntities[i].id.trim()) {
+                    validationErrors.push(`Entity ${i + 1} name cannot be empty`);
+                }
             }
-        }
 
-        // Check for duplicate names
-        const nameCounts = new Map<string, number>();
-        for (let i = 0; i < editedEntities.length; i++) {
-            const name = editedEntities[i].id.trim();
-            if (name) {
-                nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
+            // Check for duplicate names
+            const nameCounts = new Map<string, number>();
+            for (let i = 0; i < editedEntities.length; i++) {
+                const name = editedEntities[i].id.trim();
+                if (name) {
+                    nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
+                }
             }
-        }
 
-        for (const [name, count] of nameCounts.entries()) {
-            if (count > 1) {
-                validationErrors.push(`Duplicate entity name: "${name}"`);
+            for (const [name, count] of nameCounts.entries()) {
+                if (count > 1) {
+                    validationErrors.push(`Duplicate entity name: "${name}"`);
+                }
             }
         }
 
@@ -607,6 +666,30 @@
             if ($modelingStyle === 'entity_model') {
                 for (const [entityId, fields] of fieldsByEntity) {
                     if (entityIdByIndex.includes(entityId) || createdEntityIds.includes(entityId)) continue;
+                    
+                    const isOnCanvas = nodesToUse.some(n => n.id === entityId);
+                    if (!isOnCanvas) {
+                        const rel = previewData.relationships?.find(r => r.target === entityId || r.source === entityId);
+                        const stubLabel = rel?.label || entityId;
+                        
+                        const newNode: Node = {
+                            id: entityId,
+                            type: 'entity',
+                            position: { x: 100 + Math.random() * 200, y: 100 + Math.random() * 200 },
+                            data: {
+                                label: stubLabel,
+                                entity_type: 'dimension',
+                                width: 280,
+                                panelHeight: 200,
+                                collapsed: false,
+                                drafted_fields: fields,
+                            },
+                            zIndex: maxZIndex + 10,
+                        };
+                        nodesToUse = [...nodesToUse, newNode];
+                        continue;
+                    }
+
                     nodesToUse = nodesToUse.map((n) => {
                         if (n.id !== entityId || n.type !== 'entity') return n;
                         const existing: any[] = Array.isArray((n.data as any)?.drafted_fields)
@@ -869,8 +952,13 @@
 
     // Validate on entity changes - only when dialog is open to prevent infinite loops
     $effect(() => {
-        // Only validate when dialog is open and entities exist
-        if (open && editedEntities.length > 0) {
+        const hasEntityModelContent =
+            $modelingStyle === 'entity_model' &&
+            (editedRelationships.length > 0 || editedDraftedFields.length > 0);
+        if (
+            open &&
+            (editedEntities.length > 0 || hasEntityModelContent)
+        ) {
             // Use untrack to prevent reading $nodes from triggering this effect
             untrack(() => {
                 validateEntities();
@@ -950,7 +1038,7 @@
                         </p>
                     </div>
                 </div>
-            {:else if previewData && editedEntities.length > 0}
+            {:else if previewData && (editedEntities.length > 0 || ($modelingStyle === 'entity_model' && (editedRelationships.length > 0 || editedDraftedFields.length > 0)))}
                 <div class="space-y-4">
                     <!-- Validation Errors -->
                     {#if validationErrors.length > 0}
@@ -981,99 +1069,101 @@
                         </div>
                     {/if}
 
-                    <!-- Entities Table -->
                     {#if $modelingStyle === 'entity_model'}
-                        <p class="text-xs text-gray-500">
-                            Rename the central entity to the core concept (e.g. the verb or transaction, not the full sentence).
+                        <p class="text-sm text-gray-600">
+                            Assign each attribute to an entity and choose the source for each relationship. Entities
+                            created in this step appear under “From this generation” in the dropdowns.
                         </p>
-                    {/if}
-                    <div class="border border-gray-200 rounded-lg overflow-hidden">
-                        <table class="w-full">
-                            <thead class="bg-gray-50 border-b border-gray-200">
-                                <tr>
-                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
-                                        Entity Type
-                                    </th>
-                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
-                                        Name
-                                    </th>
-                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
-                                        Label
-                                    </th>
-                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
-                                        Tags
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                {#each editedEntities as entity, index}
-                                    <tr class="hover:bg-gray-50">
-                                        <td class="px-4 py-3">
-                                            <span
-                                                class="px-2 py-1 text-xs font-medium rounded {entity.entity_type === 'dimension'
-                                                    ? 'bg-green-100 text-green-700'
-                                                    : entity.entity_type === 'fact'
-                                                      ? 'bg-blue-100 text-blue-700'
-                                                      : entity.entity_type === 'entity'
-                                                        ? 'bg-purple-100 text-purple-700'
-                                                        : 'bg-gray-100 text-gray-800'}"
-                                            >
-                                                {entity.entity_type === 'dimension'
-                                                    ? 'Dimension'
-                                                    : entity.entity_type === 'fact'
-                                                      ? 'Fact'
-                                                      : entity.entity_type === 'entity'
-                                                        ? 'Entity'
-                                                        : 'Unclassified'}
-                                            </span>
-                                        </td>
-                                        <td class="px-4 py-3">
-                                            <input
-                                                type="text"
-                                                value={entity.id}
-                                                oninput={(e) =>
-                                                    updateEntityName(
-                                                        index,
-                                                        (e.target as HTMLInputElement).value
-                                                    )}
-                                                class="w-full px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                                                placeholder="Entity name"
-                                            />
-                                        </td>
-                                        <td class="px-4 py-3">
-                                            <input
-                                                type="text"
-                                                value={entity.label}
-                                                oninput={(e) =>
-                                                    updateEntityLabel(
-                                                        index,
-                                                        (e.target as HTMLInputElement).value
-                                                    )}
-                                                class="w-full px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                                                placeholder="Display label"
-                                            />
-                                        </td>
-                                        <td class="px-4 py-3">
-                                            {#if previewData.entities[index]?.tags && previewData.entities[index].tags!.length > 0}
-                                                <div class="flex flex-wrap gap-1">
-                                                    {#each previewData.entities[index].tags! as tag}
-                                                        <span
-                                                            class="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded border border-blue-200 font-mono"
-                                                            title="Inherited tag from event domain"
-                                                        >
-                                                            {tag}
-                                                        </span>
-                                                    {/each}
-                                                </div>
-                                            {:else}
-                                                <span class="text-xs text-gray-400">—</span>
-                                            {/if}
-                                        </td>
+                    {:else}
+                        <!-- Dimensional: editable entity rows -->
+                        <div class="border border-gray-200 rounded-lg overflow-hidden">
+                            <table class="w-full">
+                                <thead class="bg-gray-50 border-b border-gray-200">
+                                    <tr>
+                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
+                                            Entity Type
+                                        </th>
+                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
+                                            Name
+                                        </th>
+                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
+                                            Label
+                                        </th>
+                                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase">
+                                            Tags
+                                        </th>
                                     </tr>
-                                {/each}
-                            </tbody>
-                        </table>
-                    </div>
+                                </thead>
+                                <tbody class="bg-white divide-y divide-gray-200">
+                                    {#each editedEntities as entity, index}
+                                        <tr class="hover:bg-gray-50">
+                                            <td class="px-4 py-3">
+                                                <span
+                                                    class="px-2 py-1 text-xs font-medium rounded {entity.entity_type === 'dimension'
+                                                        ? 'bg-green-100 text-green-700'
+                                                        : entity.entity_type === 'fact'
+                                                          ? 'bg-blue-100 text-blue-700'
+                                                          : entity.entity_type === 'entity'
+                                                            ? 'bg-purple-100 text-purple-700'
+                                                            : 'bg-gray-100 text-gray-800'}"
+                                                >
+                                                    {entity.entity_type === 'dimension'
+                                                        ? 'Dimension'
+                                                        : entity.entity_type === 'fact'
+                                                          ? 'Fact'
+                                                          : entity.entity_type === 'entity'
+                                                            ? 'Entity'
+                                                            : 'Unclassified'}
+                                                </span>
+                                            </td>
+                                            <td class="px-4 py-3">
+                                                <input
+                                                    type="text"
+                                                    value={entity.id}
+                                                    oninput={(e) =>
+                                                        updateEntityName(
+                                                            index,
+                                                            (e.target as HTMLInputElement).value
+                                                        )}
+                                                    class="w-full px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                                                    placeholder="Entity name"
+                                                />
+                                            </td>
+                                            <td class="px-4 py-3">
+                                                <input
+                                                    type="text"
+                                                    value={entity.label}
+                                                    oninput={(e) =>
+                                                        updateEntityLabel(
+                                                            index,
+                                                            (e.target as HTMLInputElement).value
+                                                        )}
+                                                    class="w-full px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                                                    placeholder="Display label"
+                                                />
+                                            </td>
+                                            <td class="px-4 py-3">
+                                                {#if previewData.entities[index]?.tags && previewData.entities[index].tags!.length > 0}
+                                                    <div class="flex flex-wrap gap-1">
+                                                        {#each previewData.entities[index].tags! as tag}
+                                                            <span
+                                                                class="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded border border-blue-200 font-mono"
+                                                                title="Inherited tag from event domain"
+                                                            >
+                                                                {tag}
+                                                            </span>
+                                                        {/each}
+                                                    </div>
+                                                {:else}
+                                                    <span class="text-xs text-gray-400">—</span>
+                                                {/if}
+                                            </td>
+                                        </tr>
+                                    {/each}
+                                </tbody>
+                            </table>
+                        </div>
+                    {/if}
 
                     {#if $modelingStyle === 'entity_model' && fullExistingCanvasEntityOptions.length > 0}
                         <label
@@ -1119,41 +1209,25 @@
                                             {field.name}
                                         </span>
                                         <span class="shrink-0 text-xs font-medium text-gray-400">on</span>
-                                        <div class="relative min-w-[12rem] max-w-full flex-1">
-                                            <select
+                                        <div class="min-w-[12rem] max-w-full flex-1">
+                                            <CustomEntitySelect
                                                 value={field.targetEntityId}
-                                                onchange={(e) => {
+                                                groups={selectGroups}
+                                                onChange={(val) => {
                                                     editedDraftedFields[i] = {
                                                         ...field,
-                                                        targetEntityId: e.currentTarget.value,
+                                                        targetEntityId: val,
                                                     };
                                                 }}
-                                                class={topologySelectClass}
-                                            >
-                                                {#if dialogEntityOptions.length > 0}
-                                                    <optgroup label="From this generation">
-                                                        {#each dialogEntityOptions as opt}
-                                                            <option value={opt.id}>{opt.label}</option>
-                                                        {/each}
-                                                    </optgroup>
-                                                {/if}
-                                                {#if existingCanvasEntityOptions.length > 0}
-                                                    <optgroup
-                                                        label={topologyShowAllCanvasEntities
-                                                            ? 'Other entities on canvas'
-                                                            : 'This event — on canvas'}
-                                                    >
-                                                        {#each existingCanvasEntityOptions as opt}
-                                                            <option value={opt.id}>{opt.label}</option>
-                                                        {/each}
-                                                    </optgroup>
-                                                {/if}
-                                            </select>
-                                            <Icon
-                                                icon="lucide:chevron-down"
-                                                class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
                                             />
                                         </div>
+                                        <button
+                                            onclick={() => removeDraftedField(i)}
+                                            class="ml-auto text-gray-400 hover:text-red-500 transition-colors"
+                                            title="Remove attribute"
+                                        >
+                                            <Icon icon="lucide:x" class="h-4 w-4" />
+                                        </button>
                                     </div>
                                 {/each}
                             </div>
@@ -1172,39 +1246,16 @@
                                         <div
                                             class="flex flex-wrap items-center gap-2 rounded-lg border border-gray-100 bg-white/95 px-3 py-2.5 text-sm shadow-sm"
                                         >
-                                            <div class="relative min-w-[12rem] max-w-full flex-1 sm:max-w-[18rem]">
-                                                <select
+                                            <div class="min-w-[12rem] max-w-full flex-1 sm:max-w-[18rem]">
+                                                <CustomEntitySelect
                                                     value={rel.source}
-                                                    onchange={(e) => {
+                                                    groups={selectGroups}
+                                                    onChange={(val) => {
                                                         editedRelationships[i] = {
                                                             ...rel,
-                                                            source: e.currentTarget.value,
+                                                            source: val,
                                                         };
                                                     }}
-                                                    class={topologySelectClass}
-                                                >
-                                                    {#if dialogEntityOptions.length > 0}
-                                                        <optgroup label="From this generation">
-                                                            {#each dialogEntityOptions as opt}
-                                                                <option value={opt.id}>{opt.label}</option>
-                                                            {/each}
-                                                        </optgroup>
-                                                    {/if}
-                                                    {#if existingCanvasEntityOptions.length > 0}
-                                                        <optgroup
-                                                            label={topologyShowAllCanvasEntities
-                                                                ? 'Other entities on canvas'
-                                                                : 'This event — on canvas'}
-                                                        >
-                                                            {#each existingCanvasEntityOptions as opt}
-                                                                <option value={opt.id}>{opt.label}</option>
-                                                            {/each}
-                                                        </optgroup>
-                                                    {/if}
-                                                </select>
-                                                <Icon
-                                                    icon="lucide:chevron-down"
-                                                    class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
                                                 />
                                             </div>
                                             <span class="text-gray-300">→</span>
@@ -1212,6 +1263,13 @@
                                             {#if rel.label}
                                                 <span class="text-xs text-gray-500">({rel.label})</span>
                                             {/if}
+                                            <button
+                                                onclick={() => removeRelationship(i)}
+                                                class="ml-auto text-gray-400 hover:text-red-500 transition-colors"
+                                                title="Remove relationship"
+                                            >
+                                                <Icon icon="lucide:x" class="h-4 w-4" />
+                                            </button>
                                         </div>
                                     {/each}
                                 </div>

--- a/frontend/src/lib/components/SevenWsForm.svelte
+++ b/frontend/src/lib/components/SevenWsForm.svelte
@@ -2,6 +2,7 @@
     import Icon from "@iconify/svelte";
     import type { BusinessEvent, BusinessEventAnnotations, AnnotationType, AnnotationEntry, Dimension, EntityRole } from "$lib/types";
     import { onMount, untrack } from "svelte";
+    import { get } from "svelte/store";
     import { getBusinessEventProcesses, getBusinessEvents, getDimensions, getDataModel, saveDataModel } from "$lib/api";
     import { dimensionPrefixes, modelingStyle } from "$lib/stores";
 
@@ -273,7 +274,8 @@
         async function loadDimensionsWithRetry() {
             try {
                 dimensionsLoading = true;
-                dimensions = await getDimensions();
+                const isEntityModel = get(modelingStyle) === 'entity_model';
+                dimensions = await getDimensions(undefined, isEntityModel);
                 businessEventsLoading = true;
                 processesLoading = true;
                 const [events, processes] = await Promise.all([
@@ -486,7 +488,6 @@
     }
 
     async function updateEntryDimensionId(annotationType: AnnotationType, entryId: string, dimension_id: string) {
-        console.log('updateEntryDimensionId called:', { annotationType, entryId, dimension_id });
         editingEntries[entryId] = { ...editingEntries[entryId], dimension_id };
 
         // When linking to a dimension, the current text becomes the role
@@ -627,7 +628,7 @@
             await saveDataModel(dataModel);
 
             // Reload dimensions to get the new one
-            dimensions = await getDimensions();
+            dimensions = await getDimensions(undefined, get(modelingStyle) === 'entity_model');
 
             // Link the annotation to the new dimension
             await updateEntryDimensionId(annotationType, entryId, dimensionId);
@@ -656,6 +657,10 @@
     }
 
     function getAllowedDimensionsForType(annotationType: AnnotationType): Dimension[] {
+        // In entity_model mode all entities are available for any annotation type
+        if ($modelingStyle === 'entity_model') {
+            return dimensions;
+        }
         const allowedSet = allowedDimensionIdsByType?.[annotationType];
         return dimensions.filter((dimension) => {
             // Show dimension if:
@@ -700,6 +705,28 @@
     function applySuggestion(annotationType: AnnotationType, entryId: string, suggestion: string) {
         updateEntryText(annotationType, entryId, suggestion, false);
         activeSuggestionEntryId = null;
+    }
+
+    function applyEntitySuggestion(annotationType: AnnotationType, entryId: string, entity: Dimension) {
+        // Set the text to the entity label and auto-link the dimension_id
+        updateEntryText(annotationType, entryId, entity.label, false);
+        updateEntryDimensionId(annotationType, entryId, entity.id);
+        activeSuggestionEntryId = null;
+    }
+
+    function getEntitySuggestionsForType(annotationType: AnnotationType, currentText: string): Dimension[] {
+        if ($modelingStyle !== 'entity_model') return [];
+        const query = currentText.trim().toLowerCase();
+        return dimensions
+            .filter(d => !query || d.label.toLowerCase().includes(query) || d.id.toLowerCase().includes(query))
+            .slice(0, 8);
+    }
+
+    function unlinkEntry(annotationType: AnnotationType, entryId: string) {
+        annotations[annotationType] = annotations[annotationType].map(e =>
+            e.id === entryId ? { ...e, dimension_id: undefined, role: undefined } : e
+        );
+        selectedRoles[entryId] = undefined;
     }
 
     function cancelCreateDimension() {
@@ -967,27 +994,68 @@
                                                         disabled={loading}
                                                     />
                                                     {#if activeSuggestionEntryId === entry.id}
-                                                        {@const visibleSuggestions = getVisibleSuggestions(annotationType.type, entry.text)}
-                                                        {#if visibleSuggestions.length > 0}
+                                                        {@const entitySuggestions = getEntitySuggestionsForType(annotationType.type, entry.text)}
+                                                        {@const textSuggestions = getVisibleSuggestions(annotationType.type, entry.text)}
+                                                        {#if entitySuggestions.length > 0 || textSuggestions.length > 0}
                                                             <div class="mt-1 bg-white border border-gray-200 rounded-md shadow-sm max-h-44 overflow-y-auto">
-                                                                {#each visibleSuggestions as suggestion}
-                                                                    <button
-                                                                        type="button"
-                                                                        class="w-full text-left px-2 py-1.5 text-xs text-gray-700 hover:bg-blue-50"
-                                                                        onmousedown={(e) => {
-                                                                            e.preventDefault();
-                                                                            applySuggestion(annotationType.type, entry.id, suggestion);
-                                                                        }}
-                                                                    >
-                                                                        {suggestion}
-                                                                    </button>
-                                                                {/each}
+                                                                {#if entitySuggestions.length > 0}
+                                                                    {#if textSuggestions.length > 0}
+                                                                        <div class="px-2 py-1 text-xs font-medium text-gray-400 bg-gray-50 border-b border-gray-100">Entities</div>
+                                                                    {/if}
+                                                                    {#each entitySuggestions as entity}
+                                                                        <button
+                                                                            type="button"
+                                                                            class="w-full text-left px-2 py-1.5 text-xs text-gray-700 hover:bg-green-50 flex items-center gap-2"
+                                                                            onmousedown={(e) => {
+                                                                                e.preventDefault();
+                                                                                applyEntitySuggestion(annotationType.type, entry.id, entity);
+                                                                            }}
+                                                                        >
+                                                                            <span class="px-1.5 py-0.5 bg-green-100 text-green-700 rounded text-[10px] font-medium flex-shrink-0">entity</span>
+                                                                            {entity.label}
+                                                                        </button>
+                                                                    {/each}
+                                                                {/if}
+                                                                {#if textSuggestions.length > 0}
+                                                                    {#if entitySuggestions.length > 0}
+                                                                        <div class="px-2 py-1 text-xs font-medium text-gray-400 bg-gray-50 border-b border-gray-100 border-t">Previous entries</div>
+                                                                    {/if}
+                                                                    {#each textSuggestions as suggestion}
+                                                                        <button
+                                                                            type="button"
+                                                                            class="w-full text-left px-2 py-1.5 text-xs text-gray-700 hover:bg-blue-50"
+                                                                            onmousedown={(e) => {
+                                                                                e.preventDefault();
+                                                                                applySuggestion(annotationType.type, entry.id, suggestion);
+                                                                            }}
+                                                                        >
+                                                                            {suggestion}
+                                                                        </button>
+                                                                    {/each}
+                                                                {/if}
                                                             </div>
                                                         {/if}
                                                     {/if}
 
-                                                    <!-- Collapsible Dimension Link (generalization) -->
-                                                    {#if showGeneralizeForEntry.has(entry.id) && entry.text.trim()}
+                                                    <!-- Inline linked entity badge (entity_model) -->
+                                                    {#if $modelingStyle === 'entity_model' && entry.dimension_id}
+                                                        {@const linkedEntity = dimensions.find(d => d.id === entry.dimension_id)}
+                                                        <div class="flex items-center gap-1.5 mt-1">
+                                                            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-800 border border-green-300 rounded-full text-xs font-medium">
+                                                                <Icon icon="lucide:link" class="w-3 h-3" />
+                                                                {linkedEntity?.label || entry.dimension_id}
+                                                            </span>
+                                                            <button
+                                                                type="button"
+                                                                onclick={() => unlinkEntry(annotationType.type, entry.id)}
+                                                                class="text-xs text-gray-400 hover:text-red-500 transition-colors"
+                                                                title="Remove entity link (keep as free text)"
+                                                            >unlink</button>
+                                                        </div>
+                                                    {/if}
+
+                                                    <!-- Collapsible Dimension Link (generalization) — dimensional_model only -->
+                                                    {#if $modelingStyle !== 'entity_model' && showGeneralizeForEntry.has(entry.id) && entry.text.trim()}
                                                         <div class="ml-4 mt-2 space-y-1 border-l-2 border-gray-200 pl-3">
                                                             {#if creatingDimensionForEntry === entry.id}
                                                                 <!-- Create new dimension inline -->
@@ -1083,20 +1151,20 @@
                                                 />
                                             </div>
                                             <div class="flex flex-col gap-1">
-                                                {#if annotationType.type !== 'how_many'}
-                                                    <!-- Generalize to dimension button -->
+                                                {#if annotationType.type !== 'how_many' && $modelingStyle !== 'entity_model'}
+                                                    <!-- Generalize to dimension button (dimensional_model only) -->
                                                     <div class="group relative">
                                                         <button
                                                             type="button"
                                                             class="p-2 rounded-md transition-colors {entry.dimension_id ? 'text-green-600 hover:text-green-700 hover:bg-green-50' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'}"
                                                             onclick={() => toggleGeneralizeSection(entry.id)}
-                                                            aria-label={$modelingStyle === 'entity_model' ? 'Link to entity' : 'Generalize to a dimension'}
+                                                            aria-label="Generalize to a dimension"
                                                             disabled={loading}
                                                         >
                                                             <Icon icon="material-symbols:groups" class="w-4 h-4" />
                                                         </button>
                                                         <div class="absolute right-0 bottom-full mb-2 w-[300px] p-2 bg-gray-900 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-opacity z-50 whitespace-pre-line text-left">
-                                                            {$modelingStyle === 'entity_model' ? 'Link to an existing entity to create a relationship. Leave unlinked to keep as attribute.' : "Generalize to a dimension. Use when multiple annotations refer to the same underlying concept (e.g., 'Order Date' and 'Ship Date' are both Date)."}
+                                                            Generalize to a dimension. Use when multiple annotations refer to the same underlying concept (e.g., 'Order Date' and 'Ship Date' are both Date).
                                                             <div class="absolute right-4 top-full w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900"></div>
                                                         </div>
                                                     </div>

--- a/frontend/src/lib/components/SevenWsForm.svelte
+++ b/frontend/src/lib/components/SevenWsForm.svelte
@@ -617,7 +617,7 @@
                 id: dimensionId,
                 label: dimensionLabel,
                 description: '',
-                entity_type: (isEntityModel ? 'entity' : 'dimension') as 'entity' | 'dimension',
+                entity_type: isEntityModel ? undefined : ('dimension' as const),
                 ...(isEntityModel ? {} : { annotation_type: annotationType }),
                 position: { x: 100, y: 100 },
                 roles: []
@@ -1096,7 +1096,7 @@
                                                                 <!-- Create new dimension inline -->
                                                                 <div class="space-y-2">
                                                                     <label class="text-xs font-medium text-gray-600">
-                                                                        {$modelingStyle === 'entity_model' ? 'Create new entity' : 'Create new dimension'}
+                                                                        Create new dimension
                                                                     </label>
                                                                     <div class="flex items-center gap-2">
                                                                         <input
@@ -1141,7 +1141,7 @@
                                                                         for={`dimension-select-${entry.id}`}
                                                                         class="text-xs font-medium text-gray-600 whitespace-nowrap"
                                                                     >
-                                                                        {$modelingStyle === 'entity_model' ? 'Link to entity' : 'Generalize to'}
+                                                                        Generalize to
                                                                     </label>
                                                                     <select
                                                                         id={`dimension-select-${entry.id}`}
@@ -1161,7 +1161,7 @@
                                                                         {#each getAllowedDimensionsForType(annotationType.type) as dimension}
                                                                             <option value={dimension.id}>{dimension.label}</option>
                                                                         {/each}
-                                                                        <option value="__create_new__" class="text-blue-600 font-medium">{$modelingStyle === 'entity_model' ? '+ Create new entity…' : '+ Create new dimension...'}</option>
+                                                                        <option value="__create_new__" class="text-blue-600 font-medium">+ Create new dimension...</option>
                                                                     </select>
                                                                 </div>
                                                                 {#if entry.dimension_id}

--- a/frontend/src/lib/components/SevenWsForm.svelte
+++ b/frontend/src/lib/components/SevenWsForm.svelte
@@ -600,25 +600,27 @@
             // Fetch current data model
             const dataModel = await getDataModel();
 
-            // Generate dimension ID from label, using the configured prefix (first entry) or 'dim_' as fallback
-            const prefix = $dimensionPrefixes[0] ?? 'dim_';
+            const isEntityModel = get(modelingStyle) === 'entity_model';
+            // In entity_model mode: no prefix, plain snake_case id
+            // In dimensional_model mode: use configured dim prefix or 'dim_' fallback
+            const prefix = isEntityModel ? '' : ($dimensionPrefixes[0] ?? 'dim_');
             const dimensionId = `${prefix}${dimensionLabel.toLowerCase().replace(/[^a-z0-9]+/g, '_')}`;
 
-            // Check if dimension already exists
+            // Check if entity already exists
             if (dataModel.entities.find(e => e.id === dimensionId)) {
-                error = `Dimension "${dimensionId}" already exists`;
+                error = `${isEntityModel ? 'Entity' : 'Dimension'} "${dimensionId}" already exists`;
                 return;
             }
 
-            // Create new dimension entity
+            // Create new entity
             const newDimension = {
                 id: dimensionId,
                 label: dimensionLabel,
-                description: `${dimensionLabel} dimension`,
-                entity_type: 'dimension' as const,
-                annotation_type: annotationType,
-                position: { x: 100, y: 100 }, // Default position
-                roles: [] // Empty roles array
+                description: '',
+                entity_type: (isEntityModel ? 'entity' : 'dimension') as 'entity' | 'dimension',
+                ...(isEntityModel ? {} : { annotation_type: annotationType }),
+                position: { x: 100, y: 100 },
+                roles: []
             };
 
             // Add to data model
@@ -996,26 +998,37 @@
                                                     {#if activeSuggestionEntryId === entry.id}
                                                         {@const entitySuggestions = getEntitySuggestionsForType(annotationType.type, entry.text)}
                                                         {@const textSuggestions = getVisibleSuggestions(annotationType.type, entry.text)}
-                                                        {#if entitySuggestions.length > 0 || textSuggestions.length > 0}
+                                                        {@const showNewEntityOption = $modelingStyle === 'entity_model' && entry.text.trim() && !entitySuggestions.some(e => e.label.toLowerCase() === entry.text.trim().toLowerCase())}
+                                                        {#if entitySuggestions.length > 0 || textSuggestions.length > 0 || showNewEntityOption}
                                                             <div class="mt-1 bg-white border border-gray-200 rounded-md shadow-sm max-h-44 overflow-y-auto">
-                                                                {#if entitySuggestions.length > 0}
-                                                                    {#if textSuggestions.length > 0}
-                                                                        <div class="px-2 py-1 text-xs font-medium text-gray-400 bg-gray-50 border-b border-gray-100">Entities</div>
-                                                                    {/if}
-                                                                    {#each entitySuggestions as entity}
-                                                                        <button
-                                                                            type="button"
-                                                                            class="w-full text-left px-2 py-1.5 text-xs text-gray-700 hover:bg-green-50 flex items-center gap-2"
-                                                                            onmousedown={(e) => {
-                                                                                e.preventDefault();
-                                                                                applyEntitySuggestion(annotationType.type, entry.id, entity);
-                                                                            }}
-                                                                        >
-                                                                            <span class="px-1.5 py-0.5 bg-green-100 text-green-700 rounded text-[10px] font-medium flex-shrink-0">entity</span>
+                                                                {#if showNewEntityOption}
+                                                                    <button
+                                                                        type="button"
+                                                                        class="w-full text-left px-2 py-1.5 text-xs text-blue-600 hover:bg-blue-50 font-medium border-b border-gray-100"
+                                                                        onmousedown={(e) => {
+                                                                            e.preventDefault();
+                                                                            activeSuggestionEntryId = null;
+                                                                            newDimensionName = entry.text;
+                                                                            creatingDimensionForEntry = entry.id;
+                                                                        }}
+                                                                    >+ New entity "{entry.text}"</button>
+                                                                {/if}
+                                                                {#if entitySuggestions.length > 0 && textSuggestions.length > 0}
+                                                                    <div class="px-2 py-1 text-xs font-medium text-gray-400 bg-gray-50 border-b border-gray-100">Entities</div>
+                                                                {/if}
+                                                                {#each entitySuggestions as entity}
+                                                                    <button
+                                                                        type="button"
+                                                                        class="w-full text-left px-2 py-1.5 text-xs text-gray-700 hover:bg-green-50 flex items-center gap-2"
+                                                                        onmousedown={(e) => {
+                                                                            e.preventDefault();
+                                                                            applyEntitySuggestion(annotationType.type, entry.id, entity);
+                                                                        }}
+                                                                    >
+                                                                        <span class="px-1.5 py-0.5 bg-green-100 text-green-700 rounded text-[10px] font-medium flex-shrink-0">entity</span>
                                                                             {entity.label}
                                                                         </button>
                                                                     {/each}
-                                                                {/if}
                                                                 {#if textSuggestions.length > 0}
                                                                     {#if entitySuggestions.length > 0}
                                                                         <div class="px-2 py-1 text-xs font-medium text-gray-400 bg-gray-50 border-b border-gray-100 border-t">Previous entries</div>
@@ -1051,6 +1064,28 @@
                                                                 class="text-xs text-gray-400 hover:text-red-500 transition-colors"
                                                                 title="Remove entity link (keep as free text)"
                                                             >unlink</button>
+                                                        </div>
+                                                    {/if}
+
+                                                    <!-- Inline create entity form (entity_model only) -->
+                                                    {#if $modelingStyle === 'entity_model' && creatingDimensionForEntry === entry.id}
+                                                        <div class="mt-2 space-y-1 border-l-2 border-blue-200 pl-3">
+                                                            <label class="text-xs font-medium text-gray-600">Create new entity</label>
+                                                            <div class="flex items-center gap-2">
+                                                                <input
+                                                                    type="text"
+                                                                    bind:value={newDimensionName}
+                                                                    placeholder="e.g., Employee, Project"
+                                                                    class="flex-1 px-2 py-1 border border-gray-300 rounded text-xs focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                                                                    disabled={loading}
+                                                                    onkeydown={(e) => {
+                                                                        if (e.key === 'Enter') submitCreateDimension(annotationType.type, entry.id);
+                                                                        else if (e.key === 'Escape') cancelCreateDimension();
+                                                                    }}
+                                                                />
+                                                                <button type="button" onclick={() => submitCreateDimension(annotationType.type, entry.id)} disabled={!newDimensionName.trim() || loading} class="px-2 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed">Create</button>
+                                                                <button type="button" onclick={cancelCreateDimension} class="px-2 py-1 bg-gray-200 text-gray-700 rounded text-xs hover:bg-gray-300" disabled={loading}>Cancel</button>
+                                                            </div>
                                                         </div>
                                                     {/if}
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -372,7 +372,7 @@ export interface BusinessEventAnnotations {
 export interface Dimension {
     id: string;
     label: string;
-    entity_type: 'fact' | 'dimension' | 'unclassified';
+    entity_type: 'fact' | 'dimension' | 'unclassified' | 'entity' | undefined;
     annotation_type?: AnnotationType;
     description?: string;
 }

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -860,7 +860,7 @@ import {
 
         <!-- View Switcher -->
         <div class="flex bg-gray-100 rounded-lg p-1 border border-gray-200/60 gap-1">
-            {#if businessEventsEnabled && $modelingStyle === 'dimensional_model'}
+            {#if businessEventsEnabled}
                 <a
                     href="/business-events"
                     class="flex-1 min-w-32 px-4 py-1.5 text-sm rounded-md transition-all duration-200 font-medium flex items-center justify-center gap-2"

--- a/frontend/src/routes/(app)/config/+page.svelte
+++ b/frontend/src/routes/(app)/config/+page.svelte
@@ -923,12 +923,12 @@
                                 </div>
                             </div>
 
-                            <!-- Business Events Container (Dimensional Modeling only) -->
-                            {#if modelingStyle === 'dimensional_model'}
+                            <!-- Business Events Container -->
+                            {#if true}
                             <div class="bg-white border border-amber-200 rounded-lg p-4">
                                 <div class="flex items-center gap-2 mb-4">
                                     <h3 class="text-base font-semibold text-amber-900">Business Events</h3>
-                                    <Tooltip text="Model business events using BEAM* methodology. Annotate events with dimensions and facts to generate dimensional models. Only available for dimensional modeling style.">
+                                    <Tooltip text="Model business events by annotating natural language sentences with the 7 W's to generate entities and relationships. Works for both dimensional and entity modeling styles.">
                                         <Icon icon="lucide:help-circle" class="w-4 h-4 text-amber-600 hover:text-amber-700 cursor-help" />
                                     </Tooltip>
                                 </div>
@@ -946,7 +946,7 @@
                                             {#if getFieldMetadata('business_events.enabled')?.description}
                                                 <p class="text-xs text-gray-500 mt-1">{getFieldMetadata('business_events.enabled')?.description}</p>
                                             {:else}
-                                                <p class="text-xs text-gray-500 mt-1">Enable business events modeling with BEAM* methodology</p>
+                                                <p class="text-xs text-gray-500 mt-1">Enable business events modeling to annotate natural language sentences and generate entities</p>
                                             {/if}
                                         </div>
                                         <label class="relative inline-flex items-center cursor-pointer">

--- a/frontend/tests/business-events.spec.ts
+++ b/frontend/tests/business-events.spec.ts
@@ -1111,4 +1111,94 @@ test.describe('Business Events - entity_model mode', () => {
         const progressBadge = modal.locator('text=/\\d+\\/6/');
         await expect(progressBadge).toBeVisible({ timeout: 5000 });
     });
+
+    test('topology source dropdown', async ({ page }) => {
+        await setupEntityModelMocks(page);
+        await page.route('**/api/business-events/*/generate-entities', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    entities: [{ id: 'booking', label: 'Booking', entity_type: 'entity' }],
+                    relationships: [
+                        {
+                            source: 'booking',
+                            target: 'employee',
+                            label: 'Employee',
+                            type: 'many_to_one',
+                        },
+                    ],
+                    errors: [],
+                }),
+            });
+        });
+
+        await page.goto('/');
+        const response = await page.goto('/business-events').catch(() => null);
+        if (!response || !response.ok()) {
+            test.skip();
+            return;
+        }
+        await page.waitForLoadState('domcontentloaded');
+
+        const generateBtn = page.getByTitle('Generate entities and relationships from annotations');
+        await expect(generateBtn).toBeVisible({ timeout: 5000 });
+        await generateBtn.click();
+
+        const dialog = page.getByRole('dialog').filter({
+            hasText: /generate entities and relationships from event/i,
+        });
+        await expect(dialog).toBeVisible({ timeout: 5000 });
+
+        await expect(dialog.getByRole('heading', { name: 'Relationships:' })).toBeVisible();
+        const sourceSelect = dialog.locator('select').first();
+        await expect(sourceSelect).toBeVisible();
+        await expect(sourceSelect.locator('option[value="booking"]')).toBeAttached();
+    });
+
+    test('topology field target dropdown', async ({ page }) => {
+        await setupEntityModelMocks(page);
+        await page.route('**/api/business-events/*/generate-entities', async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    entities: [
+                        {
+                            id: 'booking',
+                            label: 'Booking',
+                            entity_type: 'entity',
+                            drafted_fields: [{ name: 'hire_date', datatype: 'date' }],
+                        },
+                    ],
+                    relationships: [],
+                    errors: [],
+                }),
+            });
+        });
+
+        await page.goto('/');
+        const response = await page.goto('/business-events').catch(() => null);
+        if (!response || !response.ok()) {
+            test.skip();
+            return;
+        }
+        await page.waitForLoadState('domcontentloaded');
+
+        const generateBtn = page.getByTitle('Generate entities and relationships from annotations');
+        await expect(generateBtn).toBeVisible({ timeout: 5000 });
+        await generateBtn.click();
+
+        const dialog = page.getByRole('dialog').filter({
+            hasText: /generate entities and relationships from event/i,
+        });
+        await expect(dialog).toBeVisible({ timeout: 5000 });
+
+        await expect(
+            dialog.getByRole('heading', { name: /attributes \(drafted fields\)/i })
+        ).toBeVisible({ timeout: 5000 });
+
+        const attributesBlock = dialog.locator('.bg-amber-50').filter({ hasText: 'hire_date' });
+        await expect(attributesBlock.locator('select')).toBeVisible();
+    });
 });

--- a/frontend/tests/business-events.spec.ts
+++ b/frontend/tests/business-events.spec.ts
@@ -1151,9 +1151,17 @@ test.describe('Business Events - entity_model mode', () => {
         await expect(dialog).toBeVisible({ timeout: 5000 });
 
         await expect(dialog.getByRole('heading', { name: 'Relationships', exact: true })).toBeVisible();
-        const sourceSelect = dialog.locator('select').first();
+        const sourceSelect = dialog.locator('button[aria-haspopup="listbox"]').first();
         await expect(sourceSelect).toBeVisible();
-        await expect(sourceSelect.locator('option[value="booking"]')).toBeAttached();
+        
+        // Click to open dropdown
+        await sourceSelect.click();
+        const listbox = page.getByRole('listbox');
+        await expect(listbox).toBeVisible();
+        
+        // Check for option
+        const bookingOption = listbox.getByRole('option', { name: 'Booking' });
+        await expect(bookingOption).toBeVisible();
     });
 
     test('topology field target dropdown', async ({ page }) => {
@@ -1198,6 +1206,6 @@ test.describe('Business Events - entity_model mode', () => {
             dialog.getByRole('heading', { name: /attributes \(drafted fields\)/i })
         ).toBeVisible({ timeout: 5000 });
 
-        await expect(dialog.locator('select').first()).toBeVisible();
+        await expect(dialog.locator('button[aria-haspopup="listbox"]').first()).toBeVisible();
     });
 });

--- a/frontend/tests/business-events.spec.ts
+++ b/frontend/tests/business-events.spec.ts
@@ -1150,7 +1150,7 @@ test.describe('Business Events - entity_model mode', () => {
         });
         await expect(dialog).toBeVisible({ timeout: 5000 });
 
-        await expect(dialog.getByRole('heading', { name: 'Relationships:' })).toBeVisible();
+        await expect(dialog.getByRole('heading', { name: 'Relationships', exact: true })).toBeVisible();
         const sourceSelect = dialog.locator('select').first();
         await expect(sourceSelect).toBeVisible();
         await expect(sourceSelect.locator('option[value="booking"]')).toBeAttached();
@@ -1198,7 +1198,6 @@ test.describe('Business Events - entity_model mode', () => {
             dialog.getByRole('heading', { name: /attributes \(drafted fields\)/i })
         ).toBeVisible({ timeout: 5000 });
 
-        const attributesBlock = dialog.locator('.bg-amber-50').filter({ hasText: 'hire_date' });
-        await expect(attributesBlock.locator('select')).toBeVisible();
+        await expect(dialog.locator('select').first()).toBeVisible();
     });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.14.1"
+version = "0.14.3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.14.0"
+version = "0.14.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/services/entity_generator.py
+++ b/trellis_datamodel/services/entity_generator.py
@@ -401,10 +401,6 @@ def _generate_from_annotations_entity_model(
     # name (e.g. "Employee makes Booking" → "booking"), fall back to full event text
     # when no What entries exist at all.
     first_what = next((e for e in (event.annotations.what or [])), None)
-    # Keep track of the first unlinked What so we can skip it from drafted_fields below
-    first_unlinked_what = next(
-        (e for e in (event.annotations.what or []) if not e.dimension_id), None
-    )
     if first_what:
         base_name = _text_to_snake_case(first_what.text)
         label = _text_to_title_case(first_what.text)
@@ -443,9 +439,6 @@ def _generate_from_annotations_entity_model(
     seen_rel_pairs: set = set()
 
     for annotation_type, entry in non_how_many_entries:
-        # Skip the first unlinked What entry — it was promoted to the central entity name
-        if first_unlinked_what and entry.id == first_unlinked_what.id:
-            continue
         if entry.dimension_id:
             # Skip self-referential relationships (linked What whose id matches
             # the central entity we derived from its text)

--- a/trellis_datamodel/services/entity_generator.py
+++ b/trellis_datamodel/services/entity_generator.py
@@ -476,17 +476,6 @@ def _generate_from_annotations_entity_model(
     if drafted_fields:
         central_entity["drafted_fields"] = drafted_fields
 
-    # #region agent log
-    try:
-        import json as _json, pathlib as _pl, time as _time
-        _log = {"sessionId":"1340c5","runId":"post-fix-3","hypothesisId":"A","location":"entity_generator.py:post-loop","message":"final state with first_what fix","data":{"entity_id":entity_id,"first_what":first_what.text if first_what else None,"first_unlinked_what":first_unlinked_what.text if first_unlinked_what else None,"drafted_fields":[f["name"] for f in drafted_fields],"relationships":[r["target"] for r in relationships]},"timestamp":_time.time()}
-        _logpath = _pl.Path("/home/thiebenthal_ubuntu/git_repos/trellis-datamodel/.cursor/debug-1340c5.log")
-        _logpath.parent.mkdir(parents=True, exist_ok=True)
-        _logpath.open("a").write(_json.dumps(_log)+"\n")
-    except Exception:
-        pass
-    # #endregion
-
     logger.info(
         f"Generated entity_model entity from event {event.id}: "
         f"1 entity, {len(relationships)} relationships, {len(drafted_fields)} drafted fields"

--- a/trellis_datamodel/services/entity_generator.py
+++ b/trellis_datamodel/services/entity_generator.py
@@ -397,15 +397,26 @@ def _generate_from_annotations_entity_model(
 
     prefixes = _entity_prefixes(config)
 
-    # Build central entity id/label from event text
-    base_name = _text_to_snake_case(event.text)
+    # Build central entity id/label — prefer first What annotation as the core concept
+    # name (e.g. "Employee makes Booking" → "booking"), fall back to full event text
+    # when no What entries exist at all.
+    first_what = next((e for e in (event.annotations.what or [])), None)
+    # Keep track of the first unlinked What so we can skip it from drafted_fields below
+    first_unlinked_what = next(
+        (e for e in (event.annotations.what or []) if not e.dimension_id), None
+    )
+    if first_what:
+        base_name = _text_to_snake_case(first_what.text)
+        label = _text_to_title_case(first_what.text)
+    else:
+        base_name = _text_to_snake_case(event.text)
+        label = _text_to_title_case(event.text)
+
     entity_id = base_name
     if prefixes:
         has_prefix = any(base_name.lower().startswith(p.lower()) for p in prefixes)
         if not has_prefix:
             entity_id = f"{prefixes[0]}{base_name}"
-
-    label = _text_to_title_case(event.text)
 
     # Build domain/tags
     domain = event.domain or None
@@ -432,7 +443,14 @@ def _generate_from_annotations_entity_model(
     seen_rel_pairs: set = set()
 
     for annotation_type, entry in non_how_many_entries:
+        # Skip the first unlinked What entry — it was promoted to the central entity name
+        if first_unlinked_what and entry.id == first_unlinked_what.id:
+            continue
         if entry.dimension_id:
+            # Skip self-referential relationships (linked What whose id matches
+            # the central entity we derived from its text)
+            if entry.dimension_id == entity_id:
+                continue
             pair = (entity_id, entry.dimension_id)
             if pair not in seen_rel_pairs:
                 relationships.append(
@@ -457,6 +475,17 @@ def _generate_from_annotations_entity_model(
 
     if drafted_fields:
         central_entity["drafted_fields"] = drafted_fields
+
+    # #region agent log
+    try:
+        import json as _json, pathlib as _pl, time as _time
+        _log = {"sessionId":"1340c5","runId":"post-fix-3","hypothesisId":"A","location":"entity_generator.py:post-loop","message":"final state with first_what fix","data":{"entity_id":entity_id,"first_what":first_what.text if first_what else None,"first_unlinked_what":first_unlinked_what.text if first_unlinked_what else None,"drafted_fields":[f["name"] for f in drafted_fields],"relationships":[r["target"] for r in relationships]},"timestamp":_time.time()}
+        _logpath = _pl.Path("/home/thiebenthal_ubuntu/git_repos/trellis-datamodel/.cursor/debug-1340c5.log")
+        _logpath.parent.mkdir(parents=True, exist_ok=True)
+        _logpath.open("a").write(_json.dumps(_log)+"\n")
+    except Exception:
+        pass
+    # #endregion
 
     logger.info(
         f"Generated entity_model entity from event {event.id}: "

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1798,7 +1798,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.13.5"
+version = "0.14.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Bumps **0.14.0 → 0.14.1** and documents the entity-model business events / generate-dialog work.

### Frontend
- **Generate Entities (entity model)**: relationship endpoints from the preview appear under **“From this generation”** with the derived entity.
- **Create All**: stub dimension nodes for relationship endpoints not yet on the canvas so edges render and filtered canvas shows the full topology.
- **Edge labels**: strip filler labels that only repeat the target id/name; overwrite stale filler on existing edges when regenerating.
- **Preview loading**: abort on close, 120s timeout, `untrack` around `loadPreview` to avoid a reactive loop, reset `loading` when the dialog closes.

### Docs / packaging
- `CHANGELOG.md` — [0.14.1] entry
- `pyproject.toml` version bump

### Testing
- `npm run check` (frontend)
- Manual: open generate dialog, Create All, canvas filter + edges

---
*Please ensure branch `fix/business_events_entity_style` is pushed to `origin` before merging.*