### PR TITLE
Fix/relationship label export path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.8] - 2026-06-10
 
+### Changed
+
+- **Entity exports show concrete join keys for relationships**: The "Relationships" section of the Markdown and Excel exports now renders each relationship as `via source_field = target_field` (e.g. `via invoice_recipient_id = customer_number`), taken from the edge's `source_field` / `target_field`, the same keys shown in the canvas lineage view. This is more useful than the business label for understanding the join. When join keys are unavailable, the export falls back to the business label, then `-`.
+
 ### Fixed
 
-- **Relationship name shows as `-` in entity exports**: Markdown and Excel exports read the relationship name from the top-level `edge.label`, which is always undefined. The name is stored at `edge.data.label` (set in `aggregateRelationshipsIntoEdges`), so every relationship rendered as `via "-"` in exports even though the canvas editor displayed the correct name. All three export sites now read `edge.data.label`. Test fixtures that encoded the wrong edge shape (label at the top level instead of under `data`), which had masked the bug, were corrected.
+- **Relationship name shows as `-` in entity exports**: Markdown and Excel exports read the relationship name from the top-level `edge.label`, which is always undefined. The name is stored at `edge.data.label` (set in `aggregateRelationshipsIntoEdges`), so every relationship rendered as `via "-"` in exports even though the canvas editor displayed the correct name. All export sites now read `edge.data`. Test fixtures that encoded the wrong edge shape (label at the top level instead of under `data`), which had masked the bug, were corrected.
 
 ## [0.15.7] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Entity exports show concrete join keys for relationships**: The "Relationships" section of the Markdown and Excel exports now renders each relationship as `via source_field = target_field` (e.g. `via invoice_recipient_id = customer_number`), taken from the edge's `source_field` / `target_field`, the same keys shown in the canvas lineage view. This is more useful than the business label for understanding the join. When join keys are unavailable, the export falls back to the business label, then `-`.
+- **Entity exports show concrete join keys for relationships**: The "Relationships" section of the Markdown and Excel exports now renders each relationship with its table-qualified join keys, `via source_model.source_field = target_model.target_field` (e.g. `via invoice_recipient.invoice_recipient_id = dim__lead.customer_number`), matching the canvas lineage view. Table qualifiers come from the edge's model names, falling back to the entity labels when no model is bound. This is more useful than the business label for understanding the join. When join keys are unavailable, the export falls back to the business label, then `-`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.8] - 2026-06-10
+
+### Fixed
+
+- **Relationship name shows as `-` in entity exports**: Markdown and Excel exports read the relationship name from the top-level `edge.label`, which is always undefined. The name is stored at `edge.data.label` (set in `aggregateRelationshipsIntoEdges`), so every relationship rendered as `via "-"` in exports even though the canvas editor displayed the correct name. All three export sites now read `edge.data.label`. Test fixtures that encoded the wrong edge shape (label at the top level instead of under `data`), which had masked the bug, were corrected.
+
 ## [0.15.7] - 2026-05-15
 
 ### CI

--- a/frontend/src/lib/utils/excel-export.test.ts
+++ b/frontend/src/lib/utils/excel-export.test.ts
@@ -273,7 +273,8 @@ describe('Sheet Generators', () => {
       ];
 
       const sheet = generateRelationshipsSheet(edges, 'entity1', nodes);
-      expect(sheet.data[1]).toEqual(['Customer', 'customer_id = id', 'N:1', 'Outgoing']);
+      // No model names on the edge, so keys are qualified with the entity labels (lowercased).
+      expect(sheet.data[1]).toEqual(['Customer', 'order.customer_id = customer.id', 'N:1', 'Outgoing']);
     });
 
     it('should handle no relationships', () => {
@@ -284,8 +285,32 @@ describe('Sheet Generators', () => {
   });
 
   describe('formatRelationshipKeys', () => {
-    it('returns source = target when both fields present', () => {
+    it('returns unqualified source = target when no model names or fallback names are given', () => {
       expect(formatRelationshipKeys({ source_field: 'a_id', target_field: 'b_id' })).toBe('a_id = b_id');
+    });
+
+    it('qualifies with edge model names (lowercased) when present', () => {
+      const data = {
+        source_field: 'invoice_recipient_id',
+        target_field: 'customer_number',
+        models: [{ source_model_name: 'Invoice_Recipient', target_model_name: 'dim__lead' }]
+      };
+      expect(formatRelationshipKeys(data)).toBe('invoice_recipient.invoice_recipient_id = dim__lead.customer_number');
+    });
+
+    it('falls back to supplied entity names (lowercased) when the edge has no model names', () => {
+      expect(formatRelationshipKeys({ source_field: 'a_id', target_field: 'b_id' }, 'Orders', 'Customers')).toBe(
+        'orders.a_id = customers.b_id'
+      );
+    });
+
+    it('prefers edge model names over supplied fallback names', () => {
+      const data = {
+        source_field: 'a_id',
+        target_field: 'b_id',
+        models: [{ source_model_name: 'fct_orders', target_model_name: 'dim_customers' }]
+      };
+      expect(formatRelationshipKeys(data, 'Orders', 'Customers')).toBe('fct_orders.a_id = dim_customers.b_id');
     });
 
     it('returns null when either field is missing', () => {

--- a/frontend/src/lib/utils/excel-export.test.ts
+++ b/frontend/src/lib/utils/excel-export.test.ts
@@ -8,6 +8,7 @@ import {
   formatEntityType,
   formatAnnotationType,
   formatRelationshipType,
+  formatRelationshipKeys,
   generateOverviewSheet,
   generateAttributesSheet,
   generateRelationshipsSheet,
@@ -253,10 +254,45 @@ describe('Sheet Generators', () => {
       expect(sheet.data[0]).toEqual(['Related Entity', 'Relationship Label', 'Relationship Type', 'Direction']);
     });
 
+    it('should use concrete join keys in the relationship cell when available', () => {
+      const edges = [
+        {
+          source: 'entity1',
+          target: 'entity2',
+          data: {
+            label: 'belongs to',
+            type: 'many_to_one',
+            source_field: 'customer_id',
+            target_field: 'id'
+          }
+        }
+      ];
+      const nodes = [
+        { id: 'entity1', data: { label: 'Order' } },
+        { id: 'entity2', data: { label: 'Customer' } }
+      ];
+
+      const sheet = generateRelationshipsSheet(edges, 'entity1', nodes);
+      expect(sheet.data[1]).toEqual(['Customer', 'customer_id = id', 'N:1', 'Outgoing']);
+    });
+
     it('should handle no relationships', () => {
       const sheet = generateRelationshipsSheet([], 'entity1', []);
       expect(sheet).toBeDefined();
       expect(sheet.data[1]).toEqual(['No relationships defined', '', '', '']);
+    });
+  });
+
+  describe('formatRelationshipKeys', () => {
+    it('returns source = target when both fields present', () => {
+      expect(formatRelationshipKeys({ source_field: 'a_id', target_field: 'b_id' })).toBe('a_id = b_id');
+    });
+
+    it('returns null when either field is missing', () => {
+      expect(formatRelationshipKeys({ source_field: 'a_id' })).toBeNull();
+      expect(formatRelationshipKeys({ target_field: 'b_id' })).toBeNull();
+      expect(formatRelationshipKeys({})).toBeNull();
+      expect(formatRelationshipKeys(undefined)).toBeNull();
     });
   });
 });

--- a/frontend/src/lib/utils/excel-export.test.ts
+++ b/frontend/src/lib/utils/excel-export.test.ts
@@ -240,8 +240,7 @@ describe('Sheet Generators', () => {
         {
           source: 'entity1',
           target: 'entity2',
-          label: 'belongs to',
-          data: { type: 'many_to_one' }
+          data: { label: 'belongs to', type: 'many_to_one' }
         }
       ];
       const nodes = [
@@ -357,7 +356,7 @@ describe('generateDataModelOverviewSheet', () => {
       { type: 'entity', id: 'e2', data: { label: 'Customer', entity_type: 'dimension' } }
     ] as unknown as Node[];
     const edges = [
-      { source: 'e1', target: 'e2', label: 'placed by', data: { type: 'many_to_one' } }
+      { source: 'e1', target: 'e2', data: { label: 'placed by', type: 'many_to_one' } }
     ];
     const sheet = generateDataModelOverviewSheet(nodes, edges);
     const allRows: string[][] = sheet.data;

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -120,6 +120,25 @@ export function formatRelationshipType(type: string): string {
 }
 
 /**
+ * Formats the concrete join keys of a relationship edge as `source_field = target_field`.
+ *
+ * The keys come from the edge's `data.source_field` / `data.target_field` (the same fields
+ * the canvas lineage view renders). Returns null when either key is missing so callers can
+ * fall back to the business label.
+ *
+ * @param data - The edge `data` object
+ * @returns A `source = target` join expression, or null when keys are unavailable
+ */
+export function formatRelationshipKeys(data: Record<string, unknown> | null | undefined): string | null {
+	const sourceField = data?.source_field as string | undefined;
+	const targetField = data?.target_field as string | undefined;
+	if (sourceField && targetField) {
+		return `${sourceField} = ${targetField}`;
+	}
+	return null;
+}
+
+/**
  * Generates Overview sheet with entity metadata in key-value format
  * @param entity - Entity data from EntityDetailModal
  * @returns Configured XLSX worksheet with bold headers and column widths
@@ -186,7 +205,7 @@ export function generateRelationshipsSheet(
 
 			return [
 				relatedEntity?.data?.label || relatedEntityId,
-				edge.data?.label || '-',
+				formatRelationshipKeys(edge.data) ?? (edge.data?.label || '-'),
 				formatRelationshipType(edge.data?.type || 'unknown'),
 				isOutgoing ? 'Outgoing' : 'Incoming'
 			];
@@ -383,7 +402,7 @@ export function generateDataModelOverviewSheet(
 			rows.push([
 				nodeById.get(edge.source) ?? edge.source,
 				nodeById.get(edge.target) ?? edge.target,
-				edge.data?.label ?? '',
+				formatRelationshipKeys(edge.data) ?? (edge.data?.label ?? ''),
 				formatRelationshipType(edge.data?.type ?? 'unknown')
 			]);
 		}

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -186,7 +186,7 @@ export function generateRelationshipsSheet(
 
 			return [
 				relatedEntity?.data?.label || relatedEntityId,
-				edge.label || '-',
+				edge.data?.label || '-',
 				formatRelationshipType(edge.data?.type || 'unknown'),
 				isOutgoing ? 'Outgoing' : 'Incoming'
 			];
@@ -383,7 +383,7 @@ export function generateDataModelOverviewSheet(
 			rows.push([
 				nodeById.get(edge.source) ?? edge.source,
 				nodeById.get(edge.target) ?? edge.target,
-				edge.label ?? '',
+				edge.data?.label ?? '',
 				formatRelationshipType(edge.data?.type ?? 'unknown')
 			]);
 		}

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -120,22 +120,40 @@ export function formatRelationshipType(type: string): string {
 }
 
 /**
- * Formats the concrete join keys of a relationship edge as `source_field = target_field`.
+ * Formats the concrete join keys of a relationship edge as a fully-qualified
+ * `source_model.source_field = target_model.target_field` expression, matching the
+ * canvas lineage view (e.g. `invoice_recipient.invoice_recipient_id = dim__lead.customer_number`).
  *
- * The keys come from the edge's `data.source_field` / `data.target_field` (the same fields
- * the canvas lineage view renders). Returns null when either key is missing so callers can
- * fall back to the business label.
+ * Keys come from `data.source_field` / `data.target_field`. The table qualifier comes from
+ * `data.models[0].source_model_name` / `target_model_name`, falling back to the supplied
+ * entity names (the canvas does the same), lowercased to match the lineage rendering. When a
+ * qualifier is unavailable the field is emitted unprefixed. Returns null when either key is
+ * missing so callers can fall back to the business label.
  *
  * @param data - The edge `data` object
- * @returns A `source = target` join expression, or null when keys are unavailable
+ * @param sourceName - Fallback name for the source side (e.g. the source entity label)
+ * @param targetName - Fallback name for the target side (e.g. the target entity label)
+ * @returns A qualified `source = target` join expression, or null when keys are unavailable
  */
-export function formatRelationshipKeys(data: Record<string, unknown> | null | undefined): string | null {
+export function formatRelationshipKeys(
+	data: Record<string, unknown> | null | undefined,
+	sourceName?: string | null,
+	targetName?: string | null
+): string | null {
 	const sourceField = data?.source_field as string | undefined;
 	const targetField = data?.target_field as string | undefined;
-	if (sourceField && targetField) {
-		return `${sourceField} = ${targetField}`;
+	if (!sourceField || !targetField) {
+		return null;
 	}
-	return null;
+
+	const models = data?.models as Array<Record<string, unknown>> | undefined;
+	const sourceModel = (models?.[0]?.source_model_name as string | undefined) || sourceName || undefined;
+	const targetModel = (models?.[0]?.target_model_name as string | undefined) || targetName || undefined;
+
+	const sourceExpr = sourceModel ? `${sourceModel.toLowerCase()}.${sourceField}` : sourceField;
+	const targetExpr = targetModel ? `${targetModel.toLowerCase()}.${targetField}` : targetField;
+
+	return `${sourceExpr} = ${targetExpr}`;
 }
 
 /**
@@ -202,10 +220,12 @@ export function generateRelationshipsSheet(
 			const isOutgoing = edge.source === entityId;
 			const relatedEntityId = isOutgoing ? edge.target : edge.source;
 			const relatedEntity = allNodes.find(n => n.id === relatedEntityId);
+			const sourceName = (allNodes.find(n => n.id === edge.source)?.data?.label as string) || edge.source;
+			const targetName = (allNodes.find(n => n.id === edge.target)?.data?.label as string) || edge.target;
 
 			return [
 				relatedEntity?.data?.label || relatedEntityId,
-				formatRelationshipKeys(edge.data) ?? (edge.data?.label || '-'),
+				formatRelationshipKeys(edge.data, sourceName, targetName) ?? (edge.data?.label || '-'),
 				formatRelationshipType(edge.data?.type || 'unknown'),
 				isOutgoing ? 'Outgoing' : 'Incoming'
 			];
@@ -402,7 +422,7 @@ export function generateDataModelOverviewSheet(
 			rows.push([
 				nodeById.get(edge.source) ?? edge.source,
 				nodeById.get(edge.target) ?? edge.target,
-				formatRelationshipKeys(edge.data) ?? (edge.data?.label ?? ''),
+				formatRelationshipKeys(edge.data, nodeById.get(edge.source), nodeById.get(edge.target)) ?? (edge.data?.label ?? ''),
 				formatRelationshipType(edge.data?.type ?? 'unknown')
 			]);
 		}

--- a/frontend/src/lib/utils/markdown-export.test.ts
+++ b/frontend/src/lib/utils/markdown-export.test.ts
@@ -323,7 +323,7 @@ describe('markdown-export utilities', () => {
 			expect(result).toContain('- **Order** via "-" (1:N, Outgoing)');
 		});
 
-		it('should show concrete join keys (source = target) when available, without quotes', () => {
+		it('should show table-qualified join keys (model.field = model.field) when model names are present', () => {
 			const edgesWithKeys = [
 				{
 					id: 'edge1',
@@ -333,17 +333,27 @@ describe('markdown-export utilities', () => {
 						label: 'customer',
 						type: 'one_to_many',
 						source_field: 'invoice_recipient_id',
-						target_field: 'customer_number'
+						target_field: 'customer_number',
+						models: [
+							{
+								source_model_name: 'invoice_recipient',
+								target_model_name: 'dim__lead',
+								source_field: 'invoice_recipient_id',
+								target_field: 'customer_number'
+							}
+						]
 					}
 				}
 			];
 
 			const result = formatEntityAsMarkdown(mockEntity, [], edgesWithKeys, mockNodes, 'customer');
 
-			expect(result).toContain('- **Order** via invoice_recipient_id = customer_number (1:N, Outgoing)');
+			expect(result).toContain(
+				'- **Order** via invoice_recipient.invoice_recipient_id = dim__lead.customer_number (1:N, Outgoing)'
+			);
 		});
 
-		it('should prefer join keys over the business label', () => {
+		it('should qualify keys with entity labels when the edge carries no model names', () => {
 			const edgesWithKeys = [
 				{
 					id: 'edge1',
@@ -360,7 +370,7 @@ describe('markdown-export utilities', () => {
 
 			const result = formatEntityAsMarkdown(mockEntity, [], edgesWithKeys, mockNodes, 'customer');
 
-			expect(result).toContain('via customer_id = customer_id');
+			expect(result).toContain('via customer.customer_id = order.customer_id');
 			expect(result).not.toContain('via "places"');
 		});
 

--- a/frontend/src/lib/utils/markdown-export.test.ts
+++ b/frontend/src/lib/utils/markdown-export.test.ts
@@ -33,15 +33,13 @@ describe('markdown-export utilities', () => {
 				id: 'edge1',
 				source: 'customer',
 				target: 'order',
-				label: 'has',
-				data: { type: 'one_to_many' }
+				data: { label: 'has', type: 'one_to_many' }
 			},
 			{
 				id: 'edge2',
 				source: 'address',
 				target: 'customer',
-				label: 'lives_at',
-				data: { type: 'many_to_one' }
+				data: { label: 'lives_at', type: 'many_to_one' }
 			}
 		];
 
@@ -158,8 +156,7 @@ describe('markdown-export utilities', () => {
 					id: 'edge1',
 					source: 'other1',
 					target: 'other2',
-					label: 'unrelated',
-					data: { type: 'one_to_one' }
+					data: { label: 'unrelated', type: 'one_to_one' }
 				}
 			];
 
@@ -317,8 +314,7 @@ describe('markdown-export utilities', () => {
 					id: 'edge1',
 					source: 'customer',
 					target: 'order',
-					label: null,
-					data: { type: 'one_to_many' }
+					data: { label: null, type: 'one_to_many' }
 				}
 			];
 
@@ -333,8 +329,7 @@ describe('markdown-export utilities', () => {
 					id: 'edge1',
 					source: 'customer',
 					target: 'order',
-					label: 'related_to',
-					data: {}
+					data: { label: 'related_to' }
 				}
 			];
 
@@ -350,8 +345,7 @@ describe('markdown-export utilities', () => {
 					id: 'edge1',
 					source: 'customer',
 					target: 'unknown_entity',
-					label: 'relates_to',
-					data: { type: 'one_to_many' }
+					data: { label: 'relates_to', type: 'one_to_many' }
 				}
 			];
 
@@ -367,22 +361,19 @@ describe('markdown-export utilities', () => {
 					id: 'edge1',
 					source: 'customer',
 					target: 'order',
-					label: 'one_many',
-					data: { type: 'one_to_many' }
+					data: { label: 'one_many', type: 'one_to_many' }
 				},
 				{
 					id: 'edge2',
 					source: 'order',
 					target: 'customer',
-					label: 'many_one',
-					data: { type: 'many_to_one' }
+					data: { label: 'many_one', type: 'many_to_one' }
 				},
 				{
 					id: 'edge3',
 					source: 'customer',
 					target: 'profile',
-					label: 'one_one',
-					data: { type: 'one_to_one' }
+					data: { label: 'one_one', type: 'one_to_one' }
 				}
 			];
 

--- a/frontend/src/lib/utils/markdown-export.test.ts
+++ b/frontend/src/lib/utils/markdown-export.test.ts
@@ -323,6 +323,66 @@ describe('markdown-export utilities', () => {
 			expect(result).toContain('- **Order** via "-" (1:N, Outgoing)');
 		});
 
+		it('should show concrete join keys (source = target) when available, without quotes', () => {
+			const edgesWithKeys = [
+				{
+					id: 'edge1',
+					source: 'customer',
+					target: 'order',
+					data: {
+						label: 'customer',
+						type: 'one_to_many',
+						source_field: 'invoice_recipient_id',
+						target_field: 'customer_number'
+					}
+				}
+			];
+
+			const result = formatEntityAsMarkdown(mockEntity, [], edgesWithKeys, mockNodes, 'customer');
+
+			expect(result).toContain('- **Order** via invoice_recipient_id = customer_number (1:N, Outgoing)');
+		});
+
+		it('should prefer join keys over the business label', () => {
+			const edgesWithKeys = [
+				{
+					id: 'edge1',
+					source: 'customer',
+					target: 'order',
+					data: {
+						label: 'places',
+						type: 'one_to_many',
+						source_field: 'customer_id',
+						target_field: 'customer_id'
+					}
+				}
+			];
+
+			const result = formatEntityAsMarkdown(mockEntity, [], edgesWithKeys, mockNodes, 'customer');
+
+			expect(result).toContain('via customer_id = customer_id');
+			expect(result).not.toContain('via "places"');
+		});
+
+		it('should fall back to the label when only one join key is present', () => {
+			const edgesPartialKeys = [
+				{
+					id: 'edge1',
+					source: 'customer',
+					target: 'order',
+					data: {
+						label: 'has',
+						type: 'one_to_many',
+						source_field: 'customer_id'
+					}
+				}
+			];
+
+			const result = formatEntityAsMarkdown(mockEntity, [], edgesPartialKeys, mockNodes, 'customer');
+
+			expect(result).toContain('- **Order** via "has" (1:N, Outgoing)');
+		});
+
 		it('should handle relationship without data.type', () => {
 			const edgesWithoutType = [
 				{

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -1,6 +1,6 @@
 import type { Node } from '@xyflow/svelte';
 import type { EntityData } from '$lib/types';
-import { formatEntityType, formatAnnotationType, formatRelationshipType } from './excel-export';
+import { formatEntityType, formatAnnotationType, formatRelationshipType, formatRelationshipKeys } from './excel-export';
 
 /**
  * Prepares a value for a GFM pipe table cell: single-line text and no raw `|` characters.
@@ -90,11 +90,14 @@ export function formatEntityAsMarkdown(
 			const relatedEntityId = isOutgoing ? edge.target : edge.source;
 			const relatedEntity = allNodes.find(n => n.id === relatedEntityId);
 			const relatedEntityName = relatedEntity?.data?.label || relatedEntityId;
-			const relationshipLabel = edge.data?.label || '-';
+			// Prefer the concrete join keys (source_field = target_field); fall back to the
+			// business label, then "-", when keys are unavailable.
+			const joinKeys = formatRelationshipKeys(edge.data);
+			const via = joinKeys ?? `"${edge.data?.label || '-'}"`;
 			const relationshipType = formatRelationshipType(edge.data?.type || 'unknown');
 			const direction = isOutgoing ? 'Outgoing' : 'Incoming';
 
-			lines.push(`- **${relatedEntityName}** via "${relationshipLabel}" (${relationshipType}, ${direction})`);
+			lines.push(`- **${relatedEntityName}** via ${via} (${relationshipType}, ${direction})`);
 		}
 	}
 

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -90,7 +90,7 @@ export function formatEntityAsMarkdown(
 			const relatedEntityId = isOutgoing ? edge.target : edge.source;
 			const relatedEntity = allNodes.find(n => n.id === relatedEntityId);
 			const relatedEntityName = relatedEntity?.data?.label || relatedEntityId;
-			const relationshipLabel = edge.label || '-';
+			const relationshipLabel = edge.data?.label || '-';
 			const relationshipType = formatRelationshipType(edge.data?.type || 'unknown');
 			const direction = isOutgoing ? 'Outgoing' : 'Incoming';
 

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -90,9 +90,12 @@ export function formatEntityAsMarkdown(
 			const relatedEntityId = isOutgoing ? edge.target : edge.source;
 			const relatedEntity = allNodes.find(n => n.id === relatedEntityId);
 			const relatedEntityName = relatedEntity?.data?.label || relatedEntityId;
-			// Prefer the concrete join keys (source_field = target_field); fall back to the
-			// business label, then "-", when keys are unavailable.
-			const joinKeys = formatRelationshipKeys(edge.data);
+			// Entity labels qualify the join keys when the edge carries no model names.
+			const sourceName = (allNodes.find(n => n.id === edge.source)?.data?.label as string) || edge.source;
+			const targetName = (allNodes.find(n => n.id === edge.target)?.data?.label as string) || edge.target;
+			// Prefer the concrete, table-qualified join keys; fall back to the business label,
+			// then "-", when keys are unavailable.
+			const joinKeys = formatRelationshipKeys(edge.data, sourceName, targetName);
 			const via = joinKeys ?? `"${edge.data?.label || '-'}"`;
 			const relationshipType = formatRelationshipType(edge.data?.type || 'unknown');
 			const direction = isOutgoing ? 'Outgoing' : 'Incoming';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.7"
+version = "0.15.8"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
##  Background
  The "Relationships" section of the Markdown and Excel exports rendered every
  relationship as via "-", even though the canvas editor showed the correct name.
  Root cause: the exports read the relationship name from the top-level edge.label,
  which is always undefined. The value lives at edge.data.label (set in
  aggregateRelationshipsIntoEdges). The tell was that each buggy line read
  edge.data.type correctly on the very next line. This was an export-only bug; the
  canvas (CustomEdge.svelte) already read the right path.

##  Changes
  - Fix: all three export sites now read from edge.data instead of the top-level edge.
  - Feature: relationships are rendered with their table-qualified join keys,
    via source_model.source_field = target_model.target_field
    (e.g. via invoice_recipient.invoice_recipient_id = dim__lead.customer_number),
    matching the canvas lineage view. The table qualifier comes from the edge's
    model names, lowercased, falling back to the entity label when no model is bound.
    This is more useful than the business label for understanding the join. When join
    keys are unavailable, the export falls back to the business label, then "-".
  - Added a shared formatRelationshipKeys helper used by the Markdown export and both
    Excel export sites, so the modal and exports stay consistent.
  - Corrected test fixtures that encoded the wrong edge shape (label at the top level
    instead of under data), which had masked the original bug.

##  Testing
  - 86 frontend unit tests pass (markdown-export + excel-export), including new
    coverage for qualified keys, the entity-label fallback, model-name precedence,
    and the no-keys fallback.
  - svelte-check: 0 errors.

##  Release
  Patch release 0.15.8 (version bumped in pyproject.toml + CHANGELOG). Merging this
  to main triggers the automated GitHub Release + PyPI publish. Validated via beta
  0.15.8b3 before opening this PR.

  Follow-up (separate PR)
  Surface relationships directly in the EntityDetailModal (read-only + clickable);
  today they only appear in the export, not the modal UI.

  Note: merge with squash or a merge commit (not rebase) so release.yml detects the
  version bump.