### PR TITLE
fix(schema): prune stale columns in schema.yml sync (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Packaging
 
-- **PyPI pre-release**: Package version `0.15.5b1` for beta testing elsewhere (`pip install trellis-datamodel==0.15.5b1` after publish).
+- **PyPI pre-release**: Package version `0.15.5b2` for beta testing elsewhere (`pip install trellis-datamodel==0.15.5b2` after publish).
 
 ### Fixed
 
-- **`schema.yml` keeps stale columns after renames/deletes (#98)**: `YamlHandler.update_columns_batch` only added/updated columns and never removed ones missing from the incoming list, so renaming or deleting fields in `data_model.yml` left orphaned entries (and outdated `data_tests`) behind in `schema.yml`. The batch update now rebuilds the column list in the order of the incoming payload, reusing existing column entries by name so custom `data_tests`/`meta` are preserved while missing names are dropped.
+- **`schema.yml` keeps stale columns after renames/deletes (#98)**: Two code paths were affected. `YamlHandler.update_columns_batch` only added/updated columns and never removed ones missing from the incoming list, so renaming or deleting fields in `data_model.yml` left orphaned entries (and outdated `data_tests`) behind in `schema.yml`. The "push to dbt" flow (`DbtCoreAdapter.sync_relationships`) had the same additive pattern for `drafted_fields`, which is why the first beta still left stale columns on push-to-dbt. Both paths now rebuild the column list from the incoming payload, reusing existing column entries by name so custom `data_tests`/`meta` are preserved while missing names are dropped. `sync_relationships` only prunes when the entity actually carries a `drafted_fields` key, so relationship-only syncs do not wipe existing columns.
 
 ## [0.15.4] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.5] - 2026-05-15
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Packaging
+
+- **PyPI pre-release**: Package version `0.15.5b1` for beta testing elsewhere (`pip install trellis-datamodel==0.15.5b1` after publish).
+
+### Fixed
+
+- **`schema.yml` keeps stale columns after renames/deletes (#98)**: `YamlHandler.update_columns_batch` only added/updated columns and never removed ones missing from the incoming list, so renaming or deleting fields in `data_model.yml` left orphaned entries (and outdated `data_tests`) behind in `schema.yml`. The batch update now rebuilds the column list in the order of the incoming payload, reusing existing column entries by name so custom `data_tests`/`meta` are preserved while missing names are dropped.
+
 ## [0.15.4] - 2026-05-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.5b2"
+version = "0.15.5"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.4"
+version = "0.15.5b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.5b1"
+version = "0.15.5b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -1006,25 +1006,32 @@ class DbtCoreAdapter:
             if entity_tags is not None:
                 self.yaml_handler.update_model_tags(model_entry, entity_tags)
 
-            # Sync Drafted Fields
-            drafted_fields = entity.get("drafted_fields", [])
-            for field in drafted_fields:
-                f_name = field.get("name")
-                f_type = field.get("datatype")
-                f_desc = field.get("description")
-                f_origin = field.get("origin")
-                if f_desc and f_origin:
-                    f_desc = f"{f_desc} | Origin: {f_origin}"
-                elif f_origin:
-                    f_desc = f"Origin: {f_origin}"
+            # Sync Drafted Fields. When drafted_fields is provided we treat it as
+            # the authoritative column list — fields removed/renamed in the data
+            # model must disappear from schema.yml (issue #98). Entities without a
+            # drafted_fields key are left untouched so relationship-only syncs
+            # don't wipe existing columns.
+            if "drafted_fields" in entity:
+                columns_payload: list[dict[str, Any]] = []
+                for field in entity.get("drafted_fields") or []:
+                    f_name = field.get("name")
+                    if not f_name:
+                        continue
+                    f_desc = field.get("description")
+                    f_origin = field.get("origin")
+                    if f_desc and f_origin:
+                        f_desc = f"{f_desc} | Origin: {f_origin}"
+                    elif f_origin:
+                        f_desc = f"Origin: {f_origin}"
+                    columns_payload.append(
+                        {
+                            "name": f_name,
+                            "data_type": field.get("datatype"),
+                            "description": f_desc,
+                        }
+                    )
 
-                if not f_name:
-                    continue
-
-                col = self.yaml_handler.ensure_column(model_entry, f_name)
-                self.yaml_handler.update_column(
-                    col, data_type=f_type, description=f_desc
-                )
+                self.yaml_handler.update_columns_batch(model_entry, columns_payload)
 
             # Sync Relationships (FKs)
             # Build a map of which fields should have which relationship tests

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -285,6 +285,63 @@ class TestSyncDbtTests:
         assert result["status"] == "success"
         assert len(result["files"]) == 2  # One for each entity
 
+    def test_sync_dbt_tests_removes_stale_drafted_fields(
+        self, test_client, temp_dir, temp_data_model_path, mock_manifest
+    ):
+        """Regression for #98: when a drafted_field is renamed/removed in
+        data_model.yml, the corresponding column must disappear from schema.yml
+        on the next "push to dbt" run instead of accumulating alongside the new
+        name."""
+        sql_dir = os.path.join(temp_dir, "models", "3_core")
+        os.makedirs(sql_dir, exist_ok=True)
+        with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+            f.write("SELECT 1")
+
+        yml_path = os.path.join(sql_dir, "users.yml")
+        with open(yml_path, "w") as f:
+            yaml.dump(
+                {
+                    "version": 2,
+                    "models": [
+                        {
+                            "name": "users",
+                            "columns": [
+                                {"name": "id", "data_type": "int"},
+                                {"name": "old_email", "data_type": "text"},
+                                {"name": "to_delete", "data_type": "text"},
+                            ],
+                        }
+                    ],
+                },
+                f,
+            )
+
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.test_project.users",
+                    "drafted_fields": [
+                        {"name": "id", "datatype": "int"},
+                        {"name": "new_email", "datatype": "text"},
+                    ],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        response = test_client.post("/api/sync-dbt-tests")
+        assert response.status_code == 200
+
+        with open(yml_path, "r") as f:
+            saved = yaml.safe_load(f)
+        names = [c["name"] for c in saved["models"][0]["columns"]]
+        assert names == ["id", "new_email"]
+
     def test_syncs_relationship_tests_with_entity_type(
         self, test_client, temp_dir, temp_data_model_path
     ):

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -721,6 +721,50 @@ class TestUpdateModelSchema:
         yml_path = os.path.join(sql_dir, "users.yml")
         assert os.path.exists(yml_path)
 
+    def test_removes_renamed_and_deleted_columns(
+        self, test_client, temp_dir, mock_manifest
+    ):
+        """Regression: renaming or deleting fields in data_model.yml must
+        propagate to schema.yml instead of leaving stale columns behind.
+        See issue #98."""
+        sql_dir = os.path.join(temp_dir, "models", "3_core")
+        os.makedirs(sql_dir, exist_ok=True)
+        with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+            f.write("SELECT 1")
+
+        yml_path = os.path.join(sql_dir, "users.yml")
+        with open(yml_path, "w") as f:
+            yaml.dump(
+                {
+                    "version": 2,
+                    "models": [
+                        {
+                            "name": "users",
+                            "columns": [
+                                {"name": "id", "data_type": "int"},
+                                {"name": "old_email", "data_type": "text"},
+                                {"name": "to_delete", "data_type": "text"},
+                            ],
+                        }
+                    ],
+                },
+                f,
+            )
+
+        request_data = {
+            "columns": [
+                {"name": "id", "data_type": "int"},
+                {"name": "new_email", "data_type": "text"},
+            ],
+        }
+        response = test_client.post("/api/models/users/schema", json=request_data)
+        assert response.status_code == 200
+
+        with open(yml_path, "r") as f:
+            saved = yaml.safe_load(f)
+        names = [c["name"] for c in saved["models"][0]["columns"]]
+        assert names == ["id", "new_email"]
+
 
 class TestInferRelationships:
     """Tests for GET /api/infer-relationships endpoint."""

--- a/trellis_datamodel/tests/test_yaml_handler.py
+++ b/trellis_datamodel/tests/test_yaml_handler.py
@@ -174,6 +174,47 @@ class TestYamlHandlerColumnOperations:
         assert model["columns"][0]["data_type"] == "int"
         assert model["columns"][1]["description"] == "User name"
 
+    def test_update_columns_batch_removes_missing_columns(self):
+        """Renamed/deleted fields in data_model.yml must disappear from schema.yml."""
+        handler = YamlHandler()
+        model = CommentedMap({"name": "orders"})
+        model["columns"] = CommentedSeq(
+            [
+                CommentedMap({"name": "order_id", "data_type": "int"}),
+                CommentedMap({"name": "old_name", "data_type": "text"}),
+                CommentedMap({"name": "amount", "data_type": "numeric"}),
+            ]
+        )
+
+        handler.update_columns_batch(
+            model,
+            [
+                {"name": "order_id", "data_type": "int"},
+                {"name": "new_name", "data_type": "text"},
+                {"name": "amount", "data_type": "numeric"},
+            ],
+        )
+
+        names = [c["name"] for c in model["columns"]]
+        assert names == ["order_id", "new_name", "amount"]
+        assert "old_name" not in names
+
+    def test_update_columns_batch_preserves_existing_metadata(self):
+        """Reused columns must keep tests/meta the user added in schema.yml."""
+        handler = YamlHandler()
+        model = CommentedMap({"name": "orders"})
+        order_id_col = CommentedMap({"name": "order_id", "data_type": "int"})
+        order_id_col["data_tests"] = CommentedSeq(["not_null"])
+        model["columns"] = CommentedSeq([order_id_col])
+
+        handler.update_columns_batch(
+            model,
+            [{"name": "order_id", "data_type": "int", "description": "PK"}],
+        )
+
+        assert list(model["columns"][0]["data_tests"]) == ["not_null"]
+        assert model["columns"][0]["description"] == "PK"
+
     def test_get_columns(self):
         handler = YamlHandler()
         model = CommentedMap(

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -421,23 +421,39 @@ class YamlHandler:
         columns_data: List[Dict[str, Any]],
     ) -> None:
         """
-        Update multiple columns at once.
+        Replace the column list of a model with ``columns_data``.
 
-        Args:
-            model: Model entry
-            columns_data: List of column dicts with name, data_type, description
+        Existing column entries are reused (preserving tests, meta, and any
+        other round-tripped keys) when their ``name`` appears in
+        ``columns_data``. Columns missing from the incoming list are dropped,
+        so renames/deletions in the data model propagate to schema.yml.
+        Final order follows ``columns_data``.
         """
+        existing_by_name: Dict[str, CommentedMap] = {}
+        for col in model.get("columns", []) or []:
+            name = col.get("name") if isinstance(col, dict) else None
+            if name:
+                existing_by_name[name] = col
+
+        new_columns = CommentedSeq()
         for col_data in columns_data:
             col_name = col_data.get("name")
             if not col_name:
                 continue
 
-            col = self.ensure_column(model, col_name)
+            col = existing_by_name.get(col_name)
+            if col is None:
+                col = CommentedMap()
+                col["name"] = col_name
+
             self.update_column(
                 col,
                 data_type=col_data.get("data_type"),
                 description=col_data.get("description"),
             )
+            new_columns.append(col)
+
+        model["columns"] = new_columns
 
     def get_columns(self, model: CommentedMap) -> List[Dict[str, Any]]:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.15.4"
+version = "0.15.5b1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.15.5b1"
+version = "0.15.5b2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Rebuild column lists from the data_model payload so renames/deletes do not leave orphaned YAML columns while preserving existing column metadata by name.

Release 0.15.5b1 as a PyPI pre-release for downstream beta testing.

fixes #98 