### PR TITLE
fix: cover disabled wizard flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Wizard disable toggle coverage**: added an end-to-end canvas regression test that disables `entity_creation_guidance.enabled`, confirms the Create Entity wizard stays closed, and verifies entities are created directly.
+
 ## [0.14.4] - 2026-04-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Wizard disable toggle coverage**: added an end-to-end canvas regression test that disables `entity_creation_guidance.enabled`, confirms the Create Entity wizard stays closed, and verifies entities are created directly.
+- **Guidance deprecation warning copy**: corrected the legacy `guidance` warning so it points users to `entity_creation_guidance.enabled`, matching the config format produced by `trellis init`.
 
 ## [0.14.4] - 2026-04-17
 

--- a/frontend/tests/canvas.spec.ts
+++ b/frontend/tests/canvas.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { cleanupTestEntities, resetDataModel, completeEntityWizard } from './helpers';
+import {
+    applyConfigOverrides,
+    cleanupTestEntities,
+    completeEntityWizard,
+    getCompanyDummyConfigOverrides,
+    resetDataModel,
+    restoreConfig,
+} from './helpers';
 
 test.describe('Canvas Interactions', () => {
     test.beforeEach(async ({ page, request }) => {
@@ -61,6 +68,31 @@ test.describe('Canvas Interactions', () => {
 
         // Verify gone
         await expect(entity).not.toBeVisible();
+    });
+
+    test('creates entity directly when wizard guidance is disabled', async ({ page, request }) => {
+        const originalConfig = await applyConfigOverrides(request, {
+            ...getCompanyDummyConfigOverrides(),
+            entity_creation_guidance: { enabled: false },
+        });
+
+        try {
+            await resetDataModel(request);
+            await page.reload();
+            await page.waitForLoadState('networkidle');
+
+            const addEntityBtn = page.getByRole('button', { name: 'Add Entity' });
+            await expect(addEntityBtn).toBeVisible({ timeout: 10000 });
+            await addEntityBtn.click();
+
+            const wizardModal = page.getByRole('dialog', { name: /create new entity/i });
+            await expect(wizardModal).not.toBeVisible({ timeout: 2000 });
+
+            const entityNameInput = page.getByPlaceholder('Entity Name').first();
+            await expect(entityNameInput).toBeVisible({ timeout: 10000 });
+        } finally {
+            await restoreConfig(request, originalConfig);
+        }
     });
 
     test('expand/collapse all entities toggle', async ({ page }) => {

--- a/trellis_datamodel/config.py
+++ b/trellis_datamodel/config.py
@@ -281,7 +281,7 @@ def _load_guidance_config(config: dict[str, Any]) -> GuidanceConfig:
     legacy_guidance_section = config.get("guidance")
     if guidance_section is None and legacy_guidance_section is not None:
         logger.warning(
-            "'guidance' is deprecated. Use 'entity_creation_guidance' with 'wizard.enabled'."
+            "'guidance' is deprecated. Use 'entity_creation_guidance' with 'enabled'."
         )
         guidance_section = legacy_guidance_section
 


### PR DESCRIPTION
## Summary
- add a Playwright regression test covering `entity_creation_guidance.enabled: false`
- verify the canvas creates entities directly without opening the Create Entity wizard when the toggle is disabled
- correct the legacy `guidance` deprecation warning so it points to `entity_creation_guidance.enabled`
- add `Unreleased` changelog entries so both changes are included in the next release notes

## Validation
- `npx playwright test tests/canvas.spec.ts -g "creates entity directly when wizard guidance is disabled"`
- manual config-load check for legacy `guidance.enabled` and `entity_creation_guidance.wizard.enabled` compatibility
- `npm run check`