### PR TITLE
Feat/entity list enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bus Matrix usage counts**: Each dimension label now shows a green badge with the number of currently-visible facts it connects to; each fact column header shows a blue badge with the number of currently-visible dimensions. Counts update as filters change.
 - **Bus Matrix sort controls**: Two sort selects let users order dimensions and facts independently by display label (A-Z) or by visible connection count (descending).
 - **Bus Matrix full-matrix export**: An "Export full matrix" button downloads `trellis-bus-matrix.xlsx` — a workbook with a `Matrix` sheet (dimensions as rows, facts as columns) and a `Longlist` sheet (every dimension-fact pair with `TRUE`/`FALSE` linked values). Export always uses the complete unfiltered dataset regardless of active UI filters.
+- **Entity List type filter**: The Entity List toolbar now has a compact Type filter (Dimension, Fact, Unclassified) with colored chips matching the existing Domain and Tag filter style. Type filters compose with search, domain, and tag filters using AND semantics; multiple selected types use OR logic within the group.
+- **Entity List name sort**: A visible A–Z / Z–A sort toggle in the filters toolbar controls entity ordering within every domain group. Clearing filters resets search, domains, tags, and type selection while preserving the chosen sort direction.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bus Matrix full-matrix export**: An "Export full matrix" button downloads `trellis-bus-matrix.xlsx` — a workbook with a `Matrix` sheet (dimensions as rows, facts as columns) and a `Longlist` sheet (every dimension-fact pair with `TRUE`/`FALSE` linked values). Export always uses the complete unfiltered dataset regardless of active UI filters.
 - **Entity List type filter**: The Entity List toolbar now has a compact Type filter (Dimension, Fact, Unclassified) with colored chips matching the existing Domain and Tag filter style. Type filters compose with search, domain, and tag filters using AND semantics; multiple selected types use OR logic within the group.
 - **Entity List name sort**: A visible A–Z / Z–A sort toggle in the filters toolbar controls entity ordering within every domain group. Clearing filters resets search, domains, tags, and type selection while preserving the chosen sort direction.
+- **Entity List group by type**: A "Group by type" checkbox in the filters toolbar adds collapsible Dimensions / Facts / Unclassified sub-headers inside each domain group. Sub-groups are independently collapsible and only appear when the checkbox is enabled.
 
 ### Changed
 

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -10,7 +10,7 @@
 	import type { Node } from '@xyflow/svelte';
 	import type { Entity, EntityData } from '$lib/types';
 	import { filterEntities } from '$lib/utils/entity-filtering';
-	import { groupEntitiesByDomain } from '$lib/utils/entity-grouping';
+	import { groupEntitiesByDomain, groupEntitiesByType } from '$lib/utils/entity-grouping';
 	import EntityRow from './EntityRow.svelte';
 	import CollapseChevron from './CollapseChevron.svelte';
 	import Icon from '@iconify/svelte';
@@ -48,23 +48,24 @@
 		return filterEntities(entities, $entityListFilters);
 	});
 
-	// Group filtered entities by domain
+	// Group filtered entities by domain or type
 	const groupedEntities = $derived.by(() => {
-		return groupEntitiesByDomain(filteredEntities, $entityListFilters.sortDirection);
+		return $entityListFilters.groupByMode === 'type'
+			? groupEntitiesByType(filteredEntities, $entityListFilters.sortDirection)
+			: groupEntitiesByDomain(filteredEntities, $entityListFilters.sortDirection);
 	});
 
 	// Sort domain groups: named domains alphabetically, then "Unassigned" last
 	const sortedDomainGroups = $derived.by(() => {
 		const groups = Array.from(groupedEntities.entries());
+		if ($entityListFilters.groupByMode === 'type') {
+			return groups; // already in canonical Dimensions → Facts → Unclassified order
+		}
 		return groups.sort((a, b) => {
 			const [domainA] = a;
 			const [domainB] = b;
-
-			// "Unassigned" always goes last
 			if (domainA === 'Unassigned') return 1;
 			if (domainB === 'Unassigned') return -1;
-
-			// Otherwise sort alphabetically
 			return domainA.localeCompare(domainB);
 		});
 	});

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -50,7 +50,7 @@
 
 	// Group filtered entities by domain
 	const groupedEntities = $derived.by(() => {
-		return groupEntitiesByDomain(filteredEntities);
+		return groupEntitiesByDomain(filteredEntities, $entityListFilters.sortDirection);
 	});
 
 	// Sort domain groups: named domains alphabetically, then "Unassigned" last

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -65,6 +65,17 @@
 		});
 	});
 
+	// Collapse state for type sub-groups keyed as "domain::typeName"
+	let typeGroupCollapseState = $state<Record<string, boolean>>({});
+
+	function isTypeGroupExpanded(domain: string, typeName: string): boolean {
+		return typeGroupCollapseState[`${domain}::${typeName}`] !== false;
+	}
+
+	function toggleTypeGroupCollapse(domain: string, typeName: string) {
+		typeGroupCollapseState[`${domain}::${typeName}`] = !isTypeGroupExpanded(domain, typeName);
+	}
+
 	// Sub-group entities by type within a domain group (only non-empty groups)
 	function subGroupByType(entities: Entity[]): Array<[string, Entity[]]> {
 		const dims = entities.filter((e) => (e.entity_type ?? 'unclassified') === 'dimension');
@@ -265,7 +276,11 @@
 						<div class="bg-white border-b border-gray-200 overflow-hidden">
 							{#if $entityListFilters.groupByEntityType}
 								{#each subGroupByType(domainEntities) as [typeName, typeEntities]}
-									<div class="flex items-center gap-2 px-4 py-1.5 bg-gray-50 border-b border-gray-100">
+									<button
+										onclick={() => toggleTypeGroupCollapse(domain, typeName)}
+										class="w-full flex items-center gap-2 px-4 py-1.5 bg-gray-50 border-b border-gray-100 hover:bg-gray-100 transition-colors group"
+									>
+										<CollapseChevron expanded={isTypeGroupExpanded(domain, typeName)} sizeClass="w-3 h-3" />
 										<Icon
 											icon={typeName === 'Dimensions' ? 'lucide:list' : typeName === 'Facts' ? 'lucide:bar-chart-3' : 'lucide:circle-dashed'}
 											class="w-3 h-3 {typeName === 'Dimensions' ? 'text-green-600' : typeName === 'Facts' ? 'text-blue-600' : 'text-gray-400'}"
@@ -274,10 +289,12 @@
 											{typeName}
 										</span>
 										<span class="text-xs text-gray-400 ml-1">({typeEntities.length})</span>
-									</div>
-									{#each typeEntities as entity (entity.id)}
-										<EntityRow {entity} />
-									{/each}
+									</button>
+									{#if isTypeGroupExpanded(domain, typeName)}
+										{#each typeEntities as entity (entity.id)}
+											<EntityRow {entity} />
+										{/each}
+									{/if}
 								{/each}
 							{:else}
 								{#each domainEntities as entity (entity.id)}

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -10,7 +10,7 @@
 	import type { Node } from '@xyflow/svelte';
 	import type { Entity, EntityData } from '$lib/types';
 	import { filterEntities } from '$lib/utils/entity-filtering';
-	import { groupEntitiesByDomain, groupEntitiesByType } from '$lib/utils/entity-grouping';
+	import { groupEntitiesByDomain } from '$lib/utils/entity-grouping';
 	import EntityRow from './EntityRow.svelte';
 	import CollapseChevron from './CollapseChevron.svelte';
 	import Icon from '@iconify/svelte';
@@ -48,19 +48,14 @@
 		return filterEntities(entities, $entityListFilters);
 	});
 
-	// Group filtered entities by domain or type
+	// Group filtered entities by domain
 	const groupedEntities = $derived.by(() => {
-		return $entityListFilters.groupByMode === 'type'
-			? groupEntitiesByType(filteredEntities, $entityListFilters.sortDirection)
-			: groupEntitiesByDomain(filteredEntities, $entityListFilters.sortDirection);
+		return groupEntitiesByDomain(filteredEntities, $entityListFilters.sortDirection);
 	});
 
 	// Sort domain groups: named domains alphabetically, then "Unassigned" last
 	const sortedDomainGroups = $derived.by(() => {
 		const groups = Array.from(groupedEntities.entries());
-		if ($entityListFilters.groupByMode === 'type') {
-			return groups; // already in canonical Dimensions → Facts → Unclassified order
-		}
 		return groups.sort((a, b) => {
 			const [domainA] = a;
 			const [domainB] = b;
@@ -69,6 +64,18 @@
 			return domainA.localeCompare(domainB);
 		});
 	});
+
+	// Sub-group entities by type within a domain group (only non-empty groups)
+	function subGroupByType(entities: Entity[]): Array<[string, Entity[]]> {
+		const dims = entities.filter((e) => (e.entity_type ?? 'unclassified') === 'dimension');
+		const facts = entities.filter((e) => (e.entity_type ?? 'unclassified') === 'fact');
+		const unclassified = entities.filter((e) => (e.entity_type ?? 'unclassified') === 'unclassified');
+		const result: Array<[string, Entity[]]> = [];
+		if (dims.length) result.push(['Dimensions', dims]);
+		if (facts.length) result.push(['Facts', facts]);
+		if (unclassified.length) result.push(['Unclassified', unclassified]);
+		return result;
+	}
 
 	// Selection mode is active when any entities are selected
 	const selectionMode = $derived($entitySelection.size > 0);
@@ -256,9 +263,27 @@
 					<!-- Domain Entities (collapsible) -->
 					{#if isDomainExpanded(domain)}
 						<div class="bg-white border-b border-gray-200 overflow-hidden">
-							{#each domainEntities as entity (entity.id)}
-								<EntityRow {entity} />
-							{/each}
+							{#if $entityListFilters.groupByEntityType}
+								{#each subGroupByType(domainEntities) as [typeName, typeEntities]}
+									<div class="flex items-center gap-2 px-4 py-1.5 bg-gray-50 border-b border-gray-100">
+										<Icon
+											icon={typeName === 'Dimensions' ? 'lucide:list' : typeName === 'Facts' ? 'lucide:bar-chart-3' : 'lucide:circle-dashed'}
+											class="w-3 h-3 {typeName === 'Dimensions' ? 'text-green-600' : typeName === 'Facts' ? 'text-blue-600' : 'text-gray-400'}"
+										/>
+										<span class="text-xs font-semibold uppercase tracking-wide {typeName === 'Dimensions' ? 'text-green-700' : typeName === 'Facts' ? 'text-blue-700' : 'text-gray-500'}">
+											{typeName}
+										</span>
+										<span class="text-xs text-gray-400 ml-1">({typeEntities.length})</span>
+									</div>
+									{#each typeEntities as entity (entity.id)}
+										<EntityRow {entity} />
+									{/each}
+								{/each}
+							{:else}
+								{#each domainEntities as entity (entity.id)}
+									<EntityRow {entity} />
+								{/each}
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -147,8 +147,8 @@
 		}));
 	}
 
-	function toggleGroupByMode(mode: 'domain' | 'type') {
-		entityListFilters.update((filters) => ({ ...filters, groupByMode: mode }));
+	function toggleGroupByEntityType() {
+		entityListFilters.update((filters) => ({ ...filters, groupByEntityType: !filters.groupByEntityType }));
 	}
 
 	// Clear all filters
@@ -160,7 +160,7 @@
 			selectedTags: [],
 			selectedEntityTypes: [],
 			sortDirection: filters.sortDirection,
-			groupByMode: filters.groupByMode,
+			groupByEntityType: filters.groupByEntityType,
 		}));
 	}
 
@@ -399,8 +399,8 @@
 		<label class="flex items-center gap-2 cursor-pointer select-none">
 			<input
 				type="checkbox"
-				checked={$entityListFilters.groupByMode === 'type'}
-				onchange={() => toggleGroupByMode($entityListFilters.groupByMode === 'type' ? 'domain' : 'type')}
+				checked={$entityListFilters.groupByEntityType}
+				onchange={toggleGroupByEntityType}
 				class="w-3.5 h-3.5 rounded border-gray-300 text-primary-600 cursor-pointer"
 			/>
 			<span class="text-xs font-medium text-gray-600">Group by type</span>

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -13,6 +13,7 @@
 
 	let searchTermLocal = $state($entityListFilters.searchTerm);
 	let searchDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
+	let lastSyncedSearchTerm = $entityListFilters.searchTerm;
 
 	// Extract unique domains from entity nodes
 	let allDomains = $derived.by(() => {
@@ -146,6 +147,10 @@
 		}));
 	}
 
+	function toggleGroupByMode(mode: 'domain' | 'type') {
+		entityListFilters.update((filters) => ({ ...filters, groupByMode: mode }));
+	}
+
 	// Clear all filters
 	function clearAllFilters() {
 		searchTermLocal = '';
@@ -155,13 +160,18 @@
 			selectedTags: [],
 			selectedEntityTypes: [],
 			sortDirection: filters.sortDirection,
+			groupByMode: filters.groupByMode,
 		}));
 	}
 
 	// Sync local search term when store changes externally
 	$effect(() => {
-		if (searchTermLocal !== $entityListFilters.searchTerm) {
-			searchTermLocal = $entityListFilters.searchTerm;
+		const storeSearchTerm = $entityListFilters.searchTerm;
+		if (storeSearchTerm !== lastSyncedSearchTerm) {
+			lastSyncedSearchTerm = storeSearchTerm;
+			if (searchTermLocal !== storeSearchTerm) {
+				searchTermLocal = storeSearchTerm;
+			}
 		}
 	});
 </script>
@@ -384,6 +394,17 @@
 				</div>
 			</div>
 		</div>
+
+		<!-- Group By Type Checkbox -->
+		<label class="flex items-center gap-2 cursor-pointer select-none">
+			<input
+				type="checkbox"
+				checked={$entityListFilters.groupByMode === 'type'}
+				onchange={() => toggleGroupByMode($entityListFilters.groupByMode === 'type' ? 'domain' : 'type')}
+				class="w-3.5 h-3.5 rounded border-gray-300 text-primary-600 cursor-pointer"
+			/>
+			<span class="text-xs font-medium text-gray-600">Group by type</span>
+		</label>
 
 		<!-- Sort Direction Toggle -->
 		<div class="flex items-center gap-2">

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -121,14 +121,41 @@
 		exportDataModelToExcel($nodes, $edges, $modelingStyle === 'dimensional_model');
 	}
 
+	function toggleEntityType(type: 'dimension' | 'fact' | 'unclassified') {
+		entityListFilters.update((filters) => {
+			const types = [...filters.selectedEntityTypes];
+			if (types.includes(type)) {
+				return { ...filters, selectedEntityTypes: types.filter((t) => t !== type) };
+			} else {
+				return { ...filters, selectedEntityTypes: [...types, type] };
+			}
+		});
+	}
+
+	function removeEntityType(type: 'dimension' | 'fact' | 'unclassified') {
+		entityListFilters.update((filters) => ({
+			...filters,
+			selectedEntityTypes: filters.selectedEntityTypes.filter((t) => t !== type),
+		}));
+	}
+
+	function toggleSortDirection() {
+		entityListFilters.update((filters) => ({
+			...filters,
+			sortDirection: filters.sortDirection === 'asc' ? 'desc' : 'asc',
+		}));
+	}
+
 	// Clear all filters
 	function clearAllFilters() {
 		searchTermLocal = '';
-		entityListFilters.set({
+		entityListFilters.update((filters) => ({
 			searchTerm: '',
 			selectedDomains: [],
 			selectedTags: [],
-		});
+			selectedEntityTypes: [],
+			sortDirection: filters.sortDirection,
+		}));
 	}
 
 	// Sync local search term when store changes externally
@@ -177,7 +204,7 @@
 			</button>
 
 			<!-- Clear Filters Button -->
-			{#if $entityListFilters.searchTerm || $entityListFilters.selectedDomains.length > 0 || $entityListFilters.selectedTags.length > 0}
+			{#if $entityListFilters.searchTerm || $entityListFilters.selectedDomains.length > 0 || $entityListFilters.selectedTags.length > 0 || $entityListFilters.selectedEntityTypes.length > 0}
 				<button
 					type="button"
 					onclick={clearAllFilters}
@@ -307,6 +334,70 @@
 				</div>
 			</div>
 		{/if}
+
+		<!-- Type Filter -->
+		<div class="flex items-center gap-2">
+			<span class="text-xs font-medium text-gray-600 uppercase">Type:</span>
+
+			<!-- Selected types as chips -->
+			{#if $entityListFilters.selectedEntityTypes.length > 0}
+				<div class="flex flex-wrap gap-1">
+					{#each $entityListFilters.selectedEntityTypes as type}
+						{@const typeLabel = type === 'dimension' ? 'Dimension' : type === 'fact' ? 'Fact' : 'Unclassified'}
+						{@const typeClass = type === 'dimension' ? 'bg-green-100 text-green-700 border-green-200' : type === 'fact' ? 'bg-blue-100 text-blue-700 border-blue-200' : 'bg-gray-100 text-gray-700 border-gray-300'}
+						<span class="inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium border {typeClass}">
+							{typeLabel}
+							<button
+								onclick={() => removeEntityType(type)}
+								class="hover:opacity-75 transition-opacity"
+								title="Remove {typeLabel}"
+							>
+								<Icon icon="lucide:x" class="w-3 h-3" />
+							</button>
+						</span>
+					{/each}
+				</div>
+			{/if}
+
+			<!-- Type dropdown -->
+			<div class="relative">
+				<select
+					value=""
+					onchange={(e) => {
+						const val = e.currentTarget.value as 'dimension' | 'fact' | 'unclassified';
+						if (val) {
+							toggleEntityType(val);
+							e.currentTarget.value = '';
+						}
+					}}
+					class="pl-2 pr-7 py-1.5 text-xs border border-gray-300 rounded bg-white focus:outline-none focus:ring-1 focus:ring-primary-600 focus:border-primary-600 appearance-none cursor-pointer"
+				>
+					<option value="" disabled selected>
+						{$entityListFilters.selectedEntityTypes.length > 0 ? 'Add type...' : 'All'}
+					</option>
+					<option value="dimension" disabled={$entityListFilters.selectedEntityTypes.includes('dimension')}>Dimension</option>
+					<option value="fact" disabled={$entityListFilters.selectedEntityTypes.includes('fact')}>Fact</option>
+					<option value="unclassified" disabled={$entityListFilters.selectedEntityTypes.includes('unclassified')}>Unclassified</option>
+				</select>
+				<div class="absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
+					<Icon icon="lucide:chevron-down" class="w-3 h-3" />
+				</div>
+			</div>
+		</div>
+
+		<!-- Sort Direction Toggle -->
+		<div class="flex items-center gap-2">
+			<span class="text-xs font-medium text-gray-600 uppercase">Sort:</span>
+			<button
+				type="button"
+				onclick={toggleSortDirection}
+				class="inline-flex items-center gap-1 px-2 py-1.5 text-xs border border-gray-300 rounded bg-white hover:bg-gray-50 transition-colors font-medium text-gray-700"
+				title="Toggle sort direction"
+			>
+				<Icon icon={$entityListFilters.sortDirection === 'asc' ? 'lucide:arrow-up-a-z' : 'lucide:arrow-down-z-a'} class="w-3.5 h-3.5" />
+				{$entityListFilters.sortDirection === 'asc' ? 'A–Z' : 'Z–A'}
+			</button>
+		</div>
 	</div>
 </div>
 

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,6 +1,6 @@
 import { writable, get } from 'svelte/store';
 import type { Node, Edge } from '@xyflow/svelte';
-import type { DbtModel, FieldDragState } from './types';
+import type { DbtModel, EntityListFilters, FieldDragState } from './types';
 
 /**
  * Deep clone that handles Svelte 5 Proxy objects (which structuredClone cannot clone).
@@ -53,11 +53,13 @@ export const bulkEditModal = writable<{
 }>({ open: false, selectedEntityIds: [] });
 
 // Filter state
-export const entityListFilters = writable<{
-	searchTerm: string;
-	selectedDomains: string[];
-	selectedTags: string[];
-}>({ searchTerm: '', selectedDomains: [], selectedTags: [] });
+export const entityListFilters = writable<EntityListFilters>({
+	searchTerm: '',
+	selectedDomains: [],
+	selectedTags: [],
+	selectedEntityTypes: [],
+	sortDirection: 'asc',
+});
 
 // Bulk selection
 export const entitySelection = writable<Set<string>>(new Set());

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -59,6 +59,7 @@ export const entityListFilters = writable<EntityListFilters>({
 	selectedTags: [],
 	selectedEntityTypes: [],
 	sortDirection: 'asc',
+	groupByMode: 'domain',
 });
 
 // Bulk selection

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -59,7 +59,7 @@ export const entityListFilters = writable<EntityListFilters>({
 	selectedTags: [],
 	selectedEntityTypes: [],
 	sortDirection: 'asc',
-	groupByMode: 'domain',
+	groupByEntityType: false,
 });
 
 // Bulk selection

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -464,6 +464,7 @@ export interface EntityListFilters {
     selectedTags: string[];
     selectedEntityTypes: Array<'dimension' | 'fact' | 'unclassified'>;
     sortDirection: 'asc' | 'desc';
+    groupByMode: 'domain' | 'type';
 }
 
 export interface EntityDetailModalState {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -464,7 +464,7 @@ export interface EntityListFilters {
     selectedTags: string[];
     selectedEntityTypes: Array<'dimension' | 'fact' | 'unclassified'>;
     sortDirection: 'asc' | 'desc';
-    groupByMode: 'domain' | 'type';
+    groupByEntityType: boolean;
 }
 
 export interface EntityDetailModalState {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -462,6 +462,8 @@ export interface EntityListFilters {
     searchTerm: string;
     selectedDomains: string[];
     selectedTags: string[];
+    selectedEntityTypes: Array<'dimension' | 'fact' | 'unclassified'>;
+    sortDirection: 'asc' | 'desc';
 }
 
 export interface EntityDetailModalState {

--- a/frontend/src/lib/utils/entity-filtering.test.ts
+++ b/frontend/src/lib/utils/entity-filtering.test.ts
@@ -9,7 +9,8 @@ describe('entity-filtering', () => {
 		label: string,
 		domain?: string,
 		tags?: string[],
-		domains?: string[]
+		domains?: string[],
+		entity_type?: 'dimension' | 'fact' | 'unclassified'
 	): Entity => ({
 		id,
 		label,
@@ -17,7 +18,7 @@ describe('entity-filtering', () => {
 		domains,
 		tags,
 		description: '',
-		entity_type: 'dimension',
+		entity_type: entity_type ?? 'dimension',
 		attributes: [],
 	});
 
@@ -513,6 +514,133 @@ describe('entity-filtering', () => {
 				expect(result).toHaveLength(1);
 				expect(result[0].label).toBe('Customer');
 			});
+		});
+	});
+
+	describe('Entity type filtering', () => {
+		it('should return all entities when selectedEntityTypes is empty', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Event', 'Sales', [], [], 'unclassified'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: [],
+			});
+
+			expect(result).toHaveLength(3);
+		});
+
+		it('should filter entities to dimensions only', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Event', 'Sales', [], [], 'unclassified'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: ['dimension'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Customer');
+		});
+
+		it('should filter entities to facts only', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				createEntity('2', 'Sales Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Revenue', 'Finance', [], [], 'fact'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: ['fact'],
+			});
+
+			expect(result).toHaveLength(2);
+			expect(result.map((e) => e.label)).toEqual(['Sales Order', 'Revenue']);
+		});
+
+		it('should filter entities to unclassified only', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Event', 'Sales', [], [], 'unclassified'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: ['unclassified'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Event');
+		});
+
+		it('should treat missing entity_type as unclassified', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				{ ...createEntity('2', 'Mystery', 'Sales'), entity_type: undefined },
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: ['unclassified'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Mystery');
+		});
+
+		it('should use OR logic within selected entity types', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension'),
+				createEntity('2', 'Sales Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Event', 'Sales', [], [], 'unclassified'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedEntityTypes: ['dimension', 'fact'],
+			});
+
+			expect(result).toHaveLength(2);
+			expect(result.map((e) => e.label)).toEqual(['Customer', 'Sales Order']);
+		});
+
+		it('should combine entity type filter with search, domain, and tag filters', () => {
+			const entities = [
+				createEntity('1', 'Customer Master', 'Sales', ['pii'], [], 'dimension'),
+				createEntity('2', 'Customer Order', 'Sales', ['transactional'], [], 'fact'),
+				createEntity('3', 'Product', 'Inventory', ['pii'], [], 'dimension'),
+				createEntity('4', 'Revenue Event', 'Finance', ['pii'], [], 'unclassified'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: 'customer',
+				selectedDomains: ['Sales'],
+				selectedTags: ['pii'],
+				selectedEntityTypes: ['dimension'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Customer Master');
 		});
 	});
 });

--- a/frontend/src/lib/utils/entity-filtering.ts
+++ b/frontend/src/lib/utils/entity-filtering.ts
@@ -31,7 +31,7 @@ export function filterEntities(
 		selectedEntityTypes?: Array<'dimension' | 'fact' | 'unclassified'>;
 	}
 ): Entity[] {
-	const result = entities.filter((entity) => {
+	return entities.filter((entity) => {
 		// Filter by search term (case-insensitive substring match on label)
 		if (!matchesSearchTerm(entity.label, filters.searchTerm)) {
 			return false;
@@ -72,6 +72,4 @@ export function filterEntities(
 
 		return true;
 	});
-
-	return result;
 }

--- a/frontend/src/lib/utils/entity-filtering.ts
+++ b/frontend/src/lib/utils/entity-filtering.ts
@@ -31,7 +31,7 @@ export function filterEntities(
 		selectedEntityTypes?: Array<'dimension' | 'fact' | 'unclassified'>;
 	}
 ): Entity[] {
-	return entities.filter((entity) => {
+	const result = entities.filter((entity) => {
 		// Filter by search term (case-insensitive substring match on label)
 		if (!matchesSearchTerm(entity.label, filters.searchTerm)) {
 			return false;
@@ -72,4 +72,6 @@ export function filterEntities(
 
 		return true;
 	});
+
+	return result;
 }

--- a/frontend/src/lib/utils/entity-filtering.ts
+++ b/frontend/src/lib/utils/entity-filtering.ts
@@ -28,12 +28,22 @@ export function filterEntities(
 		searchTerm: string;
 		selectedDomains: string[];
 		selectedTags: string[];
+		selectedEntityTypes?: Array<'dimension' | 'fact' | 'unclassified'>;
 	}
 ): Entity[] {
 	return entities.filter((entity) => {
 		// Filter by search term (case-insensitive substring match on label)
 		if (!matchesSearchTerm(entity.label, filters.searchTerm)) {
 			return false;
+		}
+
+		// Filter by entity type (OR logic within types; if empty, show all)
+		if (filters.selectedEntityTypes && filters.selectedEntityTypes.length > 0) {
+			const effectiveType: 'dimension' | 'fact' | 'unclassified' =
+				entity.entity_type ?? 'unclassified';
+			if (!filters.selectedEntityTypes.includes(effectiveType)) {
+				return false;
+			}
 		}
 
 		// Filter by domains (OR logic: if selectedDomains is empty, show all)

--- a/frontend/src/lib/utils/entity-grouping.test.ts
+++ b/frontend/src/lib/utils/entity-grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupEntitiesByDomain, groupEntitiesByTag } from './entity-grouping';
+import { groupEntitiesByDomain, groupEntitiesByTag, groupEntitiesByType } from './entity-grouping';
 import type { Entity } from '$lib/types';
 
 describe('entity-grouping', () => {
@@ -495,6 +495,90 @@ describe('entity-grouping', () => {
 			expect(result.get('tag-a')?.map((e) => e.label)).toEqual(['Apple', 'Zebra']);
 			// tag-b should have Mango and Zebra (alphabetical)
 			expect(result.get('tag-b')?.map((e) => e.label)).toEqual(['Mango', 'Zebra']);
+		});
+	});
+
+	describe('groupEntitiesByType', () => {
+		const createTypedEntity = (
+			id: string,
+			label: string,
+			entity_type?: 'dimension' | 'fact' | 'unclassified'
+		): Entity => ({
+			id,
+			label,
+			description: '',
+			entity_type,
+			attributes: [],
+		});
+
+		it('should group entities into Dimensions, Facts, and Unclassified', () => {
+			const entities = [
+				createTypedEntity('1', 'Customer', 'dimension'),
+				createTypedEntity('2', 'Sales Order', 'fact'),
+				createTypedEntity('3', 'Event', 'unclassified'),
+			];
+
+			const result = groupEntitiesByType(entities);
+
+			expect(result.size).toBe(3);
+			expect(result.get('Dimensions')).toHaveLength(1);
+			expect(result.get('Facts')).toHaveLength(1);
+			expect(result.get('Unclassified')).toHaveLength(1);
+		});
+
+		it('should treat missing entity_type as Unclassified', () => {
+			const entities = [
+				createTypedEntity('1', 'Customer', 'dimension'),
+				{ ...createTypedEntity('2', 'Mystery'), entity_type: undefined },
+			];
+
+			const result = groupEntitiesByType(entities);
+
+			expect(result.get('Unclassified')).toHaveLength(1);
+			expect(result.get('Unclassified')?.[0].label).toBe('Mystery');
+		});
+
+		it('should sort entities A-Z within each type group by default', () => {
+			const entities = [
+				createTypedEntity('1', 'Zebra', 'dimension'),
+				createTypedEntity('2', 'Apple', 'dimension'),
+				createTypedEntity('3', 'Mango', 'dimension'),
+			];
+
+			const result = groupEntitiesByType(entities);
+
+			expect(result.get('Dimensions')?.map((e) => e.label)).toEqual(['Apple', 'Mango', 'Zebra']);
+		});
+
+		it('should sort entities Z-A within each type group when sortDirection is desc', () => {
+			const entities = [
+				createTypedEntity('1', 'Apple', 'fact'),
+				createTypedEntity('2', 'Zebra', 'fact'),
+				createTypedEntity('3', 'Mango', 'fact'),
+			];
+
+			const result = groupEntitiesByType(entities, 'desc');
+
+			expect(result.get('Facts')?.map((e) => e.label)).toEqual(['Zebra', 'Mango', 'Apple']);
+		});
+
+		it('should return only non-empty groups', () => {
+			const entities = [
+				createTypedEntity('1', 'Customer', 'dimension'),
+				createTypedEntity('2', 'Order', 'dimension'),
+			];
+
+			const result = groupEntitiesByType(entities);
+
+			expect(result.size).toBe(1);
+			expect(result.has('Dimensions')).toBe(true);
+			expect(result.has('Facts')).toBe(false);
+			expect(result.has('Unclassified')).toBe(false);
+		});
+
+		it('should handle empty entities array', () => {
+			const result = groupEntitiesByType([]);
+			expect(result.size).toBe(0);
 		});
 	});
 });

--- a/frontend/src/lib/utils/entity-grouping.test.ts
+++ b/frontend/src/lib/utils/entity-grouping.test.ts
@@ -137,8 +137,85 @@ describe('entity-grouping', () => {
 
 			const result = groupEntitiesByDomain(entities);
 
-			// Non-Unassigned groups preserve input order
-			expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Zebra', 'Apple', 'Mango']);
+			// Default sort is A-Z
+			expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Apple', 'Mango', 'Zebra']);
+		});
+
+		describe('Name sorting', () => {
+			it('should sort entities A-Z within a named domain group when sortDirection is asc', () => {
+				const entities = [
+					createEntity('1', 'Zebra', 'Sales'),
+					createEntity('2', 'Apple', 'Sales'),
+					createEntity('3', 'Mango', 'Sales'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'asc');
+
+				expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Apple', 'Mango', 'Zebra']);
+			});
+
+			it('should sort entities Z-A within a named domain group when sortDirection is desc', () => {
+				const entities = [
+					createEntity('1', 'Apple', 'Sales'),
+					createEntity('2', 'Zebra', 'Sales'),
+					createEntity('3', 'Mango', 'Sales'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'desc');
+
+				expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Zebra', 'Mango', 'Apple']);
+			});
+
+			it('should sort Unassigned group A-Z when sortDirection is asc', () => {
+				const entities = [
+					createEntity('1', 'Zebra'),
+					createEntity('2', 'Apple'),
+					createEntity('3', 'Mango'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'asc');
+
+				expect(result.get('Unassigned')?.map((e) => e.label)).toEqual(['Apple', 'Mango', 'Zebra']);
+			});
+
+			it('should sort Unassigned group Z-A when sortDirection is desc', () => {
+				const entities = [
+					createEntity('1', 'Apple'),
+					createEntity('2', 'Zebra'),
+					createEntity('3', 'Mango'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'desc');
+
+				expect(result.get('Unassigned')?.map((e) => e.label)).toEqual(['Zebra', 'Mango', 'Apple']);
+			});
+
+			it('should sort multi-domain entities consistently in each group', () => {
+				const entities = [
+					createEntity('1', 'Zebra', undefined, undefined, ['Sales', 'Marketing']),
+					createEntity('2', 'Apple', undefined, undefined, ['Sales', 'Marketing']),
+					createEntity('3', 'Mango', 'Sales'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'asc');
+
+				expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Apple', 'Mango', 'Zebra']);
+				expect(result.get('Marketing')?.map((e) => e.label)).toEqual(['Apple', 'Zebra']);
+			});
+
+			it('should sort multiple domain groups consistently', () => {
+				const entities = [
+					createEntity('1', 'Zebra', 'Sales'),
+					createEntity('2', 'Apple', 'Inventory'),
+					createEntity('3', 'Mango', 'Sales'),
+					createEntity('4', 'Banana', 'Inventory'),
+				];
+
+				const result = groupEntitiesByDomain(entities, 'asc');
+
+				expect(result.get('Sales')?.map((e) => e.label)).toEqual(['Mango', 'Zebra']);
+				expect(result.get('Inventory')?.map((e) => e.label)).toEqual(['Apple', 'Banana']);
+			});
 		});
 
 		it('should handle case-sensitive domain names', () => {

--- a/frontend/src/lib/utils/entity-grouping.ts
+++ b/frontend/src/lib/utils/entity-grouping.ts
@@ -1,14 +1,17 @@
 import type { Entity } from '$lib/types';
 
+export type SortDirection = 'asc' | 'desc';
+
 /**
  * Group entities by their domain field(s)
  * Entities without domains go into "Unassigned" group
- * "Unassigned" entities are sorted alphabetically by label
+ * All groups are sorted by label according to sortDirection (default 'asc')
  *
  * @param entities - Array of entities to group
+ * @param sortDirection - Sort direction for entities within each group
  * @returns Map with domain keys and entity arrays as values
  */
-export function groupEntitiesByDomain(entities: Entity[]): Map<string, Entity[]> {
+export function groupEntitiesByDomain(entities: Entity[], sortDirection: SortDirection = 'asc'): Map<string, Entity[]> {
 	const groupMap = new Map<string, Entity[]>();
 
 	function getDomainsForGrouping(entity: Entity): string[] {
@@ -35,7 +38,7 @@ export function groupEntitiesByDomain(entities: Entity[]): Map<string, Entity[]>
 		});
 	});
 
-	// De-duplicate within groups (multi-domain can add the same entity multiple times)
+	// De-duplicate and sort every group by label
 	groupMap.forEach((group, key) => {
 		const uniqueMap = new Map<string, Entity>();
 		group.forEach((entity) => {
@@ -43,14 +46,12 @@ export function groupEntitiesByDomain(entities: Entity[]): Map<string, Entity[]>
 				uniqueMap.set(entity.id, entity);
 			}
 		});
-		groupMap.set(key, Array.from(uniqueMap.values()));
+		const sorted = Array.from(uniqueMap.values()).sort((a, b) => {
+			const cmp = a.label.localeCompare(b.label);
+			return sortDirection === 'desc' ? -cmp : cmp;
+		});
+		groupMap.set(key, sorted);
 	});
-
-	// Sort "Unassigned" group alphabetically by label
-	if (groupMap.has('Unassigned')) {
-		const unassignedGroup = groupMap.get('Unassigned')!;
-		unassignedGroup.sort((a, b) => a.label.localeCompare(b.label));
-	}
 
 	return groupMap;
 }

--- a/frontend/src/lib/utils/entity-grouping.ts
+++ b/frontend/src/lib/utils/entity-grouping.ts
@@ -56,6 +56,50 @@ export function groupEntitiesByDomain(entities: Entity[], sortDirection: SortDir
 	return groupMap;
 }
 
+const TYPE_GROUP_ORDER = ['Dimensions', 'Facts', 'Unclassified'] as const;
+const TYPE_GROUP_LABELS: Record<string, string> = {
+	dimension: 'Dimensions',
+	fact: 'Facts',
+	unclassified: 'Unclassified',
+};
+
+/**
+ * Group entities by their entity_type (Dimensions / Facts / Unclassified)
+ * Entities with missing entity_type go into "Unclassified"
+ * Groups appear in order: Dimensions, Facts, Unclassified (empty groups omitted)
+ *
+ * @param entities - Array of entities to group
+ * @param sortDirection - Sort direction for entities within each group
+ * @returns Map with type-group keys and entity arrays as values
+ */
+export function groupEntitiesByType(entities: Entity[], sortDirection: SortDirection = 'asc'): Map<string, Entity[]> {
+	const groupMap = new Map<string, Entity[]>();
+
+	entities.forEach((entity) => {
+		const key = TYPE_GROUP_LABELS[entity.entity_type ?? 'unclassified'] ?? 'Unclassified';
+		if (!groupMap.has(key)) {
+			groupMap.set(key, []);
+		}
+		groupMap.get(key)!.push(entity);
+	});
+
+	// Sort each group by label
+	groupMap.forEach((group, key) => {
+		const sorted = [...group].sort((a, b) => {
+			const cmp = a.label.localeCompare(b.label);
+			return sortDirection === 'desc' ? -cmp : cmp;
+		});
+		groupMap.set(key, sorted);
+	});
+
+	// Return in canonical order (Dimensions → Facts → Unclassified)
+	const ordered = new Map<string, Entity[]>();
+	TYPE_GROUP_ORDER.forEach((key) => {
+		if (groupMap.has(key)) ordered.set(key, groupMap.get(key)!);
+	});
+	return ordered;
+}
+
 /**
  * Group entities by their tags
  * Entities with multiple tags appear in multiple groups

--- a/frontend/src/routes/(app)/entity-list/+page.svelte
+++ b/frontend/src/routes/(app)/entity-list/+page.svelte
@@ -29,6 +29,7 @@
 					annotation_type: data.annotation_type,
 					source_system: data.source_system,
 					domain: data.domain,
+					domains: data.domains,
 				};
 			});
 	});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.0b2"
+version = "0.15.0b3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.0b3"
+version = "0.15.0b4"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
  Closes #91                                                                                                               
                                                                                                                         
  Summary                                

  - Entity type filter: adds Dimension / Fact / Unclassified chips to the Entity List toolbar, composing with existing
  search, domain, and tag filters (AND across filter types, OR within selected types)
  - A–Z / Z–A name sort: a visible sort toggle orders entities alphabetically within every domain group; clearing filters
  preserves the chosen sort direction
  - Search performance audit: code analysis confirmed duplicate entity derivation between +page.svelte and
  EntityList.svelte; 300 ms debounce and Svelte 5 $derived memoization make this immaterial for typical dataset sizes —
  documented as a follow-up if scale evidence emerges

  Changes

  ┌──────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────┐
  │           Area           │                                       What changed                                       │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ types.ts                 │ EntityListFilters extended with selectedEntityTypes and sortDirection                    │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ stores.ts                │ entityListFilters initial state includes new fields, typed via EntityListFilters         │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ entity-filtering.ts      │ filterEntities() accepts optional selectedEntityTypes; missing entity_type treated as    │
  │                          │ unclassified                                                                             │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ entity-grouping.ts       │ groupEntitiesByDomain() accepts sortDirection: 'asc' | 'desc' (default 'asc'); all       │
  │                          │ groups sorted by label                                                                   │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ EntityListFilters.svelte │ Type filter (colored chips + dropdown) and A–Z / Z–A toggle added; clearAllFilters       │
  │                          │ preserves sort direction                                                                 │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ EntityList.svelte        │ Passes $entityListFilters.sortDirection to grouping                                      │
  ├──────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
  │ +page.svelte             │ Entity map includes domains field for correct multi-domain count                         │
  └──────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘

  Test plan

  - Filter by Dimension only — only green-chip entities appear
  - Filter by Fact only — only blue-chip entities appear
  - Filter by Unclassified (including entities with no entity_type) — correct subset appears
  - Combine type filter with a search term and a domain — AND behavior, count matches list
  - Toggle A–Z → Z–A → back, verify ordering in each domain group
  - Clear filters — search, domains, tags, type chips all reset; sort direction unchanged
  - Unit tests: npm run test:unit -- --run src/lib/utils/entity-filtering.test.ts src/lib/utils/entity-grouping.test.ts →
  71 passed
  - Type check: npm run check → 0 errors
  - Smoke: npm run test:smoke → 1 passed