### PR TITLE
feat(canvas): sidebar search filters canvas entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-06-15
+
+### Added
+
+- **Sidebar search now filters the canvas**: Typing in the Explorer search box hides all canvas entities whose label does not match, giving a focused view on crowded canvases with many entities. Clearing the search restores all entities. URL-based business event filters continue to take priority over the sidebar search. The event-filter banner is not shown for search-based filtering.
+
 ## [0.15.9] - 2026-06-10
 
 ### Added

--- a/frontend/src/lib/components/Canvas.svelte
+++ b/frontend/src/lib/components/Canvas.svelte
@@ -78,7 +78,7 @@
     // Entity filtering logic
     // Filter nodes to show only entities with IDs in filteredEntityIds
     const filteredNodes = $derived(() => {
-        if (!filteredEntityIds || filteredEntityIds.length === 0) {
+        if (!filteredEntityIds) {
             return $nodes;
         }
 
@@ -129,7 +129,7 @@
 
     // Filter edges to only show connections between filtered entities
     const displayEdges = $derived(() => {
-        if (!filteredEntityIds || filteredEntityIds.length === 0) {
+        if (!filteredEntityIds) {
             return $edges;
         }
 
@@ -152,7 +152,7 @@
 
     // Calculate filtered entity count (exclude group nodes)
     const filteredEntityCount = $derived(() => {
-        if (!filteredEntityIds || filteredEntityIds.length === 0) {
+        if (!filteredEntityIds) {
             return 0;
         }
         return displayNodes.filter(node => node.type === 'entity').length;

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -10,6 +10,7 @@
         factPrefixes,
         entityTypeFilter,
         modelBoundFilter,
+        sidebarSearchTerm,
     } from "$lib/stores";
     import type { DbtModel, TreeNode, EntityData } from "$lib/types";
     import { getModelFolder, normalizeTags, classifyModelTypeFromPrefixes } from "$lib/utils";
@@ -23,6 +24,8 @@
 
     let searchTerm = $state("");
     let collapsed = $state(false);
+
+    $effect(() => { sidebarSearchTerm.set(searchTerm); });
 
     function inferModelVersion(model: DbtModel): number | null {
         if (model.version !== undefined && model.version !== null) {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -71,6 +71,9 @@ export const entityListCollapseState = writable<Record<string, boolean>>({});
 // Drag-and-drop state for field linking
 export const draggingField = writable<FieldDragState | null>(null);
 
+// Sidebar search term — synced to canvas for entity filtering
+export const sidebarSearchTerm = writable<string>('');
+
 // Global modals (rendered outside SvelteFlow to avoid viewport transform affecting position:fixed)
 export const lineageModal = writable<{ open: boolean; modelId: string | null }>({
     open: false,

--- a/frontend/src/routes/(app)/canvas/+page.svelte
+++ b/frontend/src/routes/(app)/canvas/+page.svelte
@@ -2,7 +2,7 @@
     import { getContext } from 'svelte';
     import { readable, type Readable } from 'svelte/store';
     import { page } from '$app/stores';
-    import { viewMode, nodes, edges } from '$lib/stores';
+    import { viewMode, nodes, edges, sidebarSearchTerm } from '$lib/stores';
     import Canvas from '$lib/components/Canvas.svelte';
     import type { GuidanceConfig } from '$lib/types';
 
@@ -36,9 +36,15 @@
     const entitiesParam = $derived($page.url.searchParams.get('entities'));
     const eventTextParam = $derived($page.url.searchParams.get('eventText'));
 
-    // Parse comma-separated entity IDs from URL parameter
+    // Parse comma-separated entity IDs from URL parameter, or filter by sidebar search term
     const filteredEntityIds = $derived(
-        entitiesParam ? entitiesParam.split(',').filter(id => id.trim()) : null
+        entitiesParam
+            ? entitiesParam.split(',').filter(id => id.trim())
+            : $sidebarSearchTerm.trim()
+                ? $nodes
+                    .filter(n => n.type === 'entity' && (n.data as any)?.label?.toLowerCase().includes($sidebarSearchTerm.trim().toLowerCase()))
+                    .map(n => n.id)
+                : null
     );
 
     // Pass event text for banner display

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.15.9"
+version = "0.16.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
  ## Summary

  - Typing in the Explorer search box now hides canvas entities whose label
    does not match, giving a focused view on crowded canvases with many entities
  - Clearing the search restores all entities immediately
  - URL-based business event filters take priority over sidebar search
  - The event-filter banner is not shown for search-based filtering

  ## Implementation

  | File | Change |
  |---|---|
  | `stores.ts` | Added `sidebarSearchTerm` writable store |
  | `Sidebar.svelte` | `$effect` syncs `searchTerm` → store on every keystroke |
  | `Canvas.svelte` | Removed `|| filteredEntityIds.length === 0` early-return — empty array now correctly hides all nodes |
  | `canvas/+page.svelte` | `filteredEntityIds` falls back to sidebar search when no URL filter is active |

  ## Test plan

  - [ ] Type partial entity name in sidebar → only matching entities visible on canvas
  - [ ] Clear search → all entities restored
  - [ ] Business event link → URL filter still takes priority
  - [ ] Search with no matches → canvas is empty, not showing all