### PR TITLE
Fix/entity detail modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.4] - 2026-05-08
+
+### Fixed
+
+- **Entity detail modal — attribute name input**: Typing a full attribute name no longer loses focus after each character. Root cause was the Svelte keyed-each using `field.name` as the key, which destroyed and recreated the input on every keystroke; fixed by using a stable `draft-{draftIndex}` key.
+- **Entity detail modal — attribute drag-to-reorder**: Drag handles and drop events were wired up in the data model but never attached to the DOM. Rows now have `draggable`, `ondragstart`, `ondragover`, `ondrop`, and `ondragend` handlers, restoring the ability to reorder attributes by dragging.
+
 ## [0.15.3] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Entity detail modal — attribute name input**: Typing a full attribute name no longer loses focus after each character. Root cause was the Svelte keyed-each using `field.name` as the key, which destroyed and recreated the input on every keystroke; fixed by using a stable `draft-{draftIndex}` key.
 - **Entity detail modal — attribute drag-to-reorder**: Drag handles and drop events were wired up in the data model but never attached to the DOM. Rows now have `draggable`, `ondragstart`, `ondragover`, `ondrop`, and `ondragend` handlers, restoring the ability to reorder attributes by dragging.
+- **Unbound entity type inference**: Unbound entities (not linked to a dbt model) whose ID matches a configured dimension or fact prefix (e.g. `dim_`, `fct_`) are now automatically classified on load, matching the existing behaviour for bound entities.
 
 ## [0.15.3] - 2026-04-29
 

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1334,15 +1334,23 @@
 									<div class="col-span-1"></div>
 								</div>
 								<div class="divide-y divide-gray-200">
-									{#each mergedFields as field (field.name)}
-										<div
-											class="px-3 py-2 hover:bg-gray-50 group transition-colors"
-											data-testid={`merged-field-row-${field.name}`}
-										>
+								{#each mergedFields as field (field.origin === 'draft' ? `draft-${field.draftIndex}` : `dbt-${field.name}`)}
+									<div
+										class="relative px-3 py-2 hover:bg-gray-50 group transition-colors"
+										data-testid={`merged-field-row-${field.name}`}
+										draggable={field.origin === 'draft'}
+										ondragstart={field.origin === 'draft' ? (e) => onAttributeDragStart(field.draftIndex, e) : undefined}
+										ondragover={field.origin === 'draft' ? (e) => onAttributeDragOver(field.draftIndex, e) : undefined}
+										ondrop={field.origin === 'draft' ? (e) => onAttributeDrop(field.draftIndex, e) : undefined}
+										ondragend={field.origin === 'draft' ? onAttributeDragEnd : undefined}
+										style={dragIndex === field.draftIndex ? 'opacity: 0.5;' : ''}
+									>
 											<div class="grid grid-cols-12 gap-2 items-center">
-												<!-- Name -->
-												<div class="col-span-2">
-													{#if field.origin === 'draft'}
+											<!-- Name -->
+											<div class="col-span-2">
+												{#if field.origin === 'draft'}
+													<div class="flex items-center gap-1">
+														<Icon icon="lucide:grip-vertical" class="w-4 h-4 text-gray-300 cursor-grab active:cursor-grabbing shrink-0" />
 														<input
 															type="text"
 															value={field.name}
@@ -1350,7 +1358,8 @@
 															class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-medium text-sm"
 															placeholder="attribute_name"
 														/>
-													{:else}
+													</div>
+												{:else}
 														<input
 															type="text"
 															value={field.name}
@@ -1425,32 +1434,35 @@
 														/>
 													{/if}
 												</div>
-												<!-- Actions -->
-												<div class="col-span-1 flex justify-end gap-1">
-													{#if field.origin === 'draft'}
-														{#if isBoundEntity && boundModel}
-															<button
-																type="button"
-																onclick={() => materializeDraft(field.draftIndex)}
-																class="p-1.5 text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded transition-colors"
-																aria-label={`Materialize ${field.name} into ${boundModel.name}'s schema.yml`}
-																title={`Write to ${boundModel.name}'s schema.yml`}
-															>
-																<Icon icon="lucide:arrow-up-to-line" class="w-3.5 h-3.5" />
-															</button>
-														{/if}
+										<!-- Actions -->
+										<div class="col-span-1 flex justify-end gap-1 items-center">
+											{#if field.origin === 'draft'}
+												{#if isBoundEntity && boundModel}
 														<button
 															type="button"
-															onclick={() => deleteDraftedField(field.draftIndex)}
-															class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-															title="Delete attribute"
+															onclick={() => materializeDraft(field.draftIndex)}
+															class="p-1.5 text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded transition-colors"
+															aria-label={`Materialize ${field.name} into ${boundModel.name}'s schema.yml`}
+															title={`Write to ${boundModel.name}'s schema.yml`}
 														>
-															<Icon icon="lucide:trash-2" class="w-4 h-4" />
+															<Icon icon="lucide:arrow-up-to-line" class="w-3.5 h-3.5" />
 														</button>
 													{/if}
-												</div>
+													<button
+														type="button"
+														onclick={() => deleteDraftedField(field.draftIndex)}
+														class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+														title="Delete attribute"
+													>
+														<Icon icon="lucide:trash-2" class="w-4 h-4" />
+													</button>
+												{/if}
 											</div>
 										</div>
+										{#if dropIndex === field.draftIndex && dropPosition !== null}
+											<DropIndicator position={dropPosition} />
+										{/if}
+									</div>
 									{/each}
 								</div>
 							{:else}

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1343,7 +1343,7 @@
 										ondragover={field.origin === 'draft' ? (e) => onAttributeDragOver(field.draftIndex, e) : undefined}
 										ondrop={field.origin === 'draft' ? (e) => onAttributeDrop(field.draftIndex, e) : undefined}
 										ondragend={field.origin === 'draft' ? onAttributeDragEnd : undefined}
-										style={dragIndex === field.draftIndex ? 'opacity: 0.5;' : ''}
+										style={field.origin === 'draft' && dragIndex === field.draftIndex ? 'opacity: 0.5;' : ''}
 									>
 											<div class="grid grid-cols-12 gap-2 items-center">
 											<!-- Name -->
@@ -1459,7 +1459,7 @@
 												{/if}
 											</div>
 										</div>
-										{#if dropIndex === field.draftIndex && dropPosition !== null}
+										{#if field.origin === 'draft' && dropIndex === field.draftIndex && dropPosition !== null}
 											<DropIndicator position={dropPosition} />
 										{/if}
 									</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.3"
+version = "0.15.4"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -133,12 +133,29 @@ def _merge_layout_into_model(
     return model_data
 
 
+def _infer_type_from_name(name: str, dim_prefixes: List[str], fact_prefixes: List[str]) -> str | None:
+    """Infer entity type from a name string using configured dim/fact prefixes."""
+    name_lower = name.lower()
+    for prefix in dim_prefixes:
+        if name_lower.startswith(prefix.lower()):
+            return "dimension"
+    for prefix in fact_prefixes:
+        if name_lower.startswith(prefix.lower()):
+            return "fact"
+    return None
+
+
 def _apply_entity_type_inference(model_data: Dict[str, Any]) -> Dict[str, Any]:
     """
     Apply entity type inference to model data when dimensional modeling is enabled.
 
     Inference is only applied to entities that don't already have entity_type set.
     Manually set entity_type values are preserved.
+
+    Two-pass inference:
+    1. Manifest-based: bound entities whose dbt model name matches dim_/fct_ prefixes.
+    2. ID-based fallback: unbound entities not in the manifest but whose entity ID
+       itself matches the configured dimension/fact prefix patterns.
     """
     try:
         adapter = get_adapter()
@@ -147,22 +164,30 @@ def _apply_entity_type_inference(model_data: Dict[str, Any]) -> Dict[str, Any]:
         print(f"Warning: Could not infer entity types: {e}")
         return model_data
 
+    dim_prefixes: List[str] = cfg.DIMENSIONAL_MODELING_CONFIG.dimension_prefix
+    fact_prefixes: List[str] = cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix
+
     entities = model_data.get("entities", [])
     for entity in entities:
         entity_id = entity.get("id")
         if not entity_id:
             continue
 
-        # Apply inference if entity_type is missing or still unclassified
         existing_type = entity.get("entity_type")
         should_infer = existing_type is None or existing_type == "unclassified"
-        if should_infer and entity_id in inferred_types:
+        if not should_infer:
+            continue
+
+        if entity_id in inferred_types:
+            # Manifest-based inference (bound entities)
             entity["entity_type"] = inferred_types[entity_id]
-            print(
-                f"Inferred entity_type '{inferred_types[entity_id]}' for entity '{entity_id}'"
-            )
+            print(f"Inferred entity_type '{inferred_types[entity_id]}' for entity '{entity_id}'")
         else:
-            pass
+            # ID-based fallback for unbound entities not in the dbt manifest
+            inferred = _infer_type_from_name(entity_id, dim_prefixes, fact_prefixes)
+            if inferred:
+                entity["entity_type"] = inferred
+                print(f"Inferred entity_type '{inferred}' for unbound entity '{entity_id}' from ID prefix")
 
     return model_data
 
@@ -345,10 +370,6 @@ def _split_model_and_layout(
         # Only persist source_system for unbound entities (not for bound entities)
         if "source_system" in entity and not entity.get("dbt_model"):
             model_entity["source_system"] = entity["source_system"]
-            # Log instrumentation
-            print(
-                f"DEBUG: Entity {entity_id} is unbound, persisting source_system: {entity.get('source_system')}"
-            )
 
         model_data["entities"].append(model_entity)
 

--- a/trellis_datamodel/tests/test_entity_type_inference.py
+++ b/trellis_datamodel/tests/test_entity_type_inference.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from trellis_datamodel.adapters.dbt_core import DbtCoreAdapter
 from trellis_datamodel import config as cfg
+from trellis_datamodel.routes.data_model import _infer_type_from_name, _apply_entity_type_inference
 
 
 class TestEntityTypeInference:
@@ -295,3 +296,106 @@ class TestEntityTypeInference:
         assert entity_types["fact_sales"] == "fact"
         assert entity_types["staging_data"] == "unclassified"
         assert entity_types["raw_users"] == "unclassified"
+
+
+class TestInferTypeFromName:
+    """Unit tests for the _infer_type_from_name helper."""
+
+    DIM_PREFIXES = ["dim_", "d_"]
+    FACT_PREFIXES = ["fct_", "fact_"]
+
+    def test_dim_prefix_returns_dimension(self):
+        assert _infer_type_from_name("dim_customer", self.DIM_PREFIXES, self.FACT_PREFIXES) == "dimension"
+
+    def test_d_prefix_returns_dimension(self):
+        assert _infer_type_from_name("d_product", self.DIM_PREFIXES, self.FACT_PREFIXES) == "dimension"
+
+    def test_fct_prefix_returns_fact(self):
+        assert _infer_type_from_name("fct_orders", self.DIM_PREFIXES, self.FACT_PREFIXES) == "fact"
+
+    def test_fact_prefix_returns_fact(self):
+        assert _infer_type_from_name("fact_revenue", self.DIM_PREFIXES, self.FACT_PREFIXES) == "fact"
+
+    def test_case_insensitive(self):
+        assert _infer_type_from_name("DIM_Customer", self.DIM_PREFIXES, self.FACT_PREFIXES) == "dimension"
+        assert _infer_type_from_name("FCT_Orders", self.DIM_PREFIXES, self.FACT_PREFIXES) == "fact"
+
+    def test_no_match_returns_none(self):
+        assert _infer_type_from_name("staging_data", self.DIM_PREFIXES, self.FACT_PREFIXES) is None
+        assert _infer_type_from_name("raw_users", self.DIM_PREFIXES, self.FACT_PREFIXES) is None
+
+    def test_double_underscore_id_matches(self):
+        """Entity IDs like dim__account (generated with double underscore) still match dim_ prefix."""
+        assert _infer_type_from_name("dim__account", self.DIM_PREFIXES, self.FACT_PREFIXES) == "dimension"
+
+
+class TestApplyEntityTypeInferenceUnbound:
+    """Tests for the unbound-entity ID-prefix fallback in _apply_entity_type_inference."""
+
+    @pytest.fixture(autouse=True)
+    def setup_config(self):
+        original_enabled = cfg.DIMENSIONAL_MODELING_CONFIG.enabled
+        original_dim = cfg.DIMENSIONAL_MODELING_CONFIG.dimension_prefix
+        original_fact = cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix
+        cfg.DIMENSIONAL_MODELING_CONFIG.enabled = True
+        cfg.DIMENSIONAL_MODELING_CONFIG.dimension_prefix = ["dim_", "d_"]
+        cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix = ["fct_", "fact_"]
+        yield
+        cfg.DIMENSIONAL_MODELING_CONFIG.enabled = original_enabled
+        cfg.DIMENSIONAL_MODELING_CONFIG.dimension_prefix = original_dim
+        cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix = original_fact
+        DbtCoreAdapter.reset_inference_cache()
+
+    def _make_model_data(self, entities):
+        return {"entities": entities, "relationships": []}
+
+    def _mock_adapter(self, inferred_types):
+        from unittest.mock import MagicMock, patch
+        adapter = MagicMock()
+        adapter.infer_entity_types.return_value = inferred_types
+        return patch("trellis_datamodel.routes.data_model.get_adapter", return_value=adapter)
+
+    def test_unbound_dim_entity_inferred_as_dimension(self):
+        """Unbound entity whose ID starts with dim_ is inferred as dimension."""
+        with self._mock_adapter({}):
+            model_data = self._make_model_data([
+                {"id": "dim__account", "label": "Account", "entity_type": "unclassified"},
+            ])
+            result = _apply_entity_type_inference(model_data)
+        assert result["entities"][0]["entity_type"] == "dimension"
+
+    def test_unbound_fact_entity_inferred_as_fact(self):
+        """Unbound entity whose ID starts with fct_ is inferred as fact."""
+        with self._mock_adapter({}):
+            model_data = self._make_model_data([
+                {"id": "fct_transactions", "label": "Transactions"},
+            ])
+            result = _apply_entity_type_inference(model_data)
+        assert result["entities"][0]["entity_type"] == "fact"
+
+    def test_manually_set_type_not_overridden(self):
+        """A manually saved entity_type is never overwritten by inference."""
+        with self._mock_adapter({}):
+            model_data = self._make_model_data([
+                {"id": "dim__account", "label": "Account", "entity_type": "fact"},
+            ])
+            result = _apply_entity_type_inference(model_data)
+        assert result["entities"][0]["entity_type"] == "fact"
+
+    def test_no_prefix_match_stays_unclassified(self):
+        """Unbound entity with a random/timestamp ID stays unclassified."""
+        with self._mock_adapter({}):
+            model_data = self._make_model_data([
+                {"id": "1684123456789", "label": "New Entity"},
+            ])
+            result = _apply_entity_type_inference(model_data)
+        assert result["entities"][0].get("entity_type") is None
+
+    def test_manifest_inference_takes_precedence(self):
+        """Bound entity classified via manifest is not re-evaluated by ID fallback."""
+        with self._mock_adapter({"dim_customer": "dimension"}):
+            model_data = self._make_model_data([
+                {"id": "dim_customer", "label": "Customer", "entity_type": "unclassified"},
+            ])
+            result = _apply_entity_type_inference(model_data)
+        assert result["entities"][0]["entity_type"] == "dimension"

--- a/trellis_datamodel/tests/test_entity_type_inference.py
+++ b/trellis_datamodel/tests/test_entity_type_inference.py
@@ -350,10 +350,8 @@ class TestApplyEntityTypeInferenceUnbound:
         return {"entities": entities, "relationships": []}
 
     def _mock_adapter(self, inferred_types):
-        from unittest.mock import MagicMock, patch
-        adapter = MagicMock()
-        adapter.infer_entity_types.return_value = inferred_types
-        return patch("trellis_datamodel.routes.data_model.get_adapter", return_value=adapter)
+        from unittest.mock import patch
+        return patch.object(DbtCoreAdapter, "infer_entity_types", return_value=inferred_types)
 
     def test_unbound_dim_entity_inferred_as_dimension(self):
         """Unbound entity whose ID starts with dim_ is inferred as dimension."""

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.15.1"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.15.3"
+version = "0.15.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fixes #95
## Root causes & fixes
### Focus loss on attribute name input
`{#each mergedFields as field (field.name)}` used `field.name` as the Svelte keyed-each key. Every keystroke reassigned `editableDraftedFields` → `mergedFields` recomputed → key changed → Svelte destroyed and recreated the input → focus lost.
**Fix:** Changed key to `draft-{draftIndex}` / `dbt-{fieldName}`. The `draftIndex` is stable during typing so Svelte patches the existing input in place.
### Drag-to-reorder broken
The four drag handler functions were implemented but never wired up to the DOM — the row `<div>` had no `draggable` attribute or drag event listeners.
**Fix:** Added `draggable`, `ondragstart`, `ondragover`, `ondrop`, `ondragend` to each draft row, `DropIndicator` on the active drop target, and moved the grip icon to the left of the name input.

