### PR TITLE
feat(config): add/remove buttons for dbt model paths in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Config UI: dbt model paths add/remove**: added "+ Add Path" button and remove (×) buttons for `dbt_model_paths` in the config page. Users can now set paths even when the config currently has none.
+
 ## [0.14.4] - 2026-04-17
 
 ### Changed

--- a/frontend/src/routes/(app)/config/+page.svelte
+++ b/frontend/src/routes/(app)/config/+page.svelte
@@ -554,22 +554,46 @@
                                     dbt Model Paths
                                 </label>
                                 {#each getFieldValue('dbt_model_paths') || [] as path, index}
-                                    <input
-                                        id={`dbt-model-paths-${index}`}
-                                        type="text"
-                                        value={path}
-                                        oninput={(e) => {
-                                            const newPaths = [...(getFieldValue('dbt_model_paths') || [])];
-                                            newPaths[index] = e.currentTarget.value;
-                                            handleFieldChange('dbt_model_paths', newPaths);
-                                        }}
-                                        placeholder="3_core"
-                                        class="w-full px-3 py-2 text-sm font-mono border border-gray-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 focus:outline-none transition-all duration-200 shadow-sm"
-                                    />
+                                    <div class="flex items-center gap-2 mb-2">
+                                        <input
+                                            id={`dbt-model-paths-${index}`}
+                                            type="text"
+                                            value={path}
+                                            oninput={(e) => {
+                                                const newPaths = [...(getFieldValue('dbt_model_paths') || [])];
+                                                newPaths[index] = e.currentTarget.value;
+                                                handleFieldChange('dbt_model_paths', newPaths);
+                                            }}
+                                            placeholder="3_core"
+                                            class="flex-1 px-3 py-2 text-sm font-mono border border-gray-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500 focus:border-primary-500 focus:outline-none transition-all duration-200 shadow-sm"
+                                        />
+                                        <button
+                                            type="button"
+                                            onclick={() => {
+                                                const newPaths = [...(getFieldValue('dbt_model_paths') || [])];
+                                                newPaths.splice(index, 1);
+                                                handleFieldChange('dbt_model_paths', newPaths);
+                                            }}
+                                            class="px-3 py-2 text-red-600 hover:bg-red-50 border border-red-300 rounded-md text-lg font-medium"
+                                            title="Remove path"
+                                        >
+                                            ×
+                                        </button>
+                                    </div>
                                 {/each}
                                 {#if (getFieldValue('dbt_model_paths') || []).length === 0}
                                     <p class="mt-1.5 text-xs text-gray-500">Empty = all models included</p>
                                 {/if}
+                                <button
+                                    type="button"
+                                    onclick={() => {
+                                        const newPaths = [...(getFieldValue('dbt_model_paths') || []), ''];
+                                        handleFieldChange('dbt_model_paths', newPaths);
+                                    }}
+                                    class="mt-2 px-3 py-1.5 text-sm font-medium text-primary-700 bg-primary-50 hover:bg-primary-100 border border-primary-300 rounded-md"
+                                >
+                                    + Add Path
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.14.4"
+version = "0.14.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Adds "+ Add Path" button to config page for dbt_model_paths field
- Adds remove (×) button for each path to delete it
- Allows users to set paths even when config currently has none

## Testing
- npm run test:smoke passes