### PR TITLE
feat(modal): show relationships in the entity detail modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.9] - 2026-06-10
+
+### Added
+
+- **Relationships section in the entity detail modal**: The EntityDetailModal now shows the entity's relationships directly on screen, previously they appeared only in the Markdown/Excel export, not the modal UI. Each relationship lists the related entity (a clickable link that navigates the modal to that entity), the direction (incoming/outgoing), the cardinality (e.g. 1:N), and the table-qualified join keys (`source_model.source_field = target_model.target_field`). The list reuses the same `formatRelationshipKeys` / `formatRelationshipType` helpers as the exports, so the modal and exports stay consistent. Navigating to another entity warns first if there are unsaved changes.
+
 ## [0.15.8] - 2026-06-10
 
 ### Changed

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -8,7 +8,7 @@
 	import type { Node } from '@xyflow/svelte';
 	import { getContext } from 'svelte';
 	import type { AutoSaveService } from '$lib/services/auto-save';
-	import { exportEntityToExcel } from '$lib/utils/excel-export';
+	import { exportEntityToExcel, formatRelationshipType, formatRelationshipKeys } from '$lib/utils/excel-export';
 	import { formatEntityAsMarkdown } from '$lib/utils/markdown-export';
 	import { goto } from '$app/navigation';
 	import DropIndicator from './DropIndicator.svelte';
@@ -109,6 +109,32 @@
 	let currentEntity = $derived.by(() => {
 		if (!$entityDetailModal.open || !$entityDetailModal.entityId) return null;
 		return $nodes.find((n) => n.id === $entityDetailModal.entityId) || null;
+	});
+
+	// Read-only relationships for the current entity, derived from the edges that touch it.
+	// Mirrors the markdown/Excel export: related entity, direction, cardinality, join keys.
+	let entityRelationships = $derived.by(() => {
+		const id = currentEntity?.id;
+		if (!id) return [];
+		return $edges
+			.filter((e) => e.source === id || e.target === id)
+			.map((e) => {
+				const isOutgoing = e.source === id;
+				const relatedId = isOutgoing ? e.target : e.source;
+				const relatedName = ($nodes.find((n) => n.id === relatedId)?.data?.label as string) || relatedId;
+				const sourceName = ($nodes.find((n) => n.id === e.source)?.data?.label as string) || e.source;
+				const targetName = ($nodes.find((n) => n.id === e.target)?.data?.label as string) || e.target;
+				const data = e.data as Record<string, unknown> | undefined;
+				return {
+					edgeId: e.id,
+					relatedId,
+					relatedName,
+					isOutgoing,
+					cardinality: formatRelationshipType((data?.type as string) || 'unknown'),
+					keys: formatRelationshipKeys(data, sourceName, targetName),
+					label: (data?.label as string) || ''
+				};
+			});
 	});
 
 	// Check if entity is bound to dbt model
@@ -791,6 +817,16 @@
 
 	function closeModal() {
 		$entityDetailModal = { open: false, entityId: null };
+	}
+
+	// Navigate the modal to a related entity. Warns on unsaved changes, mirroring handleCancel.
+	function openRelatedEntity(entityId: string) {
+		if (!entityId || entityId === currentEntity?.id) return;
+		if (isDirty) {
+			const confirmed = confirm('You have unsaved changes. Switch entities without saving?');
+			if (!confirmed) return;
+		}
+		entityDetailModal.set({ open: true, entityId });
 	}
 
 	// Annotation type options for dimensions
@@ -1504,6 +1540,42 @@
 										<Icon icon="lucide:layers" class="w-4 h-4 text-primary-600" />
 										<span class="font-mono text-sm text-gray-900">{model}</span>
 									</div>
+								</div>
+							{/each}
+							</div>
+						</div>
+					{/if}
+
+					<!-- Relationships (read-only, click an entity to navigate) -->
+					{#if entityRelationships.length > 0}
+						<div>
+							<label class="block text-sm font-semibold text-gray-700 mb-3">
+								Relationships ({entityRelationships.length})
+							</label>
+							<div class="space-y-2">
+							{#each entityRelationships as rel (rel.edgeId)}
+								<div class="px-4 py-3 bg-gray-50 border border-gray-200 rounded-lg">
+									<div class="flex items-center gap-2 flex-wrap">
+										<Icon
+											icon={rel.isOutgoing ? 'lucide:arrow-right' : 'lucide:arrow-left'}
+											class="w-4 h-4 text-gray-400 shrink-0"
+										/>
+										<button
+											type="button"
+											onclick={() => openRelatedEntity(rel.relatedId)}
+											class="text-sm font-medium text-primary-700 hover:text-primary-800 hover:underline focus:outline-none focus:ring-2 focus:ring-primary-500 rounded"
+										>
+											{rel.relatedName}
+										</button>
+										<span class="text-xs text-gray-500">
+											({rel.cardinality}, {rel.isOutgoing ? 'Outgoing' : 'Incoming'})
+										</span>
+									</div>
+									{#if rel.keys}
+										<div class="mt-1 ml-6 font-mono text-xs text-gray-500">{rel.keys}</div>
+									{:else if rel.label}
+										<div class="mt-1 ml-6 text-xs text-gray-500 italic">{rel.label}</div>
+									{/if}
 								</div>
 							{/each}
 							</div>

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
-import { nodes, dbtModels, entityDetailModal } from '$lib/stores';
+import { nodes, edges, dbtModels, entityDetailModal } from '$lib/stores';
 import type { DbtModel } from '$lib/types';
 import { updateModelSchema } from '$lib/api';
 
@@ -196,5 +197,84 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
       expect(screen.queryByDisplayValue('pending_col')).not.toBeInTheDocument();
       expect(screen.getByText(/Column 'pending_col' added to schema\.yml/i)).toBeInTheDocument();
     });
+  });
+});
+
+describe('EntityDetailModal — Relationships section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    nodes.set([]);
+    edges.set([]);
+    dbtModels.set([]);
+    entityDetailModal.set({ open: false, entityId: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  function setupEntityWithRelationship() {
+    nodes.set([
+      { id: 'node-lead', type: 'entity', position: { x: 0, y: 0 }, data: { label: 'Lead' } },
+      { id: 'node-ir', type: 'entity', position: { x: 0, y: 0 }, data: { label: 'Invoice Recipient' } },
+    ] as any);
+    edges.set([
+      {
+        id: 'e-ir-lead',
+        source: 'node-ir',
+        target: 'node-lead',
+        type: 'custom',
+        data: {
+          label: 'customer',
+          type: 'one_to_many',
+          source_field: 'invoice_recipient_id',
+          target_field: 'customer_number',
+          models: [{ source_model_name: 'invoice_recipient', target_model_name: 'dim__lead' }],
+        },
+      },
+    ] as any);
+    entityDetailModal.set({ open: true, entityId: 'node-lead' });
+  }
+
+  it('lists relationships with direction, cardinality, and table-qualified join keys', async () => {
+    setupEntityWithRelationship();
+    await renderModal();
+
+    expect(screen.getByText(/Relationships \(1\)/)).toBeInTheDocument();
+    // Edge source is node-ir, current entity is node-lead → incoming.
+    expect(screen.getByText(/\(1:N, Incoming\)/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Invoice Recipient' })).toBeInTheDocument();
+    expect(
+      screen.getByText('invoice_recipient.invoice_recipient_id = dim__lead.customer_number')
+    ).toBeInTheDocument();
+  });
+
+  it('navigates the modal to the related entity when its name is clicked', async () => {
+    setupEntityWithRelationship();
+    await renderModal();
+
+    // Currently showing Lead.
+    expect(screen.getByDisplayValue('Lead')).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Invoice Recipient' }));
+
+    await waitFor(() => {
+      expect(get(entityDetailModal).entityId).toBe('node-ir');
+      // Form reloaded to the related entity.
+      expect(screen.getByDisplayValue('Invoice Recipient')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render the Relationships section when the entity has no edges', async () => {
+    nodes.set([
+      { id: 'node-lead', type: 'entity', position: { x: 0, y: 0 }, data: { label: 'Lead' } },
+    ] as any);
+    edges.set([]);
+    entityDetailModal.set({ open: true, entityId: 'node-lead' });
+    await renderModal();
+
+    expect(screen.queryByText(/Relationships \(/)).not.toBeInTheDocument();
   });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.8"
+version = "0.15.9"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The EntityDetailModal now renders the entity's relationships on screen (previously only in the export). Each row shows the related entity as a clickable link that navigates the modal to that entity, the direction, the cardinality, and the table-qualified join keys. Reuses the formatRelationshipKeys/formatRelationshipType helpers so the modal and exports stay consistent; navigating warns on unsaved changes.

Bumps version to 0.15.9 + changelog.