### PR TITLE
feat: dbt reconciliation & single source of truth (v0.16.0)

### DIFF
--- a/.cursor/project.md
+++ b/.cursor/project.md
@@ -43,6 +43,23 @@ Trellis: **visual data model editor** that:
 4. **Visual Clarity**: Complex models → intuitive visual repr.
 5. **Bidirectional Sync**: Changes flow both ways — code↔visualization.
 
+### Design Principles
+
+**dbt is the source of truth for column metadata.**
+When Trellis and dbt disagree — on column existence, data types, or descriptions — dbt is right.
+
+`data_model.yml` is the single source of truth for the *model*, holding both materialized and not-yet-materialized fields. Each field carries a `source` tag:
+- `source: dbt` — mirrored from the dbt manifest on reconciliation. Read-only in Trellis (except description). Overwritten on next reconcile — dbt wins.
+- `source: draft` — authored in Trellis, not yet materialized in dbt.
+
+**Reconciliation rules:**
+- Manifest columns → `source: dbt` fields in `data_model.yml`. dbt wins on name, type, description.
+- Draft fields with no matching manifest column → preserved unchanged.
+- A model absent from the manifest (e.g. partial `dbt compile --select`) → existing fields untouched. Absence is never treated as deletion.
+- Reconciliation is one-way (manifest → `data_model.yml`) and idempotent.
+
+**Description is the one two-way attribute** of a materialized column. Users may edit it in Trellis; it writes back to `schema.yml` directly (the live source for descriptions). All other materialized column attributes are read-only.
+
 ### Differentiation
 
 Trellis unique:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-15
+
+### Added
+
+- **dbt reconciliation — `data_model.yml` as single source of truth**: Trellis now reconciles the compiled dbt manifest into `data_model.yml` on startup. Each bound entity's field list is enriched with its materialized dbt columns tagged `source: dbt`, alongside any unmatched drafted fields (`source: draft`). The file is self-contained and readable offline without a live manifest. Reconciliation is non-destructive: a model absent from the manifest (e.g. after a partial `dbt compile --select`) never removes its existing materialized fields.
+- **`POST /api/reconcile-dbt` endpoint**: Triggers manifest→`data_model.yml` reconciliation on demand. Returns `{status, changed, data_model}`. Called automatically by the frontend on app load after the manifest is fetched.
+- **Live schema.yml description read**: When opening the entity detail modal for a bound entity, Trellis fetches column descriptions directly from `schema.yml` (via `GET /api/models/{name}/schema`) rather than from the manifest. Lag-free — edited descriptions are visible immediately after save without running `dbt compile`. Priority: user edit > live `schema.yml` value > manifest value.
+- **`DraftedField.source` provenance marker**: TypeScript and YAML `drafted_fields` entries gain an optional `source: 'dbt' | 'draft'` field. `source: dbt` fields are dbt-owned and read-only (except description); `source: draft` fields are Trellis-authored. Missing `source` is treated as `draft` for backward compatibility.
+- **Collapsible entity sections in undescribed attributes warning**: The multi-entity view in the undescribed attributes modal now shows collapsible sections per entity, making it easier to navigate large lists.
+
+### Fixed
+
+- **`get_models()` now includes column descriptions**: The `/api/manifest` endpoint previously stripped column descriptions silently. Descriptions from the manifest (and `comment` from the catalog) are now included in each column entry.
+- **Catalog column names normalized to lowercase**: When a dbt catalog is present (e.g. after `dbt docs generate`), column names were returned in the database's native case (uppercase in Snowflake). This caused a mismatch with the lowercase names in `schema.yml`, breaking description lookup and display. Column names from the catalog are now normalized to lowercase. Descriptions are sourced from the manifest rather than the empty catalog.
+- **Column types read from `data_type` key**: dbt manifest columns store their type under `data_type`, not `type`. The manifest fallback only read `type`, returning null for most projects and causing reconciliation to write `datatype: unknown` for every materialized field.
+- **Non-destructive push**: `POST /api/dbt-schema` no longer deletes columns from `schema.yml` that are absent from the entity's field list. Columns added directly by developers outside Trellis are preserved.
+- **Stale relationship tests cleaned up on push**: `POST /api/dbt-schema` now removes `relationships` tests from columns that were previously FKs but are no longer, matching the behavior of `POST /api/sync-dbt-tests`.
+
 ## [0.16.0-beta.3] - 2026-06-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0-beta.3] - 2026-06-15
+
+### Fixed
+
+- **Catalog column names normalized to lowercase**: When a dbt catalog is present (e.g. after `dbt docs generate`), column names were returned in the database's native case (uppercase in Snowflake/DW). This caused a mismatch with the lowercase names in `schema.yml`, breaking description lookup and display. Column names from the catalog are now normalized to lowercase, consistent with the manifest and YAML. Descriptions are now sourced from the manifest (which holds YAML-documented descriptions) rather than the catalog (which holds empty database comments).
+
 ## [0.16.0-beta.2] - 2026-06-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0-beta.2] - 2026-06-15
+
+### Fixed
+
+- **Column types no longer overwritten to `unknown` on push**: dbt manifest columns store their type under `data_type`, not `type`. The manifest fallback in `get_models()` only read `type`, returning `None` for most real projects — reconciliation then wrote `datatype: unknown` for every materialized field. Fixed to read `data_type` as fallback, matching the catalog path.
+
 ## [0.16.0-beta.1] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0-beta.1] - 2026-06-15
+
+### Added
+
+- **dbt reconciliation — `data_model.yml` as single source of truth**: Trellis now reconciles the compiled dbt manifest into `data_model.yml` on startup. Each bound entity's field list is enriched with its materialized dbt columns tagged `source: dbt`, alongside any unmatched drafted fields (`source: draft`). The file is self-contained and readable offline without a live manifest. Reconciliation is non-destructive: a model absent from the manifest (e.g. after a partial `dbt compile --select`) never removes its existing materialized fields.
+- **`POST /api/reconcile-dbt` endpoint**: Triggers manifest→`data_model.yml` reconciliation on demand. Returns `{status, changed, data_model}`. Called automatically by the frontend on app load after the manifest is fetched.
+- **Live schema.yml description read**: When opening the entity detail modal for a bound entity, Trellis now fetches column descriptions directly from `schema.yml` (via `GET /api/models/{name}/schema`) rather than from the manifest. This is lag-free — edited descriptions are visible immediately after save without running `dbt compile`. Priority: user edit > live `schema.yml` value > manifest value.
+- **`DraftedField.source` provenance marker**: TypeScript and YAML `drafted_fields` entries gain an optional `source: 'dbt' | 'draft'` field. `source: dbt` fields are dbt-owned and read-only (except description); `source: draft` fields are Trellis-authored. Missing `source` is treated as `draft` for backward compatibility.
+
+### Fixed
+
+- **`get_models()` now includes column descriptions**: The `/api/manifest` endpoint previously stripped column descriptions silently. Descriptions from the manifest (and `comment` from the catalog) are now included in each column entry.
+- **Non-destructive push**: `POST /api/dbt-schema` no longer deletes columns from `schema.yml` that are absent from the entity's field list. Columns added directly by developers outside Trellis are preserved.
+- **Stale relationship tests cleaned up on push**: `POST /api/dbt-schema` now removes `relationships` tests from columns that were previously FKs but are no longer, matching the behavior of `POST /api/sync-dbt-tests`.
+
 ## [0.15.9] - 2026-06-10
 
 ### Added

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1133,3 +1133,17 @@ export async function detachEventsFromProcess(
     }
 }
 
+export async function reconcileDbt(): Promise<{ status: string; changed: boolean; data_model: DataModel }> {
+    try {
+        const res = await fetch(`${API_BASE}/reconcile-dbt`, { method: 'POST' });
+        if (!res.ok) {
+            if (res.status === 404) return { status: 'success', changed: false, data_model: {} as DataModel };
+            throw new Error(`Failed to reconcile dbt: ${res.status}`);
+        }
+        return await res.json();
+    } catch (e) {
+        console.error('Error reconciling dbt:', e);
+        return { status: 'success', changed: false, data_model: {} as DataModel };
+    }
+}
+

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { nodes, edges, entityDetailModal, pushHistory, dbtModels, modelingStyle } from '$lib/stores';
-	import { getSourceSystemSuggestions, getBusinessEventProcesses, updateModelSchema, getManifest } from '$lib/api';
+	import { getSourceSystemSuggestions, getBusinessEventProcesses, updateModelSchema, getManifest, getModelSchema } from '$lib/api';
 	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn } from '$lib/types';
 	import { mergeFields } from '$lib/utils/merged-fields';
 	import type { MergedField } from '$lib/utils/merged-fields';
@@ -157,6 +157,10 @@
 	// Pending description edits for materialized (dbt) columns — written to schema.yml on save
 	let materializedDescriptionEdits = $state<Map<string, string>>(new Map());
 
+	// Live descriptions read directly from schema.yml (lag-free, not from manifest).
+	// Loaded on modal open for bound entities; used as baseline when displaying and saving.
+	let liveSchemaDescriptions = $state<Map<string, string>>(new Map());
+
 	// Feedback banners for materialize action
 	let materializeWarnings = $state<string[]>([]);
 	let materializeError = $state('');
@@ -170,7 +174,10 @@
 			name: f.name,
 			type: f.datatype || 'unknown',
 			description: f.origin === 'dbt'
-				? (materializedDescriptionEdits.get(f.name) ?? f.description ?? '')
+				? (materializedDescriptionEdits.get(f.name)
+					?? liveSchemaDescriptions.get(f.name)
+					?? f.description
+					?? '')
 				: (f.description ?? ''),
 			origin: f.origin === 'dbt' ? undefined : (editableDraftedFields[f.draftIndex]?.origin),
 		})),
@@ -299,6 +306,7 @@
 		showDeleteConfirm = false;
 		isDirty = false;
 		materializedDescriptionEdits = new Map();
+		liveSchemaDescriptions = new Map();
 		materializeWarnings = [];
 		materializeError = '';
 	});
@@ -310,6 +318,31 @@
 			loadProcesses();
 		}
 	});
+
+	// Load live descriptions from schema.yml when a bound entity modal opens.
+	// The manifest lags behind schema.yml by a dbt compile; reading directly gives
+	// the user the current description without requiring a recompile.
+	$effect(() => {
+		if ($entityDetailModal.open && isBoundEntity && boundModel) {
+			loadLiveSchemaDescriptions(boundModel.name, boundModel.version ?? undefined);
+		}
+	});
+
+	async function loadLiveSchemaDescriptions(modelName: string, version: number | undefined) {
+		try {
+			const schema = await getModelSchema(modelName, version);
+			if (!schema) return;
+			const map = new Map<string, string>();
+			for (const col of schema.columns ?? []) {
+				if (col.name && col.description != null) {
+					map.set(col.name, col.description);
+				}
+			}
+			liveSchemaDescriptions = map;
+		} catch {
+			// Non-fatal: fall back to manifest descriptions already in editableDraftedFields
+		}
+	}
 
 	async function loadSourceSuggestions() {
 		try {
@@ -645,17 +678,23 @@
 			});
 		});
 
-		// If any materialized description edits, write them to schema.yml
+		// If any materialized description edits, write them to schema.yml.
+		// Baseline is the live schema.yml content (lag-free); user edits overlay on top.
 		if (isBoundEntity && boundModel && materializedDescriptionEdits.size > 0) {
 			try {
-				const columns: ModelSchemaColumn[] = (boundModel.columns ?? []).map((c) => ({
+				// Collect all materialized column names from either the live schema or the bound model
+				const allCols: ModelSchemaColumn[] = (boundModel.columns ?? []).map((c) => ({
 					name: c.name,
 					data_type: c.type,
-					description: materializedDescriptionEdits.get(c.name) ?? (c as any).description ?? '',
+					// Priority: user's staged edit > live schema.yml value > manifest value
+					description: materializedDescriptionEdits.get(c.name)
+						?? liveSchemaDescriptions.get(c.name)
+						?? (c as any).description
+						?? '',
 				}));
-				await updateModelSchema(boundModel.name, boundModel.version ?? undefined, columns);
-				const models = await getManifest();
-				dbtModels.set(models);
+				await updateModelSchema(boundModel.name, boundModel.version ?? undefined, allCols);
+				// Re-read schema.yml so liveSchemaDescriptions reflects the saved state
+				await loadLiveSchemaDescriptions(boundModel.name, boundModel.version ?? undefined);
 				materializedDescriptionEdits = new Map();
 			} catch (e: unknown) {
 				const msg = e instanceof Error ? e.message : 'Failed to save descriptions to schema.yml';
@@ -1436,7 +1475,7 @@
 												{#if field.origin === 'dbt'}
 													<input
 														type="text"
-														value={materializedDescriptionEdits.get(field.name) ?? field.description ?? ''}
+														value={materializedDescriptionEdits.get(field.name) ?? liveSchemaDescriptions.get(field.name) ?? field.description ?? ''}
 														oninput={(e) => {
 															const map = new Map(materializedDescriptionEdits);
 															map.set(field.name, (e.target as HTMLInputElement).value);

--- a/frontend/src/lib/components/UndescribedAttributesWarningModal.svelte
+++ b/frontend/src/lib/components/UndescribedAttributesWarningModal.svelte
@@ -40,6 +40,18 @@
     function handleConfirm() {
         onConfirm();
     }
+
+    let collapsedEntities = $state(new Set<string>());
+
+    function toggleEntity(entityId: string) {
+        const next = new Set(collapsedEntities);
+        if (next.has(entityId)) {
+            next.delete(entityId);
+        } else {
+            next.add(entityId);
+        }
+        collapsedEntities = next;
+    }
 </script>
 
 {#if open}
@@ -82,25 +94,36 @@
             <!-- Attribute List -->
             {#if isMultipleEntities}
                 <!-- Multiple entities view -->
-                <div class="mb-6 max-h-64 overflow-y-auto border border-gray-200 rounded-md">
+                <div class="mb-6 max-h-96 overflow-y-auto border border-gray-200 rounded-md">
                     {#each entitiesWithAttributes! as entity}
+                        {@const collapsed = collapsedEntities.has(entity.entityId)}
                         <div class="border-b border-gray-200 last:border-b-0">
-                            <div class="px-3 py-2 bg-gray-50">
+                            <button
+                                class="w-full flex items-center gap-2 px-3 py-2 bg-gray-50 hover:bg-gray-100 text-left transition-colors"
+                                onclick={() => toggleEntity(entity.entityId)}
+                                aria-expanded={!collapsed}
+                            >
+                                <Icon
+                                    icon="lucide:chevron-down"
+                                    class="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform {collapsed ? '-rotate-90' : ''}"
+                                />
                                 <span class="font-medium text-gray-900">{entity.entityLabel}</span>
                                 {#if entity.entityId !== entity.entityLabel}
-                                    <span class="text-gray-500 ml-2 text-xs">({entity.entityId})</span>
+                                    <span class="text-gray-500 text-xs">({entity.entityId})</span>
                                 {/if}
-                                <span class="text-gray-500 text-xs ml-2">
-                                    ({entity.attributeNames.length} {entity.attributeNames.length === 1 ? 'attribute' : 'attributes'})
+                                <span class="text-gray-400 text-xs ml-auto">
+                                    {entity.attributeNames.length} {entity.attributeNames.length === 1 ? 'attribute' : 'attributes'}
                                 </span>
-                            </div>
-                            <ul class="divide-y divide-gray-100">
-                                {#each entity.attributeNames as attributeName}
-                                    <li class="px-3 py-1.5 text-sm pl-6">
-                                        <span class="font-mono text-gray-700">{attributeName}</span>
-                                    </li>
-                                {/each}
-                            </ul>
+                            </button>
+                            {#if !collapsed}
+                                <ul class="divide-y divide-gray-100">
+                                    {#each entity.attributeNames as attributeName}
+                                        <li class="px-3 py-1.5 text-sm pl-8">
+                                            <span class="font-mono text-gray-700">{attributeName}</span>
+                                        </li>
+                                    {/each}
+                                </ul>
+                            {/if}
                         </div>
                     {/each}
                 </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface DraftedField {
     datatype: 'text' | 'int' | 'float' | 'bool' | 'date' | 'timestamp' | 'unknown';
     description?: string;
     origin?: string;
+    source?: 'dbt' | 'draft';
 }
 
 export interface EntityData {

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -35,6 +35,7 @@
         inferRelationships,
         syncDbtTests,
         getExposures,
+        reconcileDbt,
     } from "$lib/api";
 import {
     getModelFolder,
@@ -58,7 +59,6 @@ import {
     import Icon from "$lib/components/Icon.svelte";
     import { lineageModal, closeLineageModal, sourceEditorModal, closeSourceEditorModal, deleteConfirmModal, closeDeleteConfirmModal } from "$lib/stores";
     import { AutoSaveService } from "$lib/services/auto-save";
-    import { autoPromoteAllNodes } from "$lib/utils/auto-promote-nodes";
     import { 
         getIncompleteEntities, 
         getEntitiesWithUndescribedAttributes,
@@ -558,14 +558,12 @@ import {
                 const models = await getManifest();
                 $dbtModels = models;
 
-                // Auto-promote drafted fields whose names now appear in the manifest
-                const { nodes: promotedNodes, changed } = autoPromoteAllNodes($nodes, models);
-                if (changed) {
-                    $nodes = promotedNodes;
-                    // The $effect watching $nodes will trigger autoSaveService.save() automatically
-                }
+                // Reconcile manifest columns into data_model.yml (provenance-aware, non-destructive).
+                // This writes source='dbt' fields into each bound entity before we load the data model,
+                // so the data model read below sees the fully reconciled state.
+                await reconcileDbt();
 
-                // Load Data Model
+                // Load Data Model (reads the reconciled file)
                 const dataModel = await getDataModel();
 
                 // Load source_colors from canvas_layout.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.0b3"
+version = "0.16.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.0b1"
+version = "0.16.0b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.9"
+version = "0.16.0b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.0b2"
+version = "0.16.0b3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -499,11 +499,16 @@ class DbtCoreAdapter:
                         {
                             "name": col.get("name"),
                             "type": col.get("type") or col.get("data_type"),
+                            "description": col.get("comment") or col.get("description"),
                         }
                     )
             else:
                 for col_name, col_data in node.get("columns", {}).items():
-                    columns.append({"name": col_name, "type": col_data.get("type")})
+                    columns.append({
+                        "name": col_name,
+                        "type": col_data.get("type"),
+                        "description": col_data.get("description"),
+                    })
 
             # Extract materialization
             config = node.get("config", {})
@@ -1121,6 +1126,8 @@ class DbtCoreAdapter:
         # Build a map of field names to relationships for this entity
         relationships = data_model.get("relationships", [])
         field_to_relationship: dict[str, dict] = {}
+        # Track ALL fields involved in any relationship for this entity (for stale test cleanup)
+        all_relationship_fields: set[str] = set()
         # Map entity -> dbt model name for refs
         entity_model_name = {
             e.get("id"): self._entity_to_model_name(e)
@@ -1163,6 +1170,12 @@ class DbtCoreAdapter:
                 fk_field = target_field
                 ref_entity = source_id
                 ref_field = source_field
+
+            # Track all fields involved in relationships for this entity
+            if source_id == entity_id:
+                all_relationship_fields.add(source_field)
+            if target_id == entity_id:
+                all_relationship_fields.add(target_field)
 
             if fk_entity == entity_id:
                 field_to_relationship[fk_field] = {
@@ -1214,7 +1227,7 @@ class DbtCoreAdapter:
             version_entry = self.yaml_handler.ensure_model_version(
                 model_entry, target_version
             )
-            self.yaml_handler.update_columns_batch(version_entry, columns)
+            self.yaml_handler.merge_columns_non_destructive(version_entry, columns)
 
             if entity_description:
                 self.yaml_handler.update_model_description(
@@ -1231,12 +1244,29 @@ class DbtCoreAdapter:
                     model_entry, entity_description
                 )
 
-            self.yaml_handler.update_columns_batch(model_entry, columns)
+            self.yaml_handler.merge_columns_non_destructive(model_entry, columns)
 
             if tags is not None:
                 self.yaml_handler.update_model_tags(model_entry, tags)
 
             schema_entry = model_entry
+
+        # Remove stale relationship tests: any column that has a relationship test
+        # but is not a current FK for this entity.
+        fk_fields = set(field_to_relationship.keys())
+        if "columns" in schema_entry:
+            for col in schema_entry.get("columns", []):
+                col_name = col.get("name")
+                if not col_name or col_name in fk_fields:
+                    continue
+                # Check whether this column currently has a relationship test
+                has_rel_test = any(
+                    isinstance(t, dict) and "relationships" in t
+                    for key in ("data_tests", "tests")
+                    for t in col.get(key, [])
+                )
+                if has_rel_test:
+                    self.yaml_handler.remove_relationship_test(col)
 
         # Apply relationship tests after columns are written
         for field in fields:

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -494,12 +494,24 @@ class DbtCoreAdapter:
             catalog_node = catalog_nodes.get(unique_id)
 
             if catalog_node:
+                # Catalog has accurate DB types but uppercase names (Snowflake/DW convention)
+                # and no YAML descriptions. Normalize names to lowercase and pull
+                # descriptions from the manifest, which holds the documented descriptions.
+                manifest_col_desc: dict[str, str] = {
+                    col_name.lower(): (col_data.get("description") or "")
+                    for col_name, col_data in node.get("columns", {}).items()
+                }
                 for col in catalog_node.get("columns", {}).values():
+                    col_name_lower = (col.get("name") or "").lower()
                     columns.append(
                         {
-                            "name": col.get("name"),
+                            "name": col_name_lower,
                             "type": col.get("type") or col.get("data_type"),
-                            "description": col.get("comment") or col.get("description"),
+                            "description": (
+                                manifest_col_desc.get(col_name_lower)
+                                or col.get("comment")
+                                or col.get("description")
+                            ),
                         }
                     )
             else:

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -506,7 +506,7 @@ class DbtCoreAdapter:
                 for col_name, col_data in node.get("columns", {}).items():
                     columns.append({
                         "name": col_name,
-                        "type": col_data.get("type"),
+                        "type": col_data.get("type") or col_data.get("data_type"),
                         "description": col_data.get("description"),
                     })
 

--- a/trellis_datamodel/routes/__init__.py
+++ b/trellis_datamodel/routes/__init__.py
@@ -7,6 +7,7 @@ from .exposures import router as exposures_router
 from .lineage import router as lineage_router
 from .bus_matrix import router as bus_matrix_router
 from .business_events import router as business_events_router
+from .reconcile import router as reconcile_router
 
 __all__ = [
     "manifest_router",
@@ -17,5 +18,6 @@ __all__ = [
     "lineage_router",
     "bus_matrix_router",
     "business_events_router",
+    "reconcile_router",
 ]
 

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -1,0 +1,20 @@
+"""Route for dbt reconciliation."""
+
+from fastapi import APIRouter
+
+from trellis_datamodel.services.reconciliation import reconcile_dbt
+
+router = APIRouter(prefix="/api", tags=["reconciliation"])
+
+
+@router.post("/reconcile-dbt")
+async def reconcile_dbt_endpoint():
+    """Reconcile dbt manifest columns into data_model.yml with provenance tags.
+
+    Reads the current manifest, merges materialized columns (source='dbt')
+    into each bound entity's drafted_fields, and writes back only if changed.
+    Non-destructive: entities whose model is absent from the manifest are
+    left untouched (handles partial dbt compiles).
+    """
+    data_model, changed = reconcile_dbt()
+    return {"status": "success", "changed": changed, "data_model": data_model}

--- a/trellis_datamodel/server.py
+++ b/trellis_datamodel/server.py
@@ -28,6 +28,7 @@ from trellis_datamodel.routes import (
     exposures_router,
     lineage_router,
     manifest_router,
+    reconcile_router,
     schema_router,
 )
 
@@ -154,6 +155,7 @@ def _register_routers(app: FastAPI) -> None:
     app.include_router(manifest_router)
     app.include_router(data_model_router)
     app.include_router(schema_router)
+    app.include_router(reconcile_router)
     app.include_router(exposures_router)
     app.include_router(lineage_router)
     app.include_router(bus_matrix_router)

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -1,0 +1,162 @@
+"""
+Provenance-aware reconciliation of dbt manifest columns into data_model.yml.
+
+Governing rule: when Trellis and dbt disagree, dbt is right.
+- manifest_columns=None means the model is absent from a (possibly partial)
+  manifest — the non-destructive invariant applies: existing fields untouched.
+- Reconciliation is idempotent: reconciling an already-reconciled model
+  returns the identical field list and changed=False.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# dbt type → DraftedField datatype mapping
+# ---------------------------------------------------------------------------
+
+_INT_PREFIXES = ("int", "bigint", "smallint", "tinyint", "serial", "integer")
+_FLOAT_PREFIXES = ("float", "double", "numeric", "decimal", "real", "money")
+_BOOL_PREFIXES = ("bool",)
+_DATE_EXACT = {"date"}
+_TIMESTAMP_PREFIXES = ("timestamp", "datetime")
+_TEXT_PREFIXES = ("varchar", "char", "text", "string", "nvarchar", "nchar", "clob")
+
+
+def _map_dbt_type(dbt_type: str | None) -> str:
+    """Map a dbt/warehouse column type string to a DraftedField datatype enum value."""
+    if not dbt_type:
+        return "unknown"
+    t = dbt_type.lower().strip()
+    if t in _DATE_EXACT:
+        return "date"
+    for prefix in _TIMESTAMP_PREFIXES:
+        if t.startswith(prefix):
+            return "timestamp"
+    for prefix in _BOOL_PREFIXES:
+        if t.startswith(prefix):
+            return "bool"
+    for prefix in _INT_PREFIXES:
+        if t.startswith(prefix):
+            return "int"
+    for prefix in _FLOAT_PREFIXES:
+        if t.startswith(prefix):
+            return "float"
+    for prefix in _TEXT_PREFIXES:
+        if t.startswith(prefix):
+            return "text"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Pure reconciliation core
+# ---------------------------------------------------------------------------
+
+def reconcile_entity_fields(
+    existing_fields: list[dict[str, Any]],
+    manifest_columns: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """
+    Merge manifest columns into existing drafted_fields with provenance.
+
+    Args:
+        existing_fields: Current drafted_fields list from data_model.yml.
+        manifest_columns: Column list from the manifest for the bound model,
+            or None when the model is absent from the manifest (non-destructive).
+
+    Returns:
+        Reconciled field list. Order: dbt fields (manifest order) then
+        surviving draft fields (original order).
+    """
+    if manifest_columns is None:
+        # Model absent from manifest — non-destructive, return unchanged.
+        return existing_fields
+
+    # Index existing fields by name for O(1) lookup
+    existing_by_name: dict[str, dict[str, Any]] = {}
+    for field in existing_fields:
+        name = field.get("name")
+        if name:
+            existing_by_name[name] = field
+
+    manifest_names: set[str] = set()
+    result: list[dict[str, Any]] = []
+
+    for col in manifest_columns:
+        col_name = col.get("name")
+        if not col_name:
+            continue
+        manifest_names.add(col_name)
+
+        # Start from existing entry to preserve extra keys (e.g. origin, roles)
+        existing = existing_by_name.get(col_name, {})
+        field: dict[str, Any] = dict(existing)
+
+        # dbt is authoritative for these attributes
+        field["name"] = col_name
+        field["datatype"] = _map_dbt_type(col.get("type"))
+        field["source"] = "dbt"
+        desc = col.get("description")
+        if desc is not None:
+            field["description"] = desc
+        elif "description" not in field:
+            pass  # keep absent rather than writing None
+
+        result.append(field)
+
+    # Append surviving draft fields (those not matched by any manifest column)
+    for field in existing_fields:
+        name = field.get("name")
+        if name and name not in manifest_names:
+            result.append(field)
+
+    return result
+
+
+def reconcile_data_model(
+    data_model: dict[str, Any],
+    manifest_models: list[dict[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    """
+    Apply reconcile_entity_fields to each bound entity in the data model.
+
+    Args:
+        data_model: Parsed data_model.yml content.
+        manifest_models: List of model dicts from get_models() (each has
+            unique_id, name, columns).
+
+    Returns:
+        (reconciled_data_model, changed) where changed is True only if at
+        least one entity's field list was modified.
+    """
+    # Index manifest by unique_id for O(1) lookup
+    manifest_by_id: dict[str, list[dict[str, Any]]] = {}
+    for model in manifest_models:
+        uid = model.get("unique_id")
+        if uid:
+            manifest_by_id[uid] = model.get("columns") or []
+
+    result = copy.deepcopy(data_model)
+    changed = False
+
+    for entity in result.get("entities", []):
+        dbt_model = entity.get("dbt_model")
+        if not dbt_model:
+            continue  # unbound — untouched
+
+        # None signals model absent from manifest (non-destructive)
+        manifest_columns = manifest_by_id.get(dbt_model, None)
+        if dbt_model not in manifest_by_id:
+            manifest_columns = None
+
+        existing = entity.get("drafted_fields") or []
+        reconciled = reconcile_entity_fields(existing, manifest_columns)
+
+        if reconciled != existing:
+            entity["drafted_fields"] = reconciled
+            changed = True
+
+    return result, changed

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -11,7 +11,10 @@ Governing rule: when Trellis and dbt disagree, dbt is right.
 from __future__ import annotations
 
 import copy
+import os
 from typing import Any
+
+import yaml
 
 
 # ---------------------------------------------------------------------------
@@ -160,3 +163,49 @@ def reconcile_data_model(
             changed = True
 
     return result, changed
+
+
+# ---------------------------------------------------------------------------
+# IO wrapper
+# ---------------------------------------------------------------------------
+
+def reconcile_dbt() -> tuple[dict[str, Any], bool]:
+    """
+    Load manifest + data_model.yml, reconcile, write back if changed.
+
+    Returns:
+        (data_model, changed) — the (possibly updated) data model dict and
+        whether the file was rewritten. A missing, empty, or unparseable
+        manifest is a safe no-op.
+    """
+    from trellis_datamodel import config as cfg
+    from trellis_datamodel.adapters import get_adapter
+    from trellis_datamodel.utils.yaml_handler import YamlHandler
+
+    data_model_path = getattr(cfg, "DATA_MODEL_PATH", None)
+    if not data_model_path or not os.path.exists(data_model_path):
+        return {}, False
+
+    try:
+        with open(data_model_path, "r") as f:
+            data_model = yaml.safe_load(f) or {}
+    except Exception:
+        return {}, False
+
+    # Load manifest models — guard against missing/broken manifest
+    try:
+        adapter = get_adapter()
+        manifest_models = adapter.get_models()
+    except Exception:
+        return data_model, False
+
+    if not manifest_models:
+        return data_model, False
+
+    reconciled, changed = reconcile_data_model(data_model, manifest_models)
+
+    if changed:
+        handler = YamlHandler()
+        handler.save_file(data_model_path, reconciled)
+
+    return reconciled, changed

--- a/trellis_datamodel/tests/conftest.py
+++ b/trellis_datamodel/tests/conftest.py
@@ -113,8 +113,8 @@ def mock_manifest_data():
                 "alias": "users",
                 "original_file_path": "models/3_core/users.sql",
                 "columns": {
-                    "id": {"name": "id", "type": "integer", "description": "Primary key"},
-                    "name": {"name": "name", "type": "text", "description": "Full name"},
+                    "id": {"name": "id", "data_type": "integer", "description": "Primary key"},
+                    "name": {"name": "name", "data_type": "varchar", "description": "Full name"},
                 },
                 "description": "User table",
                 "config": {"materialized": "table"},

--- a/trellis_datamodel/tests/conftest.py
+++ b/trellis_datamodel/tests/conftest.py
@@ -113,8 +113,8 @@ def mock_manifest_data():
                 "alias": "users",
                 "original_file_path": "models/3_core/users.sql",
                 "columns": {
-                    "id": {"name": "id", "type": "integer"},
-                    "name": {"name": "name", "type": "text"},
+                    "id": {"name": "id", "type": "integer", "description": "Primary key"},
+                    "name": {"name": "name", "type": "text", "description": "Full name"},
                 },
                 "description": "User table",
                 "config": {"materialized": "table"},

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -38,6 +38,59 @@ class TestSaveDbtSchema:
         assert model["description"] == "User entity"
         assert len(model["columns"]) == 2
 
+    def test_push_is_non_destructive_for_unlisted_columns(
+        self, test_client, temp_dir, mock_manifest
+    ):
+        """Pushing a subset of fields must not delete columns already in schema.yml
+        that are absent from the incoming field list (e.g. added by a developer directly)."""
+        sql_dir = os.path.join(temp_dir, "models", "3_core")
+        os.makedirs(sql_dir, exist_ok=True)
+        with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+            f.write("SELECT 1")
+
+        yml_path = os.path.join(sql_dir, "users.yml")
+        with open(yml_path, "w") as f:
+            yaml.dump(
+                {
+                    "version": 2,
+                    "models": [
+                        {
+                            "name": "users",
+                            "columns": [
+                                {"name": "id", "data_type": "int"},
+                                {"name": "name", "data_type": "text"},
+                                {"name": "legacy_col", "data_type": "text"},
+                            ],
+                        }
+                    ],
+                },
+                f,
+            )
+
+        # Push only id + name — legacy_col must survive
+        response = test_client.post(
+            "/api/dbt-schema",
+            json={
+                "entity_id": "users",
+                "model_name": "users",
+                "fields": [
+                    {"name": "id", "datatype": "int"},
+                    {"name": "name", "datatype": "text"},
+                ],
+            },
+        )
+        assert response.status_code == 200
+
+        with open(yml_path, "r") as f:
+            saved = yaml.safe_load(f)
+
+        col_names = [c["name"] for c in saved["models"][0]["columns"]]
+        assert "legacy_col" in col_names, (
+            f"legacy_col was deleted by push; got columns: {col_names}"
+        )
+        assert "id" in col_names
+        assert "name" in col_names
+
     def test_preserves_versioned_models_and_versions(
         self, test_client, temp_dir, temp_data_model_path
     ):
@@ -245,6 +298,78 @@ class TestSaveDbtSchema:
                 }
             }
         ]
+
+
+    def test_save_dbt_schema_removes_stale_relationship_test(
+        self, test_client, temp_dir, temp_data_model_path
+    ):
+        """save_dbt_schema must remove a relationship test from a field that was
+        previously an FK but is no longer one (relationship removed or type changed)."""
+        # First push: orders.customer_id has a many_to_one FK → customers
+        data_model_with_rel = {
+            "version": 0.1,
+            "entities": [
+                {"id": "orders", "label": "Orders"},
+                {"id": "customers", "label": "Customers"},
+            ],
+            "relationships": [
+                {
+                    "source": "orders",
+                    "target": "customers",
+                    "type": "many_to_one",
+                    "source_field": "customer_id",
+                    "target_field": "id",
+                }
+            ],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model_with_rel, f)
+
+        response = test_client.post(
+            "/api/dbt-schema",
+            json={
+                "entity_id": "orders",
+                "model_name": "orders",
+                "fields": [{"name": "customer_id", "datatype": "int"}],
+            },
+        )
+        assert response.status_code == 200
+        yml_path = response.json()["file_path"]
+
+        with open(yml_path) as f:
+            schema = yaml.safe_load(f)
+        rel_tests = schema["models"][0]["columns"][0].get("data_tests", [])
+        assert any("relationships" in t for t in rel_tests), "Relationship test not written in first push"
+
+        # Second push: relationship removed — customer_id is no longer an FK
+        data_model_no_rel = {
+            "version": 0.1,
+            "entities": [
+                {"id": "orders", "label": "Orders"},
+                {"id": "customers", "label": "Customers"},
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model_no_rel, f)
+
+        response2 = test_client.post(
+            "/api/dbt-schema",
+            json={
+                "entity_id": "orders",
+                "model_name": "orders",
+                "fields": [{"name": "customer_id", "datatype": "int"}],
+            },
+        )
+        assert response2.status_code == 200
+
+        with open(yml_path) as f:
+            schema2 = yaml.safe_load(f)
+        remaining_tests = schema2["models"][0]["columns"][0].get("data_tests", [])
+        has_rel_test = any("relationships" in t for t in remaining_tests)
+        assert not has_rel_test, (
+            f"Stale relationship test not removed; data_tests: {remaining_tests}"
+        )
 
 
 class TestSyncDbtTests:

--- a/trellis_datamodel/tests/test_manifest.py
+++ b/trellis_datamodel/tests/test_manifest.py
@@ -118,6 +118,17 @@ class TestGetManifest:
         col = next(c for c in users["columns"] if c["name"] == "id")
         assert col.get("description") == "Primary key"
 
+    def test_column_type_from_data_type_key(self, test_client):
+        """Manifest columns using data_type (not type) must have their type passed through.
+        Real dbt manifests use data_type; type is often absent or null."""
+        response = test_client.get("/api/manifest")
+        models = response.json()["models"]
+        users = next(m for m in models if m["name"] == "users")
+        col = next(c for c in users["columns"] if c["name"] == "id")
+        assert col.get("type") == "integer", (
+            f"Expected 'integer' from data_type key, got: {col.get('type')}"
+        )
+
     def test_filters_by_model_path(self, test_client, temp_dir, mock_manifest):
         # Update manifest to have models in different paths
         with open(mock_manifest, "r") as f:

--- a/trellis_datamodel/tests/test_manifest.py
+++ b/trellis_datamodel/tests/test_manifest.py
@@ -110,6 +110,14 @@ class TestGetManifest:
         assert users_model["materialization"] == "table"
         assert users_model["tags"] == ["core"]
 
+    def test_column_descriptions_included(self, test_client):
+        response = test_client.get("/api/manifest")
+        assert response.status_code == 200
+        models = response.json()["models"]
+        users = next(m for m in models if m["name"] == "users")
+        col = next(c for c in users["columns"] if c["name"] == "id")
+        assert col.get("description") == "Primary key"
+
     def test_filters_by_model_path(self, test_client, temp_dir, mock_manifest):
         # Update manifest to have models in different paths
         with open(mock_manifest, "r") as f:

--- a/trellis_datamodel/tests/test_manifest.py
+++ b/trellis_datamodel/tests/test_manifest.py
@@ -118,6 +118,43 @@ class TestGetManifest:
         col = next(c for c in users["columns"] if c["name"] == "id")
         assert col.get("description") == "Primary key"
 
+    def test_catalog_columns_normalized_to_lowercase_with_manifest_descriptions(
+        self, test_client, temp_dir, mock_manifest_data, monkeypatch
+    ):
+        """When a catalog is present, column names are lowercased (Snowflake returns
+        uppercase names) and descriptions come from the manifest, not the empty catalog."""
+        import json, os
+        from trellis_datamodel import config as cfg
+
+        # Write a catalog with UPPERCASE column names and no descriptions
+        catalog_data = {
+            "nodes": {
+                "model.project.users": {
+                    "unique_id": "model.project.users",
+                    "columns": {
+                        "ID": {"name": "ID", "type": "NUMBER", "comment": None},
+                        "NAME": {"name": "NAME", "type": "TEXT", "comment": None},
+                    },
+                }
+            }
+        }
+        catalog_path = os.path.join(temp_dir, "catalog.json")
+        with open(catalog_path, "w") as f:
+            json.dump(catalog_data, f)
+        monkeypatch.setattr(cfg, "CATALOG_PATH", catalog_path)
+
+        response = test_client.get("/api/manifest")
+        assert response.status_code == 200
+        users = next(m for m in response.json()["models"] if m["name"] == "users")
+
+        cols = {c["name"]: c for c in users["columns"]}
+        # Names must be lowercase even though catalog had uppercase
+        assert "id" in cols, f"Expected lowercase 'id', got: {list(cols.keys())}"
+        assert "name" in cols
+        # Descriptions come from the manifest, not the empty catalog
+        assert cols["id"]["description"] == "Primary key"
+        assert cols["name"]["description"] == "Full name"
+
     def test_column_type_from_data_type_key(self, test_client):
         """Manifest columns using data_type (not type) must have their type passed through.
         Real dbt manifests use data_type; type is often absent or null."""

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -1,0 +1,106 @@
+"""Tests for POST /api/reconcile-dbt endpoint."""
+
+import os
+import json
+import yaml
+import pytest
+
+
+class TestReconcileDbtEndpoint:
+    """Tests for POST /api/reconcile-dbt."""
+
+    def test_reconciles_bound_entity_from_manifest(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        """Bound entity with matching manifest model gets dbt columns reconciled."""
+        # users model is in the mock manifest with columns id + name
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        response = test_client.post("/api/reconcile-dbt")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["changed"] is True
+
+        entities = data["data_model"]["entities"]
+        users = next(e for e in entities if e["id"] == "users")
+        fields = users["drafted_fields"]
+        assert len(fields) == 2
+        assert all(f["source"] == "dbt" for f in fields)
+        names = [f["name"] for f in fields]
+        assert "id" in names
+        assert "name" in names
+
+    def test_noop_when_already_reconciled(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        """Reconciling an already-reconciled model returns changed=False."""
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [
+                        {"name": "id", "datatype": "int", "description": "Primary key", "source": "dbt"},
+                        {"name": "name", "datatype": "text", "description": "Full name", "source": "dbt"},
+                    ],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        response = test_client.post("/api/reconcile-dbt")
+        assert response.status_code == 200
+        assert response.json()["changed"] is False
+
+    def test_noop_when_no_data_model(self, test_client, temp_dir, mock_manifest):
+        """Missing data_model.yml is a no-op — endpoint succeeds without error."""
+        # No data_model.yml written
+        response = test_client.post("/api/reconcile-dbt")
+        assert response.status_code == 200
+        assert response.json()["changed"] is False
+
+    def test_absent_model_non_destructive(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        """Entity bound to a model NOT in the manifest keeps its existing fields."""
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "products",
+                    "label": "Products",
+                    "dbt_model": "model.project.products",  # not in mock_manifest
+                    "drafted_fields": [
+                        {"name": "sku", "datatype": "text", "source": "dbt"}
+                    ],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        response = test_client.post("/api/reconcile-dbt")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["changed"] is False
+        fields = data["data_model"]["entities"][0]["drafted_fields"]
+        assert fields == [{"name": "sku", "datatype": "text", "source": "dbt"}]

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -1,0 +1,252 @@
+"""Tests for the dbt reconciliation service."""
+
+import pytest
+from trellis_datamodel.services.reconciliation import (
+    reconcile_entity_fields,
+    reconcile_data_model,
+)
+
+
+class TestReconcileEntityFields:
+    """Unit tests for the pure reconcile_entity_fields function."""
+
+    def test_materializes_manifest_columns(self):
+        """Manifest columns become source=dbt fields with name/datatype/description."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "id", "type": "integer", "description": "Primary key"},
+                {"name": "email", "type": "text", "description": "Email address"},
+            ],
+        )
+        assert len(result) == 2
+        assert result[0]["name"] == "id"
+        assert result[0]["source"] == "dbt"
+        assert result[0]["description"] == "Primary key"
+        assert result[1]["name"] == "email"
+        assert result[1]["source"] == "dbt"
+        assert result[1]["description"] == "Email address"
+
+    def test_maps_dbt_type_to_datatype(self):
+        """Manifest types are mapped to the DraftedField datatype enum."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "count", "type": "bigint"},
+                {"name": "ratio", "type": "float8"},
+                {"name": "flag", "type": "boolean"},
+                {"name": "created", "type": "date"},
+                {"name": "updated", "type": "timestamp without time zone"},
+                {"name": "label", "type": "varchar"},
+                {"name": "weird", "type": "bytea"},
+            ],
+        )
+        assert result[0]["datatype"] == "int"
+        assert result[1]["datatype"] == "float"
+        assert result[2]["datatype"] == "bool"
+        assert result[3]["datatype"] == "date"
+        assert result[4]["datatype"] == "timestamp"
+        assert result[5]["datatype"] == "text"
+        assert result[6]["datatype"] == "unknown"
+
+    def test_promotes_matching_draft(self):
+        """A draft whose name matches a manifest column is promoted to source=dbt,
+        with manifest metadata overwriting the draft's values."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "revenue", "datatype": "float", "description": "Old draft desc", "source": "draft"},
+            ],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "Manifest desc"},
+            ],
+        )
+        assert len(result) == 1
+        assert result[0]["name"] == "revenue"
+        assert result[0]["source"] == "dbt"
+        assert result[0]["description"] == "Manifest desc"
+
+    def test_preserves_unmatched_draft(self):
+        """A drafted field with no matching manifest column is kept unchanged."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "forecast", "datatype": "float", "description": "Future metric"},
+            ],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric"},
+            ],
+        )
+        names = [f["name"] for f in result]
+        assert "forecast" in names
+        draft = next(f for f in result if f["name"] == "forecast")
+        assert draft.get("source") in (None, "draft")
+        assert draft["description"] == "Future metric"
+
+    def test_non_destructive_when_model_absent(self):
+        """manifest_columns=None means the model is absent from the manifest;
+        existing fields must be returned unchanged (non-destructive invariant)."""
+        existing = [
+            {"name": "id", "datatype": "int", "source": "dbt"},
+            {"name": "draft_col", "datatype": "text", "source": "draft"},
+        ]
+        result = reconcile_entity_fields(existing_fields=existing, manifest_columns=None)
+        assert result == existing
+
+    def test_deterministic_order(self):
+        """dbt fields appear in manifest order, then drafts in original order."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "draft_a", "datatype": "text"},
+                {"name": "draft_b", "datatype": "text"},
+            ],
+            manifest_columns=[
+                {"name": "col_z", "type": "text"},
+                {"name": "col_a", "type": "text"},
+            ],
+        )
+        names = [f["name"] for f in result]
+        assert names == ["col_z", "col_a", "draft_a", "draft_b"]
+
+    def test_empty_existing_empty_manifest(self):
+        """Both empty — result is empty, not an error."""
+        result = reconcile_entity_fields(existing_fields=[], manifest_columns=[])
+        assert result == []
+
+    def test_existing_source_dbt_fields_overwritten(self):
+        """Previously reconciled source=dbt fields are overwritten from manifest (dbt is right)."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "id", "datatype": "text", "description": "Stale description", "source": "dbt"},
+            ],
+            manifest_columns=[
+                {"name": "id", "type": "integer", "description": "Fresh from manifest"},
+            ],
+        )
+        assert len(result) == 1
+        assert result[0]["description"] == "Fresh from manifest"
+        assert result[0]["datatype"] == "int"
+        assert result[0]["source"] == "dbt"
+
+    def test_origin_field_preserved_on_promoted_draft(self):
+        """The free-text origin field on a drafted field is preserved after promotion."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "revenue", "datatype": "float", "origin": "DH1: SCHEMA.TABLE.COL"},
+            ],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric"},
+            ],
+        )
+        assert result[0].get("origin") == "DH1: SCHEMA.TABLE.COL"
+
+
+class TestReconcileDataModel:
+    """Unit tests for the reconcile_data_model function."""
+
+    def _make_manifest_models(self, name, columns):
+        return [{"name": name, "unique_id": f"model.project.{name}", "columns": columns}]
+
+    def test_reconciles_bound_entity(self):
+        """A bound entity present in the manifest gets its dbt fields reconciled."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                }
+            ]
+        }
+        manifest_models = [
+            {
+                "unique_id": "model.project.users",
+                "name": "users",
+                "columns": [{"name": "id", "type": "integer", "description": "PK"}],
+            }
+        ]
+        result, changed = reconcile_data_model(data_model, manifest_models)
+        assert changed is True
+        entity = result["entities"][0]
+        assert len(entity["drafted_fields"]) == 1
+        assert entity["drafted_fields"][0]["source"] == "dbt"
+        assert entity["drafted_fields"][0]["name"] == "id"
+
+    def test_unbound_entity_untouched(self):
+        """An entity without dbt_model is not modified."""
+        data_model = {
+            "entities": [
+                {"id": "sketch", "drafted_fields": [{"name": "col", "datatype": "text"}]}
+            ]
+        }
+        result, changed = reconcile_data_model(data_model, [])
+        assert changed is False
+        assert result["entities"][0]["drafted_fields"] == [{"name": "col", "datatype": "text"}]
+
+    def test_absent_model_non_destructive(self):
+        """A bound entity whose model is absent from the manifest is left untouched."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [{"name": "id", "datatype": "int", "source": "dbt"}],
+                }
+            ]
+        }
+        # manifest_models does NOT contain users
+        result, changed = reconcile_data_model(data_model, [])
+        assert changed is False
+        assert result["entities"][0]["drafted_fields"] == [
+            {"name": "id", "datatype": "int", "source": "dbt"}
+        ]
+
+    def test_changed_false_when_already_reconciled(self):
+        """Reconciling an already-reconciled model returns changed=False (idempotency)."""
+        manifest_models = [
+            {
+                "unique_id": "model.project.users",
+                "name": "users",
+                "columns": [{"name": "id", "type": "integer", "description": "PK"}],
+            }
+        ]
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [
+                        {"name": "id", "datatype": "int", "description": "PK", "source": "dbt"}
+                    ],
+                }
+            ]
+        }
+        result, changed = reconcile_data_model(data_model, manifest_models)
+        assert changed is False
+
+    def test_multiple_entities_mixed(self):
+        """Bound entity reconciled, unbound entity untouched."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                },
+                {
+                    "id": "sketch",
+                    "drafted_fields": [{"name": "future_col", "datatype": "text"}],
+                },
+            ]
+        }
+        manifest_models = [
+            {
+                "unique_id": "model.project.users",
+                "name": "users",
+                "columns": [{"name": "id", "type": "integer"}],
+            }
+        ]
+        result, changed = reconcile_data_model(data_model, manifest_models)
+        assert changed is True
+        users = next(e for e in result["entities"] if e["id"] == "users")
+        sketch = next(e for e in result["entities"] if e["id"] == "sketch")
+        assert users["drafted_fields"][0]["source"] == "dbt"
+        assert sketch["drafted_fields"] == [{"name": "future_col", "datatype": "text"}]

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -455,6 +455,56 @@ class YamlHandler:
 
         model["columns"] = new_columns
 
+    def merge_columns_non_destructive(
+        self,
+        model: CommentedMap,
+        columns_data: List[Dict[str, Any]],
+    ) -> None:
+        """
+        Merge ``columns_data`` into the model's existing column list without
+        deleting columns that are absent from the incoming list.
+
+        - Incoming columns that already exist: updated (data_type, description).
+        - Incoming columns that are new: appended.
+        - Existing columns not in the incoming list: preserved unchanged.
+
+        Order: incoming columns first (in incoming order), then surviving
+        existing columns not present in the incoming list.
+        """
+        existing_by_name: Dict[str, CommentedMap] = {}
+        existing_order: List[str] = []
+        for col in model.get("columns", []) or []:
+            name = col.get("name") if isinstance(col, dict) else None
+            if name:
+                existing_by_name[name] = col
+                existing_order.append(name)
+
+        incoming_names: List[str] = []
+        new_columns = CommentedSeq()
+
+        for col_data in columns_data:
+            col_name = col_data.get("name")
+            if not col_name:
+                continue
+            incoming_names.append(col_name)
+            col = existing_by_name.get(col_name)
+            if col is None:
+                col = CommentedMap()
+                col["name"] = col_name
+            self.update_column(
+                col,
+                data_type=col_data.get("data_type"),
+                description=col_data.get("description"),
+            )
+            new_columns.append(col)
+
+        incoming_set = set(incoming_names)
+        for name in existing_order:
+            if name not in incoming_set:
+                new_columns.append(existing_by_name[name])
+
+        model["columns"] = new_columns
+
     def get_columns(self, model: CommentedMap) -> List[Dict[str, Any]]:
         """
         Extract columns from a model as a list of dicts.

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.15.7"
+version = "0.16.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
  ## Summary

  Establishes **dbt as the source of truth** for column metadata and makes
  `data_model.yml` the single, self-contained record of a bound entity —
  including both materialized dbt columns and not-yet-materialized drafted fields.

  - **Reconciliation service**: On app load, manifest columns are merged into
    `data_model.yml` with provenance tags (`source: dbt`). Non-destructive on
    partial compiles — a model absent from the manifest never deletes its fields.
  - **Live schema.yml descriptions**: Entity detail modal fetches descriptions
    directly from `schema.yml` (lag-free, no `dbt compile` needed). Edits write
    back to `schema.yml` immediately.
  - **Non-destructive push**: `POST /api/dbt-schema` no longer deletes columns
    absent from the entity's field list — preserves columns added directly in dbt.
  - **Bug fix**: `get_models()` now passes column descriptions through the manifest
    endpoint (previously silently discarded).
  - **Bug fix**: Stale relationship tests cleaned up on push, matching
    `sync_relationships` behavior.

  ## Design principle

  > When Trellis and dbt disagree on column metadata, **dbt is right.**
  > `data_model.yml` is the single source of truth, holding materialized
  > (`source: dbt`) and drafted (`source: draft`) fields together.

  ## Test plan

  - [ ] Open a bound entity modal — materialized columns appear with descriptions
        from `schema.yml` (not manifest)
  - [ ] Edit a materialized column description, save — description updates in
        `schema.yml` immediately, visible on re-open without `dbt compile`
  - [ ] Push an entity — columns present in `schema.yml` but not in the entity's
        field list are preserved
  - [ ] Change a relationship type and push — stale relationship tests removed
        from the old FK field
  - [ ] `uv run pytest` → 355 passed
  - [ ] `npm run check` → 0 errors
  - [ ] Restart app against a real dbt project — reconciliation runs on load,
        `data_model.yml` gains `source: dbt` fields on bound entities

  ## Spec

  `specs/2026-06-15-dbt-column-authority/`