### PR TITLE
fix: parse origin from description when reading schema.yml and manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-06-24
+- Add parsing of "Origin" values from the dbt column description
+
 ## [0.16.1] - 2026-06-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.2b1"
+version = "0.16.2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.2-beta.1"
+version = "0.16.2b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.1"
+version = "0.16.2-beta.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -28,6 +28,37 @@ _DATE_EXACT = {"date"}
 _TIMESTAMP_PREFIXES = ("timestamp", "datetime")
 _TEXT_PREFIXES = ("varchar", "char", "text", "string", "nvarchar", "nchar", "clob")
 
+_ORIGIN_SEPARATOR = " | Origin: "
+_ORIGIN_PREFIX = "Origin: "
+
+
+def _parse_description_with_origin(
+    raw_description: str | None,
+) -> tuple[str | None, str | None]:
+    """Split a description into (description, origin).
+
+    The write paths embed origin into the description as:
+      - "desc | Origin: value"  (both present)
+      - "Origin: value"         (only origin, no description)
+
+    This reverses that encoding so origin round-trips through a
+    dedicated field.
+    """
+    if not raw_description:
+        return raw_description, None
+
+    sep_idx = raw_description.find(_ORIGIN_SEPARATOR)
+    if sep_idx != -1:
+        desc = raw_description[:sep_idx]
+        origin = raw_description[sep_idx + len(_ORIGIN_SEPARATOR) :]
+        return (desc or None), (origin or None)
+
+    if raw_description.startswith(_ORIGIN_PREFIX):
+        origin = raw_description[len(_ORIGIN_PREFIX) :]
+        return None, (origin or None)
+
+    return raw_description, None
+
 
 def _map_dbt_type(dbt_type: str | None) -> str:
     """Map a dbt/warehouse column type string to a DraftedField datatype enum value."""
@@ -104,7 +135,14 @@ def reconcile_entity_fields(
         field["source"] = "dbt"
         desc = col.get("description")
         if desc is not None:
-            field["description"] = desc
+            # Parse origin from description if embedded
+            parsed_desc, parsed_origin = _parse_description_with_origin(desc)
+            field["description"] = parsed_desc
+            if parsed_origin is not None:
+                field["origin"] = parsed_origin
+            elif "origin" in field:
+                # Remove stale origin if description no longer contains it
+                del field["origin"]
         elif "description" not in field:
             pass  # keep absent rather than writing None
 

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -138,6 +138,41 @@ class TestReconcileEntityFields:
         )
         assert result[0].get("origin") == "DH1: SCHEMA.TABLE.COL"
 
+    def test_origin_parsed_from_manifest_description(self):
+        """Origin embedded in manifest description is parsed into separate field."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "Total revenue | Origin: DH1: SCHEMA.TABLE.COL"},
+            ],
+        )
+        assert result[0]["description"] == "Total revenue"
+        assert result[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_origin_only_parsed_from_manifest_description(self):
+        """Origin-only description (no preceding text) is parsed correctly."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "Origin: DH1: SCHEMA.TABLE.COL"},
+            ],
+        )
+        assert result[0]["description"] is None
+        assert result[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_stale_origin_removed_when_description_changes(self):
+        """If manifest description no longer contains origin, stale origin is removed."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "revenue", "datatype": "float", "description": "Old desc", "origin": "OLD_ORIGIN"},
+            ],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "New desc without origin"},
+            ],
+        )
+        assert result[0]["description"] == "New desc without origin"
+        assert "origin" not in result[0]
+
 
 class TestReconcileDataModel:
     """Unit tests for the reconcile_data_model function."""

--- a/trellis_datamodel/tests/test_yaml_handler.py
+++ b/trellis_datamodel/tests/test_yaml_handler.py
@@ -230,6 +230,57 @@ class TestYamlHandlerColumnOperations:
         assert len(cols) == 2
         assert cols[0]["name"] == "id"
         assert cols[0]["description"] == "Primary key"
+        assert "origin" not in cols[0]
+
+    def test_get_columns_parses_origin_from_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {
+                        "name": "revenue",
+                        "data_type": "float",
+                        "description": "Total revenue | Origin: DH1: SCHEMA.TABLE.COL",
+                    },
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] == "Total revenue"
+        assert cols[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_get_columns_parses_origin_only_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {
+                        "name": "revenue",
+                        "data_type": "float",
+                        "description": "Origin: DH1: SCHEMA.TABLE.COL",
+                    },
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] is None
+        assert cols[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_get_columns_no_origin_when_none_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {"name": "id", "data_type": "int"},
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] is None
+        assert "origin" not in cols[0]
 
 
 class TestYamlHandlerRelationshipTests:

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -505,6 +505,38 @@ class YamlHandler:
 
         model["columns"] = new_columns
 
+    _ORIGIN_SEPARATOR = " | Origin: "
+    _ORIGIN_PREFIX = "Origin: "
+
+    @staticmethod
+    def _parse_description_with_origin(
+        raw_description: str | None,
+    ) -> tuple[str | None, str | None]:
+        """Split a schema.yml description into (description, origin).
+
+        The write paths embed origin into the description as:
+          - "desc | Origin: value"  (both present)
+          - "Origin: value"         (only origin, no description)
+
+        This method reverses that encoding so the origin round-trips
+        through a dedicated field instead of staying glued to the
+        description.
+        """
+        if not raw_description:
+            return raw_description, None
+
+        sep_idx = raw_description.find(YamlHandler._ORIGIN_SEPARATOR)
+        if sep_idx != -1:
+            desc = raw_description[:sep_idx]
+            origin = raw_description[sep_idx + len(YamlHandler._ORIGIN_SEPARATOR) :]
+            return (desc or None), (origin or None)
+
+        if raw_description.startswith(YamlHandler._ORIGIN_PREFIX):
+            origin = raw_description[len(YamlHandler._ORIGIN_PREFIX) :]
+            return None, (origin or None)
+
+        return raw_description, None
+
     def get_columns(self, model: CommentedMap) -> List[Dict[str, Any]]:
         """
         Extract columns from a model as a list of dicts.
@@ -519,11 +551,16 @@ class YamlHandler:
         result = []
 
         for col in columns:
+            raw_description = col.get("description")
+            description, origin = self._parse_description_with_origin(raw_description)
+
             col_dict = {
                 "name": col.get("name"),
                 "data_type": col.get("data_type"),
-                "description": col.get("description"),
+                "description": description,
             }
+            if origin is not None:
+                col_dict["origin"] = origin
 
             # Extract tests (supports both dbt's tests and data_tests keys)
             collected_tests: list[dict[str, Any]] = []


### PR DESCRIPTION
## Problem
When an entity is written to schema.yml, the origin gets appended to the description as `"desc | Origin: value"`. On the next read, the origin was never parsed back out — the whole string stayed as the description and the origin field was lost.

This affected two read paths:
1. **schema.yml** via `yaml_handler.get_columns()`
2. **manifest.json** via `reconciliation.reconcile_entity_fields()` (after dbt compiles the schema.yml into the manifest)

## Fix
- Added `_parse_description_with_origin()` that reverses the encoding:
  - `"desc | Origin: value"` → `description="desc"`, `origin="value"`
  - `"Origin: value"` (no description) → `description=None`, `origin="value"`
  - Normal descriptions pass through unchanged
- Applied parsing in both read paths
- Stale origin is removed when description no longer contains it

## Tests
- 3 new tests in `test_yaml_handler.py` (schema.yml read path)
- 3 new tests in `test_reconciliation.py` (manifest read path)
- All 363 tests pass

## Version
Bumped to `0.16.2-beta.1` for beta testing.

Fixes #108