### PR TITLE
Feat/structured origin meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.0] - 2026-06-24
+## [0.17.0] - 2026-07-24
 
 ### Added
 - **Structured origin metadata**: Entity attribute `origin` is now a list of `{source_id: path}` objects in `data_model.yml`, written as `meta.origin` in dbt `schema.yml` on materialization, read back from manifest/meta (with `| Origin:` description fallback), and shown read-only in the EntityDetailModal. Legacy pipe-separated strings still load via silent migration.
+- **dbt origin icon in EntityDetailModal**: Rows whose origin comes from a materialized dbt model now show a dbt icon in the origin column, distinguishing them from manually entered origin values.
 
 ### Changed
 - **Origin exports**: Excel and Markdown exports stringify structured origin lists back to the legacy `KEY: VALUE | KEY: VALUE` format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-06-24
+
+### Added
+- **Structured origin metadata**: Entity attribute `origin` is now a list of `{source_id: path}` objects in `data_model.yml`, written as `meta.origin` in dbt `schema.yml` on materialization, read back from manifest/meta (with `| Origin:` description fallback), and shown read-only in the EntityDetailModal. Legacy pipe-separated strings still load via silent migration.
+
+### Changed
+- **Origin exports**: Excel and Markdown exports stringify structured origin lists back to the legacy `KEY: VALUE | KEY: VALUE` format.
+
 ## [0.16.2] - 2026-06-24
 - Add parsing of "Origin" values from the dbt column description
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2026-06-24
+- Add parsing of "Origin" values from the dbt column description
+
 ## [0.16.1] - 2026-06-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup backend frontend dev prod help build-package
+.PHONY: setup backend frontend dev prod help build-package sync-cursor-commands
 
 help:
 	@echo "Trellis Data Makefile"
@@ -16,29 +16,21 @@ help:
 	@echo "  make test-e2e      - Run E2E tests (auto-starts backend with test data)"
 	@echo "  make test-all      - Run all tests (check + smoke + unit + e2e)"
 	@echo "  make test-check    - Run TypeScript/compilation check"
+	@echo "  make sync-cursor-commands - Copy .ai_agent/commands into .cursor/commands for Cursor"
 	@echo "  make help          - Show this help message"
 
 install-uv:
 	@echo "Installing uv..."
 	pip install uv
 
-setup: install-uv setup-cursor-symlink
+setup: install-uv sync-cursor-commands
 	@echo "Installing backend dependencies..."
 	uv sync
 	@echo "Installing frontend dependencies..."
 	cd frontend && npm install
 
-setup-cursor-symlink:
-	@echo "Setting up .cursor directory with symlinks to .ai_agent commands..."
-	@if [ -L .cursor ]; then \
-		echo "Warning: .cursor is a symlink, converting to directory..."; \
-		rm .cursor; \
-	fi
-	@mkdir -p .cursor
-	@if [ ! -L .cursor/commands ]; then \
-		ln -sf ../.ai_agent/commands .cursor/commands && echo "Created .cursor/commands symlink"; \
-	fi
-	@echo ".cursor directory setup complete (mcp.json can be created here)"
+sync-cursor-commands:
+	@bash scripts/sync_cursor_commands.sh
 
 backend:
 	@echo "Starting backend server..."

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        /* Base URL to use in actions like `await page.goto('')`. */
-        baseURL: 'http://localhost:5173',
+        /* Dedicated dev port so E2E does not collide with a running `make frontend` on 5173. */
+        baseURL: 'http://localhost:5174',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
@@ -62,14 +62,13 @@ export default defineConfig({
             timeout: 30000,
         },
         {
-            // Frontend dev server
-            command: 'npm run dev',
+            // Frontend dev server on 5174 — avoids colliding with `make frontend` on 5173.
+            command: 'npm run dev -- --port 5174',
             env: {
-                // Point frontend Vite proxy to test backend API
                 VITE_DEV_API_TARGET: 'http://localhost:8000',
             },
-            url: 'http://localhost:5173',
-            reuseExistingServer: !process.env.CI,
+            url: 'http://localhost:5174',
+            reuseExistingServer: false,
         },
     ],
 });

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -2,7 +2,7 @@
 	import Icon from '@iconify/svelte';
 	import { nodes, edges, entityDetailModal, pushHistory, dbtModels, modelingStyle } from '$lib/stores';
 	import { getSourceSystemSuggestions, getBusinessEventProcesses, updateModelSchema, getManifest, getModelSchema } from '$lib/api';
-	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn } from '$lib/types';
+	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn, OriginEntry } from '$lib/types';
 	import { mergeFields } from '$lib/utils/merged-fields';
 	import type { MergedField } from '$lib/utils/merged-fields';
 	import type { Node } from '@xyflow/svelte';
@@ -179,7 +179,7 @@
 					?? f.description
 					?? '')
 				: (f.description ?? ''),
-			origin: f.origin === 'dbt' ? undefined : (editableDraftedFields[f.draftIndex]?.origin),
+			origin: f.originRefs,
 		})),
 	);
 
@@ -784,15 +784,12 @@
 	}
 
 
-	// Build legacy attributes shape from mergedFields for export helpers
-	function buildExportAttributes(): Array<{ name: string; type: string; description?: string; origin?: string }> {
+	function buildExportAttributes(): Array<{ name: string; type: string; description?: string; origin?: OriginEntry[] }> {
 		const attributes = mergedFields.map((f) => ({
 			name: f.name,
 			type: f.datatype ?? '',
 			description: f.description ?? '',
-			origin: f.origin === 'dbt'
-				? (boundModel?.unique_id ?? 'dbt')
-				: (editableDraftedFields[f.draftIndex]?.origin ?? ''),
+			origin: f.originRefs,
 		}));
 		return attributes;
 	}
@@ -1494,26 +1491,20 @@
 													/>
 													{/if}
 												</div>
-												<!-- Origin label -->
-												<div class="col-span-2 text-xs text-gray-400 font-mono truncate" title={field.origin === 'dbt' ? 'dbt model' : 'drafted'}>
-													{#if field.origin === 'dbt'}
-														<span
-															class="inline-flex items-center"
-															aria-label={`Materialized in dbt model '${boundModel?.name ?? ''}'`}
-															title={`Materialized in dbt model '${boundModel?.name ?? ''}'`}
-														>
-															<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 text-gray-400 opacity-70" aria-hidden="true" />
-														</span>
-													{:else}
-													<input
-														type="text"
-														value={editableDraftedFields[field.draftIndex]?.origin ?? ''}
-														oninput={(e) => updateDraftedField(field.draftIndex, { origin: (e.target as HTMLInputElement).value })}
-														class="w-full px-2 py-2 border border-gray-300 rounded-lg text-xs text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
-														placeholder="Origin"
-															aria-label={`Drafted in Trellis — not yet materialized in dbt. Use the materialize button in this row's Actions column to write into ${boundModel?.name ?? ''}'s schema.yml.`}
-															title={`Drafted in Trellis — not yet materialized in dbt. Use the materialize button in this row's Actions column to write into ${boundModel?.name ?? ''}'s schema.yml.`}
-														/>
+												<!-- Origin (read-only) -->
+												<div class="col-span-2 text-xs text-gray-600 font-mono space-y-0.5">
+													{#if field.originRefs?.length}
+														{#each field.originRefs as entry (JSON.stringify(entry))}
+															{#each Object.entries(entry) as [originKey, originValue]}
+																<div
+																	class="truncate"
+																	data-testid="origin-entry"
+																	title={originKey ? `${originKey}: ${originValue}` : originValue}
+																>
+																	{originKey ? `${originKey}: ${originValue}` : originValue}
+																</div>
+															{/each}
+														{/each}
 													{/if}
 												</div>
 										<!-- Actions -->

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1408,8 +1408,7 @@
 									<div class="col-span-2">Name</div>
 									<div class="col-span-1">Type</div>
 									<div class="col-span-6">Description</div>
-									<div class="col-span-2">Origin</div>
-									<div class="col-span-1"></div>
+									<div class="col-span-3">Origin</div>
 								</div>
 								<div class="divide-y divide-gray-200">
 								{#each mergedFields as field (field.origin === 'draft' ? `draft-${field.draftIndex}` : `dbt-${field.name}`)}
@@ -1492,7 +1491,7 @@
 													{/if}
 												</div>
 												<!-- Origin (read-only) -->
-												<div class="col-span-2 text-xs text-gray-600 font-mono space-y-0.5">
+												<div class={field.origin === 'dbt' ? "col-span-3 text-xs text-gray-600 font-mono space-y-0.5" : "col-span-2 text-xs text-gray-600 font-mono space-y-0.5"}>
 													{#if field.origin === 'dbt'}
 														<span
 															class="inline-flex items-center text-gray-400"
@@ -1517,8 +1516,8 @@
 													{/if}
 												</div>
 										<!-- Actions -->
-										<div class="col-span-1 flex justify-end gap-1 items-center">
-											{#if field.origin === 'draft'}
+										{#if field.origin === 'draft'}
+											<div class="col-span-1 flex justify-end gap-1 items-center">
 												{#if isBoundEntity && boundModel}
 														<button
 															type="button"
@@ -1538,8 +1537,8 @@
 													>
 														<Icon icon="lucide:trash-2" class="w-4 h-4" />
 													</button>
-												{/if}
 											</div>
+										{/if}
 										</div>
 										{#if field.origin === 'draft' && dropIndex === field.draftIndex && dropPosition !== null}
 											<DropIndicator position={dropPosition} />

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1493,6 +1493,15 @@
 												</div>
 												<!-- Origin (read-only) -->
 												<div class="col-span-2 text-xs text-gray-600 font-mono space-y-0.5">
+													{#if field.origin === 'dbt'}
+														<span
+															class="inline-flex items-center text-gray-400"
+															aria-label={`Materialized in dbt model '${boundModel?.name ?? ''}'`}
+															title={`Materialized in dbt model '${boundModel?.name ?? ''}'`}
+														>
+															<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+														</span>
+													{/if}
 													{#if field.originRefs?.length}
 														{#each field.originRefs as entry (JSON.stringify(entry))}
 															{#each Object.entries(entry) as [originKey, originValue]}

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -145,6 +145,13 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
     expect(materializeButtons).toHaveLength(1);
   });
 
+  it('shows dbt icon on materialized rows in the origin column', async () => {
+    setupBoundEntityWithDraft();
+    await renderModal();
+    const materializedIndicators = screen.getAllByLabelText(/Materialized in dbt model/i);
+    expect(materializedIndicators).toHaveLength(2);
+  });
+
   it('shows read-only origin lines for draft rows without an origin input', async () => {
     setupBoundEntityWithDraftOrigin();
     await renderModal();

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -52,7 +52,10 @@ function setupUnboundEntityWithDraftOrigin() {
         name: 'appointment_id',
         datatype: 'text',
         description: 'Unique identifier',
-        origin: 'DH1: CORE.T_DYN_APPOINTMENT.ACTIVITYID | DH2: CBUS_APPOINTMENT.APPOINTMENT_AID',
+        origin: [
+          { DH1: 'CORE.T_DYN_APPOINTMENT.ACTIVITYID' },
+          { DH2: 'CBUS_APPOINTMENT.APPOINTMENT_AID' },
+        ],
       }],
     } as any,
   }] as any);
@@ -73,7 +76,7 @@ function setupBoundEntityWithDraftOrigin() {
         name: 'extra_col',
         datatype: 'text',
         description: 'Draft column',
-        origin: 'LINEAGE:user_defined',
+        origin: [{ LINEAGE: 'user_defined' }],
       }],
     } as any,
   }] as any);
@@ -110,10 +113,10 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
   it('renders 3 rows for 2 dbt columns + 1 draft on a bound entity', async () => {
     setupBoundEntityWithDraft();
     await renderModal();
-    const materializedIndicators = screen.getAllByLabelText(/Materialized in dbt model/i);
-    expect(materializedIndicators).toHaveLength(2);
-    const draftIndicators = screen.getAllByLabelText(/Drafted in Trellis/i);
-    expect(draftIndicators).toHaveLength(1);
+    expect(screen.getAllByPlaceholderText('attribute_name')).toHaveLength(3);
+    expect(screen.getByTestId('merged-field-row-id')).toBeInTheDocument();
+    expect(screen.getByTestId('merged-field-row-created_at')).toBeInTheDocument();
+    expect(screen.getByTestId('merged-field-row-pending_col')).toBeInTheDocument();
   });
 
   it('shows Add Attribute button for bound entities', async () => {
@@ -142,10 +145,11 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
     expect(materializeButtons).toHaveLength(1);
   });
 
-  it('shows editable origin input for draft rows', async () => {
-    setupBoundEntityWithDraft();
+  it('shows read-only origin lines for draft rows without an origin input', async () => {
+    setupBoundEntityWithDraftOrigin();
     await renderModal();
-    expect(screen.getByPlaceholderText('Origin')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Origin')).not.toBeInTheDocument();
+    expect(screen.getByText('LINEAGE: user_defined')).toBeInTheDocument();
   });
 
   it('Copy as Markdown: unbound entity copies title, drafted origins, and relationships placeholder', async () => {
@@ -180,9 +184,9 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
       expect(navigator.clipboard.writeText).toHaveBeenCalled();
       const markdown = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(markdown).toContain('# Mixed Entity');
-      expect(markdown).toContain('| id | int |  | model.proj.entity_x |');
-      expect(markdown).toContain('| created_at | timestamp |  | model.proj.entity_x |');
-      expect(markdown).toContain('| extra_col | text | Draft column | LINEAGE:user_defined |');
+      expect(markdown).toContain('| id | int |  |  |');
+      expect(markdown).toContain('| created_at | timestamp |  |  |');
+      expect(markdown).toContain('| extra_col | text | Draft column | LINEAGE: user_defined |');
     });
   });
 

--- a/frontend/src/lib/types.test.ts
+++ b/frontend/src/lib/types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { OriginEntry, DbtColumn, DraftedField } from './types';
+
+describe('origin types', () => {
+	it('OriginEntry is a single-key record', () => {
+		expectTypeOf<OriginEntry>().toEqualTypeOf<Record<string, string>>();
+	});
+
+	it('DbtColumn accepts structured origin', () => {
+		expectTypeOf<DbtColumn['origin']>().toEqualTypeOf<OriginEntry[] | undefined>();
+	});
+
+	it('DraftedField origin is a structured list', () => {
+		const field: DraftedField = {
+			name: 'amount',
+			datatype: 'float',
+			origin: [{ DH1: 'CORE.A' }],
+		};
+		expectTypeOf(field.origin).toEqualTypeOf<OriginEntry[] | undefined>();
+	});
+});

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,7 +1,10 @@
+export type OriginEntry = Record<string, string>;
+
 export interface DbtColumn {
     name: string;
     type: string;
     description?: string;
+    origin?: OriginEntry[];
 }
 
 export interface DbtModel {
@@ -41,7 +44,7 @@ export interface DraftedField {
     name: string;
     datatype: 'text' | 'int' | 'float' | 'bool' | 'date' | 'timestamp' | 'unknown';
     description?: string;
-    origin?: string;
+    origin?: OriginEntry[];
     source?: 'dbt' | 'draft';
 }
 

--- a/frontend/src/lib/utils/excel-export.test.ts
+++ b/frontend/src/lib/utils/excel-export.test.ts
@@ -220,7 +220,7 @@ describe('Sheet Generators', () => {
 
     it('should include origin value when populated', () => {
       const attributes = [
-        { name: 'campaign_id', type: 'text', description: 'Unique identifier', origin: 'DH1: CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID' }
+        { name: 'campaign_id', type: 'text', description: 'Unique identifier', origin: [{ DH1: 'CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID' }] }
       ];
       const sheet = generateAttributesSheet(attributes);
       expect(sheet.data[1][3]).toBe('DH1: CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID');
@@ -232,6 +232,19 @@ describe('Sheet Generators', () => {
       ];
       const sheet = generateAttributesSheet(attributes);
       expect(sheet.data[1][3]).toBe('');
+    });
+
+    it('should stringify structured origin entries for the origin cell', () => {
+      const attributes = [
+        {
+          name: 'amount',
+          type: 'numeric',
+          description: 'Net sales',
+          origin: [{ DH1: 'CORE.A' }, { DH2: 'CBUS.B' }],
+        },
+      ];
+      const sheet = generateAttributesSheet(attributes);
+      expect(sheet.data[1][3]).toBe('DH1: CORE.A | DH2: CBUS.B');
     });
   });
 

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -1,6 +1,14 @@
 import * as XLSX from 'xlsx';
 import type { Node } from '@xyflow/svelte';
-import type { AnnotationType, EntityData } from '$lib/types';
+import type { AnnotationType, EntityData, OriginEntry } from '$lib/types';
+import { stringifyOrigin } from './origin';
+
+type ExportAttribute = {
+	name: string;
+	type: string;
+	description?: string;
+	origin?: OriginEntry[];
+};
 
 /**
  * Sanitizes a filename by removing or replacing special characters.
@@ -262,7 +270,7 @@ export function generateRelationshipsSheet(
  * @note Cell styling (bold headers) requires SheetJS Pro. Community Edition ignores the .s property.
  */
 export function generateAttributesSheet(
-	attributes: Array<{ name: string; type: string; description?: string; origin?: string }>
+	attributes: ExportAttribute[]
 ): XLSX.WorkSheet {
 	// Create 4-column array: Name | Type | Description | Origin
 	const attributesData = [
@@ -271,7 +279,7 @@ export function generateAttributesSheet(
 			attr.name,
 			attr.type,
 			attr.description || '',
-			attr.origin || ''
+			stringifyOrigin(attr.origin)
 		])
 	];
 
@@ -309,7 +317,7 @@ export function generateAttributesSheet(
  */
 export function exportEntityToExcel(
 	entity: EntityData,
-	attributes: Array<{ name: string; type: string; description?: string; origin?: string }>,
+	attributes: ExportAttribute[],
 	edges: any[],
 	allNodes: Node[],
 	entityId: string,
@@ -435,7 +443,7 @@ export function generateDataModelOverviewSheet(
 
 function draftedFieldsToAttributes(
 	entity: EntityData
-): Array<{ name: string; type: string; description?: string; origin?: string }> {
+): ExportAttribute[] {
 	const fields = entity.drafted_fields ?? [];
 	return fields.map((f) => ({
 		name: f.name,

--- a/frontend/src/lib/utils/markdown-export.test.ts
+++ b/frontend/src/lib/utils/markdown-export.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { formatEntityAsMarkdown } from './markdown-export';
-import type { EntityData } from '$lib/types';
+import type { EntityData, OriginEntry } from '$lib/types';
 import type { Node } from '@xyflow/svelte';
 
 describe('markdown-export utilities', () => {
 	let mockEntity: EntityData;
-	let mockAttributes: Array<{ name: string; type: string; description?: string; origin?: string }>;
+	let mockAttributes: Array<{ name: string; type: string; description?: string; origin?: OriginEntry[] }>;
 	let mockEdges: any[];
 	let mockNodes: Node[];
 
@@ -210,21 +210,26 @@ describe('markdown-export utilities', () => {
 			{
 				label: 'NIP status (DH1 | DH2 / alt)',
 				name: 'refund_status_code',
-				origin:
-					'DH1: DATA_MART_MAIN.T_DIM_NIP_STATUS.REFUND_STATUS | DH2: CBUS_CUSTOMER_REFUND_MASTER.REFUND_STATUS / CBUS_REFUND.REFUND_STATUS',
+				origin: [
+					{ DH1: 'DATA_MART_MAIN.T_DIM_NIP_STATUS.REFUND_STATUS' },
+					{ DH2: 'CBUS_CUSTOMER_REFUND_MASTER.REFUND_STATUS / CBUS_REFUND.REFUND_STATUS' },
+				],
 				expectEncoded: 'DH1: DATA_MART_MAIN.T_DIM_NIP_STATUS.REFUND_STATUS &#124; DH2:',
 			},
 			{
 				label: 'appointment (DH1 | DH2)',
 				name: 'activity_id',
-				origin: 'DH1: CORE.T_DYN_APPOINTMENT.ACTIVITYID | DH2: CBUS_APPOINTMENT.APPOINTMENT_AID',
+				origin: [
+					{ DH1: 'CORE.T_DYN_APPOINTMENT.ACTIVITYID' },
+					{ DH2: 'CBUS_APPOINTMENT.APPOINTMENT_AID' },
+				],
 				expectEncoded: 'DH1: CORE.T_DYN_APPOINTMENT.ACTIVITYID &#124; DH2: CBUS_APPOINTMENT.APPOINTMENT_AID',
 			},
 			{
 				label: 'minimal split',
 				name: 'x',
-				origin: 'A | B',
-				expectEncoded: 'A &#124; B',
+				origin: [{ A: 'B' }, { C: 'D' }],
+				expectEncoded: 'A: B &#124; C: D',
 			},
 		])(
 			'should encode pipes in origin without extra table columns ($label)',
@@ -244,7 +249,7 @@ describe('markdown-export utilities', () => {
 					name: 'x',
 					type: 'text',
 					description: 'Line1\nLine2',
-					origin: 'a\nb'
+					origin: [{ '': 'a\nb' }],
 				}
 			];
 			const result = formatEntityAsMarkdown(mockEntity, attributes, [], mockNodes, 'customer');
@@ -564,10 +569,25 @@ describe('markdown-export utilities', () => {
 
 		it('should render origin value in 4th column', () => {
 			const attributes = [
-				{ name: 'campaign_id', type: 'text', description: 'Unique ID', origin: 'DH1: CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID' }
+				{ name: 'campaign_id', type: 'text', description: 'Unique ID', origin: [{ DH1: 'CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID' }] }
 			];
 			const result = formatEntityAsMarkdown(mockEntity, attributes, [], mockNodes, 'customer');
 			expect(result).toContain('| campaign_id | text | Unique ID | DH1: CORE.V_DYN_CAMPAIGN_CUR.CAMPAIGNID |');
+		});
+
+		it('should stringify structured origin entries with pipe escaping', () => {
+			const attributes = [
+				{
+					name: 'amount',
+					type: 'numeric',
+					description: 'Net sales',
+					origin: [{ DH1: 'CORE.A' }, { DH2: 'CBUS.B' }],
+				},
+			];
+			const result = formatEntityAsMarkdown(mockEntity, attributes, [], mockNodes, 'customer');
+			const row = result.split('\n').find((line) => line.startsWith('| amount |'));
+			expect(row).toBeDefined();
+			expect(row).toContain('DH1: CORE.A &#124; DH2: CBUS.B');
 		});
 
 		it('should render empty string for undefined origin in 4th column', () => {

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -1,6 +1,7 @@
 import type { Node } from '@xyflow/svelte';
-import type { EntityData } from '$lib/types';
+import type { EntityData, OriginEntry } from '$lib/types';
 import { formatEntityType, formatAnnotationType, formatRelationshipType, formatRelationshipKeys } from './excel-export';
+import { stringifyOrigin } from './origin';
 
 /**
  * Prepares a value for a GFM pipe table cell: single-line text and no raw `|` characters.
@@ -27,7 +28,7 @@ function markdownTableCell(value: unknown): string {
  */
 export function formatEntityAsMarkdown(
 	entity: EntityData,
-	attributes: Array<{ name: string; type: string; description?: string; origin?: string }>,
+	attributes: Array<{ name: string; type: string; description?: string; origin?: OriginEntry[] }>,
 	edges: any[],
 	allNodes: Node[],
 	entityId: string,
@@ -66,7 +67,7 @@ export function formatEntityAsMarkdown(
 			const name = markdownTableCell(attr.name);
 			const type = markdownTableCell(attr.type);
 			const description = markdownTableCell(attr.description ?? '');
-			const origin = markdownTableCell(attr.origin ?? '');
+			const origin = markdownTableCell(stringifyOrigin(attr.origin));
 			lines.push(`| ${name} | ${type} | ${description} | ${origin} |`);
 		}
 	}

--- a/frontend/src/lib/utils/merged-fields.test.ts
+++ b/frontend/src/lib/utils/merged-fields.test.ts
@@ -92,4 +92,34 @@ describe('mergeFields', () => {
 		const result = mergeFields(undefined, drafted);
 		expect(result[0]).toMatchObject({ description: 'some field' });
 	});
+
+	it('passes originRefs from dbt columns with origin discriminant dbt', () => {
+		const dbtCols: DbtColumn[] = [
+			{ name: 'amount', type: 'numeric', origin: [{ DH1: 'CORE.A' }] },
+		];
+		const result = mergeFields(dbtCols, undefined);
+		expect(result[0]).toMatchObject({
+			origin: 'dbt',
+			originRefs: [{ DH1: 'CORE.A' }],
+		});
+	});
+
+	it('passes originRefs from drafted fields with origin discriminant draft', () => {
+		const drafted: DraftedField[] = [
+			{ name: 'amount', datatype: 'float', origin: [{ DH2: 'CBUS.B' }] },
+		];
+		const result = mergeFields(undefined, drafted);
+		expect(result[0]).toMatchObject({
+			origin: 'draft',
+			originRefs: [{ DH2: 'CBUS.B' }],
+		});
+	});
+
+	it('leaves originRefs undefined when no origin is present', () => {
+		const dbtCols: DbtColumn[] = [{ name: 'id', type: 'int' }];
+		const drafted: DraftedField[] = [{ name: 'extra', datatype: 'text' }];
+		const result = mergeFields(dbtCols, drafted);
+		expect(result[0].originRefs).toBeUndefined();
+		expect(result[1].originRefs).toBeUndefined();
+	});
 });

--- a/frontend/src/lib/utils/merged-fields.ts
+++ b/frontend/src/lib/utils/merged-fields.ts
@@ -1,12 +1,13 @@
-import type { DbtColumn, DraftedField } from '$lib/types';
+import type { DbtColumn, DraftedField, OriginEntry } from '$lib/types';
 
 export type MergedField =
-  | { origin: 'dbt'; name: string; datatype?: string; description?: string }
+  | { origin: 'dbt'; name: string; datatype?: string; description?: string; originRefs?: OriginEntry[] }
   | {
       origin: 'draft';
       name: string;
       datatype?: string;
       description?: string;
+      originRefs?: OriginEntry[];
       draftIndex: number;
     };
 
@@ -26,6 +27,7 @@ export function mergeFields(
     name: c.name,
     datatype: c.type,
     description: c.description,
+    originRefs: c.origin,
   }));
   const draftRows: MergedField[] = [];
   draftedList.forEach((d, i) => {
@@ -35,6 +37,7 @@ export function mergeFields(
       name: d.name,
       datatype: d.datatype,
       description: d.description,
+      originRefs: d.origin,
       draftIndex: i,
     });
   });

--- a/frontend/src/lib/utils/origin.test.ts
+++ b/frontend/src/lib/utils/origin.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { stringifyOrigin } from './origin';
+
+describe('stringifyOrigin', () => {
+	it('joins keyed entries with pipe separator', () => {
+		expect(stringifyOrigin([{ DH1: 'CORE.A' }, { DH2: 'CBUS.B' }])).toBe(
+			'DH1: CORE.A | DH2: CBUS.B'
+		);
+	});
+
+	it('renders empty key as value only', () => {
+		expect(stringifyOrigin([{ '': 'SAP.X' }])).toBe('SAP.X');
+	});
+
+	it('returns empty string for empty or undefined input', () => {
+		expect(stringifyOrigin([])).toBe('');
+		expect(stringifyOrigin(undefined)).toBe('');
+	});
+});

--- a/frontend/src/lib/utils/origin.ts
+++ b/frontend/src/lib/utils/origin.ts
@@ -1,0 +1,13 @@
+import type { OriginEntry } from '$lib/types';
+
+export function stringifyOrigin(entries?: OriginEntry[]): string {
+	if (!entries?.length) {
+		return '';
+	}
+
+	return entries
+		.flatMap((entry) =>
+			Object.entries(entry).map(([key, value]) => (key ? `${key}: ${value}` : value))
+		)
+		.join(' | ');
+}

--- a/frontend/tests/canvas_layout.yml
+++ b/frontend/tests/canvas_layout.yml
@@ -1,16 +1,9 @@
 version: 0.1
 entities:
-  origin_draft_e2e:
-    position:
-      x: 50
-      y: 50
-    width: 280
-    panel_height: 200
-    collapsed: false
   clean_customer_e2e:
     position:
       x: 50
-      y: 450
+      y: 50
     width: 280
     panel_height: 200
     collapsed: false

--- a/frontend/tests/canvas_layout.yml
+++ b/frontend/tests/canvas_layout.yml
@@ -1,4 +1,18 @@
 version: 0.1
-entities: {}
+entities:
+  origin_draft_e2e:
+    position:
+      x: 50
+      y: 50
+    width: 280
+    panel_height: 200
+    collapsed: false
+  clean_customer_e2e:
+    position:
+      x: 50
+      y: 450
+    width: 280
+    panel_height: 200
+    collapsed: false
 relationships: {}
 source_colors: {}

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -2,8 +2,8 @@ import type { APIRequestContext, Page } from '@playwright/test';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-// Playwright pages use the frontend baseURL (localhost:5173). Point API calls to the backend.
-const API_URL = process.env.VITE_PUBLIC_API_URL || 'http://localhost:8000/api';
+// Hit the Playwright test backend directly (same port as webServer below).
+const API_URL = 'http://127.0.0.1:8000/api';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..', '..');

--- a/frontend/tests/lineage.spec.ts
+++ b/frontend/tests/lineage.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { applyConfigOverrides, getCompanyDummyConfigOverrides, resetDataModel, restoreConfig, type DataModelPayload } from './helpers';
 
-const API_URL = process.env.VITE_PUBLIC_API_URL || 'http://localhost:8000/api';
+const API_URL = 'http://127.0.0.1:8000/api';
 
 test.describe.configure({ mode: 'serial' });
 

--- a/frontend/tests/merged-fields.spec.ts
+++ b/frontend/tests/merged-fields.spec.ts
@@ -82,7 +82,7 @@ test.describe('Merged dbt + drafted fields', () => {
 		await resetDataModel(request, payload);
 
 		await page.goto('/entity-list');
-		await page.waitForLoadState('networkidle');
+		await page.waitForSelector('[data-testid="app-ready"]', { timeout: 30000 });
 
 		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
 		await expect(page.getByRole('heading', { name: /Clean Customer E2E Details/i })).toBeVisible({
@@ -127,9 +127,8 @@ test.describe('Merged dbt + drafted fields', () => {
 		const yml = fs.readFileSync(CLEAN_CUSTOMER_SCHEMA_YML, 'utf8');
 		expect(yml).toContain('pending_col');
 
-		const pendingRow = dialog2.getByTestId('merged-field-row-pending_col');
-		await expect(pendingRow).toBeVisible();
-		await expect(pendingRow.getByPlaceholder('attribute_name')).toHaveAttribute('readonly', '');
+		// Written to schema.yml but not in manifest until dbt compile — draft row is removed.
+		await expect(dialog2.getByTestId('merged-field-row-pending_col')).toHaveCount(0);
 	});
 
 	test('modal: editing a materialized column description persists to schema.yml', async ({ page, request }) => {
@@ -166,7 +165,7 @@ models:
 		await resetDataModel(request, payload);
 
 		await page.goto('/entity-list');
-		await page.waitForLoadState('networkidle');
+		await page.waitForSelector('[data-testid="app-ready"]', { timeout: 30000 });
 
 		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
 		await expect(page.getByRole('heading', { name: /Clean Customer E2E Details/i })).toBeVisible({

--- a/frontend/tests/merged-fields.spec.ts
+++ b/frontend/tests/merged-fields.spec.ts
@@ -93,9 +93,8 @@ test.describe('Merged dbt + drafted fields', () => {
 			has: page.getByRole('heading', { name: /Clean Customer E2E Details/i }),
 		});
 
-		const matBefore = dialog.locator('[aria-label*="Materialized in dbt model"]');
-		await expect(matBefore.first()).toBeVisible({ timeout: 15000 });
-		await expect(matBefore).toHaveCount(7);
+		await expect(dialog.getByPlaceholder('attribute_name')).toHaveCount(7);
+		await expect(dialog.locator('input[placeholder="attribute_name"][readonly]')).toHaveCount(7);
 
 		await dialog.getByRole('button', { name: /Add Attribute/i }).click();
 
@@ -117,7 +116,7 @@ test.describe('Merged dbt + drafted fields', () => {
 		const dialog2 = page.getByRole('dialog').filter({
 			has: page.getByRole('heading', { name: /Clean Customer E2E Details/i }),
 		});
-		await expect(dialog2.locator('[aria-label*="Drafted in Trellis"]')).toHaveCount(1);
+		await expect(dialog2.getByTestId('merged-field-row-pending_col')).toBeVisible();
 
 		await dialog2.getByTitle(/Write to clean_customer's schema\.yml/i).click();
 
@@ -128,7 +127,9 @@ test.describe('Merged dbt + drafted fields', () => {
 		const yml = fs.readFileSync(CLEAN_CUSTOMER_SCHEMA_YML, 'utf8');
 		expect(yml).toContain('pending_col');
 
-		await expect(dialog2.locator('[aria-label*="Drafted in Trellis"]')).toHaveCount(0);
+		const pendingRow = dialog2.getByTestId('merged-field-row-pending_col');
+		await expect(pendingRow).toBeVisible();
+		await expect(pendingRow.getByPlaceholder('attribute_name')).toHaveAttribute('readonly', '');
 	});
 
 	test('modal: editing a materialized column description persists to schema.yml', async ({ page, request }) => {

--- a/frontend/tests/origin-display.spec.ts
+++ b/frontend/tests/origin-display.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { resetDataModel, type DataModelPayload } from './helpers';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const MANIFEST_PATH = path.join(REPO_ROOT, 'dbt_company_dummy', 'target', 'manifest.json');
+const MODEL_ID = 'model.company_dummy.clean_customer';
+
+test.describe('Origin display in EntityDetailModal', () => {
+	let manifestBackup: string;
+
+	test.beforeAll(() => {
+		manifestBackup = fs.readFileSync(MANIFEST_PATH, 'utf8');
+	});
+
+	test.afterAll(() => {
+		fs.writeFileSync(MANIFEST_PATH, manifestBackup, 'utf8');
+	});
+
+	test('shows read-only structured origin for draft and dbt fields', async ({ page, request }) => {
+		const manifest = JSON.parse(manifestBackup);
+		manifest.nodes[MODEL_ID].columns = {
+			...(manifest.nodes[MODEL_ID].columns ?? {}),
+			id: {
+				name: 'id',
+				data_type: 'bigint',
+				description: 'Customer id',
+				meta: { origin: [{ DH1: 'CORE.CUSTOMER.ID' }] },
+			},
+		};
+		fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest), 'utf8');
+
+		const payload: DataModelPayload = {
+			version: 0.1,
+			entities: [
+				{
+					id: 'origin_draft_e2e',
+					label: 'Origin Draft E2E',
+					entity_type: 'dimension',
+					drafted_fields: [
+						{
+							name: 'campaign_amount',
+							datatype: 'float',
+							description: 'Allocated amount',
+							origin: [
+								{ DH1: 'CORE.T_SALES.AMOUNT' },
+								{ DH2: 'CBUS.AMOUNT' },
+							],
+						},
+					],
+				},
+				{
+					id: 'clean_customer_e2e',
+					label: 'Clean Customer E2E',
+					entity_type: 'dimension',
+					dbt_model: MODEL_ID,
+					drafted_fields: [],
+				},
+			],
+			relationships: [],
+		};
+		await resetDataModel(request, payload);
+
+		await page.goto('/entity-list');
+		await page.waitForLoadState('networkidle');
+
+		await page.getByRole('row', { name: /Origin Draft E2E/i }).click();
+		let dialog = page.getByRole('dialog');
+		await expect(dialog.getByTestId('origin-entry').filter({ hasText: 'DH1: CORE.T_SALES.AMOUNT' })).toBeVisible();
+		await expect(dialog.getByTestId('origin-entry').filter({ hasText: 'DH2: CBUS.AMOUNT' })).toBeVisible();
+		await expect(dialog.locator('input[placeholder="Origin"]')).toHaveCount(0);
+
+		await dialog.getByRole('button', { name: 'Close' }).click();
+		await expect(dialog).toBeHidden({ timeout: 10000 });
+
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+
+		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
+		dialog = page.getByRole('dialog');
+		const idRow = dialog.getByTestId('merged-field-row-id');
+		await expect(idRow.getByTestId('origin-entry').filter({ hasText: 'DH1: CORE.CUSTOMER.ID' })).toBeVisible({
+			timeout: 15000,
+		});
+		await expect(dialog.locator('input[placeholder="Origin"]')).toHaveCount(0);
+	});
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.2b1"
+version = "0.16.2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.2"
+version = "0.17.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.0b2"
+version = "0.17.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.0"
+version = "0.17.0b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.2-beta.1"
+version = "0.16.2b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.0b1"
+version = "0.17.0b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.16.1"
+version = "0.16.2-beta.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/sync_cursor_commands.sh
+++ b/scripts/sync_cursor_commands.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copy .ai_agent/commands into .cursor/commands (flat) for Cursor slash-command discovery.
+# Cursor does not reliably follow symlinks or scan subdirectories under .cursor/commands/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="${ROOT}/.ai_agent/commands"
+DEST="${ROOT}/.cursor/commands"
+
+if [[ ! -d "$SRC" ]]; then
+	echo "error: source directory not found: $SRC" >&2
+	exit 1
+fi
+
+mkdir -p "${ROOT}/.cursor"
+
+if [[ -L "$DEST" ]]; then
+	rm "$DEST"
+fi
+mkdir -p "$DEST"
+
+declare -A seen=()
+while IFS= read -r -d '' file; do
+	base="$(basename "$file")"
+	if [[ -n "${seen[$base]:-}" ]]; then
+		echo "error: duplicate command filename '$base' under $SRC" >&2
+		exit 1
+	fi
+	seen[$base]=1
+done < <(find "$SRC" -name '*.md' -type f -print0)
+
+rm -f "${DEST}"/*.md 2>/dev/null || true
+
+count=0
+while IFS= read -r -d '' file; do
+	cp "$file" "${DEST}/$(basename "$file")"
+	count=$((count + 1))
+done < <(find "$SRC" -name '*.md' -type f -print0)
+
+echo "Synced ${count} command(s) from .ai_agent/commands to .cursor/commands"

--- a/trellis_datamodel/adapters/base.py
+++ b/trellis_datamodel/adapters/base.py
@@ -40,6 +40,7 @@ class ColumnSchema(TypedDict, total=False):
     data_type: Optional[str]
     description: Optional[str]
     data_tests: Optional[list[dict[str, Any]]]
+    origin: Optional[list[dict[str, str]]]
 
 
 class ModelSchema(TypedDict, total=False):

--- a/trellis_datamodel/adapters/base.py
+++ b/trellis_datamodel/adapters/base.py
@@ -6,7 +6,7 @@ enabling support for dbt-core, SQLMesh, Bruin, etc.
 """
 
 from pathlib import Path
-from typing import Protocol, TypedDict, Optional, Any
+from typing import Protocol, TypedDict, Optional, Any, NotRequired
 
 
 class ColumnInfo(TypedDict):
@@ -14,6 +14,8 @@ class ColumnInfo(TypedDict):
 
     name: str
     type: Optional[str]
+    description: NotRequired[Optional[str]]
+    origin: NotRequired[list[dict[str, str]]]
 
 
 class ModelInfo(TypedDict):

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 
 from trellis_datamodel import config as cfg
 from trellis_datamodel.utils.yaml_handler import YamlHandler
+from trellis_datamodel.utils.origin import parse_origin
 from .base import (
     ColumnInfo,
     ColumnSchema,
@@ -22,6 +23,24 @@ from .base import (
     ModelSchema,
     Relationship,
 )
+
+
+def _origin_meta(raw_origin: object) -> dict[str, Any] | None:
+    parsed = parse_origin(raw_origin)
+    return {"origin": parsed} if parsed else None
+
+
+def _resolve_origin_from_column(
+    col_data: dict[str, Any], description: str | None
+) -> tuple[str | None, list[dict[str, str]]]:
+    meta = col_data.get("meta") or {}
+    origin = parse_origin(meta.get("origin"))
+    desc = description
+    if not origin and desc and " | Origin: " in desc:
+        prefix, suffix = desc.split(" | Origin: ", 1)
+        origin = parse_origin(suffix)
+        desc = prefix or None
+    return desc, origin
 
 
 class DbtCoreAdapter:
@@ -501,25 +520,39 @@ class DbtCoreAdapter:
                     col_name.lower(): (col_data.get("description") or "")
                     for col_name, col_data in node.get("columns", {}).items()
                 }
+                manifest_col_by_lower: dict[str, dict[str, Any]] = {
+                    col_name.lower(): col_data
+                    for col_name, col_data in node.get("columns", {}).items()
+                }
                 for col in catalog_node.get("columns", {}).values():
                     col_name_lower = (col.get("name") or "").lower()
+                    manifest_col = manifest_col_by_lower.get(col_name_lower, {})
+                    description = (
+                        manifest_col_desc.get(col_name_lower)
+                        or col.get("comment")
+                        or col.get("description")
+                    )
+                    description, origin = _resolve_origin_from_column(
+                        manifest_col, description
+                    )
                     columns.append(
                         {
                             "name": col_name_lower,
                             "type": col.get("type") or col.get("data_type"),
-                            "description": (
-                                manifest_col_desc.get(col_name_lower)
-                                or col.get("comment")
-                                or col.get("description")
-                            ),
+                            "description": description,
+                            "origin": origin,
                         }
                     )
             else:
                 for col_name, col_data in node.get("columns", {}).items():
+                    description, origin = _resolve_origin_from_column(
+                        col_data, col_data.get("description")
+                    )
                     columns.append({
                         "name": col_name,
                         "type": col_data.get("type") or col_data.get("data_type"),
-                        "description": col_data.get("description"),
+                        "description": description,
+                        "origin": origin,
                     })
 
             # Extract materialization
@@ -1036,17 +1069,15 @@ class DbtCoreAdapter:
                         continue
                     f_desc = field.get("description")
                     f_origin = field.get("origin")
-                    if f_desc and f_origin:
-                        f_desc = f"{f_desc} | Origin: {f_origin}"
-                    elif f_origin:
-                        f_desc = f"Origin: {f_origin}"
-                    columns_payload.append(
-                        {
-                            "name": f_name,
-                            "data_type": field.get("datatype"),
-                            "description": f_desc,
-                        }
-                    )
+                    col_payload: dict[str, Any] = {
+                        "name": f_name,
+                        "data_type": field.get("datatype"),
+                        "description": f_desc,
+                    }
+                    origin_meta = _origin_meta(f_origin)
+                    if origin_meta:
+                        col_payload["meta"] = origin_meta
+                    columns_payload.append(col_payload)
 
                 self.yaml_handler.update_columns_batch(model_entry, columns_payload)
 
@@ -1200,15 +1231,12 @@ class DbtCoreAdapter:
         for field in fields:
             desc = field.get("description")
             origin = field.get("origin")
-            if desc and origin:
-                combined_desc = f"{desc} | Origin: {origin}"
-            elif origin:
-                combined_desc = f"Origin: {origin}"
-            else:
-                combined_desc = desc
             col: dict = {"name": field["name"], "data_type": field["datatype"]}
-            if combined_desc:
-                col["description"] = combined_desc
+            if desc:
+                col["description"] = desc
+            origin_meta = _origin_meta(origin)
+            if origin_meta:
+                col["meta"] = origin_meta
             columns.append(col)
 
         target_version = self._resolve_model_version(

--- a/trellis_datamodel/models/schemas.py
+++ b/trellis_datamodel/models/schemas.py
@@ -102,7 +102,7 @@ class DbtSchemaRequest(BaseModel):
     """Schema for creating a new dbt schema file."""
     entity_id: str
     model_name: str
-    fields: List[Dict[str, str]]
+    fields: List[Dict[str, Any]]
     description: Optional[str] = None
     tags: Optional[List[str]] = None
 

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -10,8 +10,23 @@ from trellis_datamodel.models.schemas import DataModelUpdate
 from trellis_datamodel.services.lineage import extract_source_systems_for_model
 from trellis_datamodel.adapters import get_adapter
 from trellis_datamodel.utils.yaml_handler import YamlHandler
+from trellis_datamodel.utils.origin import parse_origin
 
 router = APIRouter(prefix="/api", tags=["data-model"])
+
+
+def _normalize_field_origin(field: Dict[str, Any]) -> None:
+    origin = parse_origin(field.get("origin"))
+    if origin:
+        field["origin"] = origin
+    elif "origin" in field:
+        del field["origin"]
+
+
+def _normalize_model_origins(model_data: Dict[str, Any]) -> None:
+    for entity in model_data.get("entities", []):
+        for field in entity.get("drafted_fields") or []:
+            _normalize_field_origin(field)
 
 
 def load_data_model_raw() -> Dict[str, Any]:
@@ -217,6 +232,8 @@ async def get_data_model():
         if not model_data.get("relationships"):
             model_data["relationships"] = []
 
+        _normalize_model_origins(model_data)
+
         # Apply entity type inference when dimensional modeling is enabled
         if cfg.DIMENSIONAL_MODELING_CONFIG.enabled:
             model_data = _apply_entity_type_inference(model_data)
@@ -341,7 +358,12 @@ def _split_model_and_layout(
         if "additional_models" in entity:
             model_entity["additional_models"] = entity["additional_models"]
         if "drafted_fields" in entity:
-            model_entity["drafted_fields"] = entity["drafted_fields"]
+            drafted_fields = []
+            for field in entity["drafted_fields"]:
+                normalized = dict(field)
+                _normalize_field_origin(normalized)
+                drafted_fields.append(normalized)
+            model_entity["drafted_fields"] = drafted_fields
         if "tags" in entity:
             model_entity["tags"] = entity["tags"]
         if "domain" in entity:

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -28,6 +28,37 @@ _DATE_EXACT = {"date"}
 _TIMESTAMP_PREFIXES = ("timestamp", "datetime")
 _TEXT_PREFIXES = ("varchar", "char", "text", "string", "nvarchar", "nchar", "clob")
 
+_ORIGIN_SEPARATOR = " | Origin: "
+_ORIGIN_PREFIX = "Origin: "
+
+
+def _parse_description_with_origin(
+    raw_description: str | None,
+) -> tuple[str | None, str | None]:
+    """Split a description into (description, origin).
+
+    The write paths embed origin into the description as:
+      - "desc | Origin: value"  (both present)
+      - "Origin: value"         (only origin, no description)
+
+    This reverses that encoding so origin round-trips through a
+    dedicated field.
+    """
+    if not raw_description:
+        return raw_description, None
+
+    sep_idx = raw_description.find(_ORIGIN_SEPARATOR)
+    if sep_idx != -1:
+        desc = raw_description[:sep_idx]
+        origin = raw_description[sep_idx + len(_ORIGIN_SEPARATOR) :]
+        return (desc or None), (origin or None)
+
+    if raw_description.startswith(_ORIGIN_PREFIX):
+        origin = raw_description[len(_ORIGIN_PREFIX) :]
+        return None, (origin or None)
+
+    return raw_description, None
+
 
 def _map_dbt_type(dbt_type: str | None) -> str:
     """Map a dbt/warehouse column type string to a DraftedField datatype enum value."""
@@ -104,7 +135,14 @@ def reconcile_entity_fields(
         field["source"] = "dbt"
         desc = col.get("description")
         if desc is not None:
-            field["description"] = desc
+            # Parse origin from description if embedded
+            parsed_desc, parsed_origin = _parse_description_with_origin(desc)
+            field["description"] = parsed_desc
+            if parsed_origin is not None:
+                field["origin"] = parsed_origin
+            elif "origin" in field:
+                # Remove stale origin if description no longer contains it
+                del field["origin"]
         elif "description" not in field:
             pass  # keep absent rather than writing None
 

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -288,3 +288,85 @@ class TestSaveDataModel:
 
         assert saved["entities"][0]["id"] == "dim_employee"
         assert saved["entities"][0]["roles"] == ["Sales Agent"]
+
+
+def test_get_data_model_normalizes_origin(test_client, temp_data_model_path):
+    """Legacy string origin in data_model.yml is returned as a structured list."""
+    model_data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "sales",
+                "label": "Sales",
+                "drafted_fields": [
+                    {
+                        "name": "amount",
+                        "datatype": "numeric",
+                        "origin": "DH1: CORE.A | DH2: CBUS.B",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(model_data, f)
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    field = response.json()["entities"][0]["drafted_fields"][0]
+    assert field["origin"] == [{"DH1": "CORE.A"}, {"DH2": "CBUS.B"}]
+
+
+def test_save_data_model_writes_origin_list(test_client, temp_data_model_path):
+    """Saved data_model.yml persists structured origin lists; legacy strings migrate."""
+    legacy_payload = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "sales",
+                "label": "Sales",
+                "drafted_fields": [
+                    {
+                        "name": "amount",
+                        "datatype": "numeric",
+                        "origin": "DH1: CORE.A",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    response = test_client.post("/api/data-model", json=legacy_payload)
+    assert response.status_code == 200
+
+    with open(temp_data_model_path, "r") as f:
+        saved = yaml.safe_load(f)
+    assert saved["entities"][0]["drafted_fields"][0]["origin"] == [{"DH1": "CORE.A"}]
+
+    structured_payload = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "sales",
+                "label": "Sales",
+                "drafted_fields": [
+                    {
+                        "name": "amount",
+                        "datatype": "numeric",
+                        "origin": [{"DH1": "CORE.A"}, {"DH2": "CBUS.B"}],
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    response = test_client.post("/api/data-model", json=structured_payload)
+    assert response.status_code == 200
+
+    with open(temp_data_model_path, "r") as f:
+        saved = yaml.safe_load(f)
+    assert saved["entities"][0]["drafted_fields"][0]["origin"] == [
+        {"DH1": "CORE.A"},
+        {"DH2": "CBUS.B"},
+    ]

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -111,6 +111,117 @@ def test_sync_dbt_tests_writes_meta_origin(
     assert "| Origin:" not in (col.get("description") or "")
 
 
+def test_round_trip_demo_origin(monkeypatch, temp_dir):
+    """Demo-style project: materialize structured origin to schema.yml and read back via get_models."""
+    from trellis_datamodel import config as cfg
+    from trellis_datamodel.adapters.dbt_core import DbtCoreAdapter
+
+    model_name = "fact__campaign_management"
+    model_uid = "model.demo.fact__campaign_management"
+    entity_id = "fact__campaign_management"
+    origin_list = [
+        {"DH1": "CORE.T_SALES.AMOUNT"},
+        {"DH2": "CBUS.AMOUNT"},
+    ]
+
+    models_dir = os.path.join(temp_dir, "models", "3-entity")
+    os.makedirs(models_dir, exist_ok=True)
+    with open(os.path.join(models_dir, f"{model_name}.sql"), "w") as f:
+        f.write("select 1 as sales_amount_dc")
+
+    manifest_path = os.path.join(temp_dir, "manifest.json")
+    manifest_data = {
+        "nodes": {
+            model_uid: {
+                "unique_id": model_uid,
+                "resource_type": "model",
+                "name": model_name,
+                "schema": "main",
+                "alias": model_name,
+                "original_file_path": f"models/3-entity/{model_name}.sql",
+                "columns": {},
+                "description": "Campaign management fact",
+                "config": {"materialized": "table"},
+                "tags": [],
+            }
+        }
+    }
+    with open(manifest_path, "w") as f:
+        json.dump(manifest_data, f)
+
+    data_model_path = os.path.join(temp_dir, "data_model.yml")
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": entity_id,
+                "label": "Campaign Management",
+                "dbt_model": model_uid,
+                "drafted_fields": [
+                    {
+                        "name": "sales_amount_dc",
+                        "datatype": "numeric",
+                        "description": "Net sales",
+                        "origin": origin_list,
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    monkeypatch.setattr(cfg, "DBT_PROJECT_PATH", temp_dir)
+    monkeypatch.setattr(cfg, "MANIFEST_PATH", manifest_path)
+    monkeypatch.setattr(cfg, "CATALOG_PATH", "")
+    monkeypatch.setattr(cfg, "DATA_MODEL_PATH", data_model_path)
+    monkeypatch.setattr(cfg, "DBT_MODEL_PATHS", ["3-entity"])
+
+    adapter = DbtCoreAdapter(
+        manifest_path=manifest_path,
+        catalog_path="",
+        project_path=temp_dir,
+        data_model_path=data_model_path,
+        model_paths=["3-entity"],
+    )
+
+    yml_path = adapter.save_dbt_schema(
+        entity_id=entity_id,
+        model_name=model_name,
+        fields=[
+            {
+                "name": "sales_amount_dc",
+                "datatype": "numeric",
+                "description": "Net sales",
+                "origin": origin_list,
+            }
+        ],
+    )
+
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = schema["models"][0]["columns"][0]
+    assert col["meta"]["origin"] == origin_list
+    assert col["description"] == "Net sales"
+    assert "| Origin:" not in (col.get("description") or "")
+
+    manifest_data["nodes"][model_uid]["columns"]["sales_amount_dc"] = {
+        "name": "sales_amount_dc",
+        "data_type": "numeric",
+        "description": "Net sales",
+        "meta": {"origin": origin_list},
+    }
+    with open(manifest_path, "w") as f:
+        json.dump(manifest_data, f)
+
+    models = adapter.get_models()
+    model = next(m for m in models if m["name"] == model_name)
+    read_col = next(c for c in model["columns"] if c["name"] == "sales_amount_dc")
+    assert read_col["origin"] == origin_list
+    assert read_col.get("description") == "Net sales"
+
+
 class TestSaveDbtSchema:
     """Tests for POST /api/dbt-schema endpoint."""
 

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -19,6 +19,98 @@ def test_columninfo_allows_origin_key():
     assert column["origin"] == [{"DH1": "CORE.A"}]
 
 
+@pytest.mark.parametrize(
+    "origin_input",
+    [
+        [{"DH1": "CORE.T_SALES.AMOUNT"}, {"DH2": "CBUS.AMOUNT"}],
+        "DH1: CORE.T_SALES.AMOUNT | DH2: CBUS.AMOUNT",
+    ],
+)
+def test_materialize_writes_meta_origin(test_client, temp_dir, mock_manifest, origin_input):
+    """Materialization writes meta.origin and keeps description free of | Origin: suffix."""
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "sales.yml"), "w") as f:
+        yaml.dump({"version": 2, "models": [{"name": "sales", "columns": []}]}, f)
+
+    expected_origin = [
+        {"DH1": "CORE.T_SALES.AMOUNT"},
+        {"DH2": "CBUS.AMOUNT"},
+    ]
+
+    # Site 2: POST /api/dbt-schema
+    response = test_client.post(
+        "/api/dbt-schema",
+        json={
+            "entity_id": "sales",
+            "model_name": "sales",
+            "fields": [
+                {
+                    "name": "amount",
+                    "datatype": "numeric",
+                    "description": "Net sales",
+                    "origin": origin_input,
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200
+    with open(response.json()["file_path"], "r") as f:
+        schema = yaml.safe_load(f)
+    col = schema["models"][0]["columns"][0]
+    assert col["meta"]["origin"] == expected_origin
+    assert col["description"] == "Net sales"
+    assert "| Origin:" not in (col.get("description") or "")
+
+
+def test_sync_dbt_tests_writes_meta_origin(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """Batch sync writes meta.origin for drafted fields (site 1)."""
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+        yaml.dump({"version": 2, "models": [{"name": "users", "columns": []}]}, f)
+
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.project.users",
+                "drafted_fields": [
+                    {
+                        "name": "amount",
+                        "datatype": "numeric",
+                        "description": "Net sales",
+                        "origin": "DH1: CORE.T_SALES.AMOUNT | DH2: CBUS.AMOUNT",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = next(c for c in schema["models"][0]["columns"] if c["name"] == "amount")
+    assert col["meta"]["origin"] == [
+        {"DH1": "CORE.T_SALES.AMOUNT"},
+        {"DH2": "CBUS.AMOUNT"},
+    ]
+    assert col["description"] == "Net sales"
+    assert "| Origin:" not in (col.get("description") or "")
+
+
 class TestSaveDbtSchema:
     """Tests for POST /api/dbt-schema endpoint."""
 

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -6,6 +6,18 @@ import yaml
 import json
 import pytest
 
+from trellis_datamodel.adapters.base import ColumnInfo
+
+
+def test_columninfo_allows_origin_key():
+    """ColumnInfo accepts structured origin metadata."""
+    column: ColumnInfo = {
+        "name": "sales_amount",
+        "type": "numeric",
+        "origin": [{"DH1": "CORE.A"}],
+    }
+    assert column["origin"] == [{"DH1": "CORE.A"}]
+
 
 class TestSaveDbtSchema:
     """Tests for POST /api/dbt-schema endpoint."""

--- a/trellis_datamodel/tests/test_demo_origin_fixtures.py
+++ b/trellis_datamodel/tests/test_demo_origin_fixtures.py
@@ -1,0 +1,46 @@
+"""Regression guards for demo-project origin fixture shapes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DBT_DEMO = REPO_ROOT / "dbt_demo"
+
+
+def test_demo_data_model_retains_legacy_string_origin():
+    """dbt_demo/data_model.yml keeps pipe-string origins for silent migration."""
+    if not DBT_DEMO.exists():
+        return
+
+    data_model_path = DBT_DEMO / "data_model.yml"
+    with open(data_model_path, "r") as f:
+        data_model = yaml.safe_load(f)
+
+    legacy_origins = [
+        field.get("origin")
+        for entity in data_model.get("entities", [])
+        for field in entity.get("drafted_fields") or []
+        if isinstance(field.get("origin"), str) and field.get("origin")
+    ]
+    assert legacy_origins, "expected at least one legacy string origin in dbt_demo"
+
+
+def test_demo_schema_has_hand_written_meta_origin():
+    """dbt_demo schema.yml includes at least one column with meta.origin."""
+    if not DBT_DEMO.exists():
+        return
+
+    schema_path = DBT_DEMO / "models" / "3-entity" / "dim__lead.yml"
+    with open(schema_path, "r") as f:
+        schema = yaml.safe_load(f)
+
+    lead_model = next(m for m in schema["models"] if m["name"] == "dim__lead")
+    lead_key = next(c for c in lead_model["columns"] if c["name"] == "lead_key")
+    assert lead_key.get("meta", {}).get("origin") == [
+        {"DH1": "CORE.T_DYN_LEAD.LEADKEY"},
+        {"DH2": "SCD2_LEAD.LEADKEY"},
+    ]

--- a/trellis_datamodel/tests/test_demo_origin_fixtures.py
+++ b/trellis_datamodel/tests/test_demo_origin_fixtures.py
@@ -11,8 +11,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DBT_DEMO = REPO_ROOT / "dbt_demo"
 
 
-def test_demo_data_model_retains_legacy_string_origin():
-    """dbt_demo/data_model.yml keeps pipe-string origins for silent migration."""
+def test_demo_data_model_origins_are_structured_lists():
+    """dbt_demo/data_model.yml origins are fully migrated to structured lists."""
     if not DBT_DEMO.exists():
         return
 
@@ -20,17 +20,23 @@ def test_demo_data_model_retains_legacy_string_origin():
     with open(data_model_path, "r") as f:
         data_model = yaml.safe_load(f)
 
-    legacy_origins = [
+    all_origins = [
         field.get("origin")
         for entity in data_model.get("entities", [])
         for field in entity.get("drafted_fields") or []
-        if isinstance(field.get("origin"), str) and field.get("origin")
+        if field.get("origin") is not None
     ]
-    assert legacy_origins, "expected at least one legacy string origin in dbt_demo"
+    assert all_origins, "expected at least one origin entry in dbt_demo"
+    legacy = [o for o in all_origins if isinstance(o, str)]
+    assert not legacy, f"expected no legacy string origins, found: {legacy}"
+    for origin in all_origins:
+        assert isinstance(origin, list), f"origin should be a list, got: {type(origin)}"
+        for entry in origin:
+            assert isinstance(entry, dict), f"each origin entry should be a dict, got: {type(entry)}"
 
 
-def test_demo_schema_has_hand_written_meta_origin():
-    """dbt_demo schema.yml includes at least one column with meta.origin."""
+def test_demo_schema_has_meta_origin():
+    """dbt_demo schema.yml has at least one column with a structured meta.origin list."""
     if not DBT_DEMO.exists():
         return
 
@@ -39,8 +45,11 @@ def test_demo_schema_has_hand_written_meta_origin():
         schema = yaml.safe_load(f)
 
     lead_model = next(m for m in schema["models"] if m["name"] == "dim__lead")
-    lead_key = next(c for c in lead_model["columns"] if c["name"] == "lead_key")
-    assert lead_key.get("meta", {}).get("origin") == [
-        {"DH1": "CORE.T_DYN_LEAD.LEADKEY"},
-        {"DH2": "SCD2_LEAD.LEADKEY"},
+    cols_with_origin = [
+        c for c in lead_model["columns"]
+        if isinstance(c.get("meta", {}).get("origin"), list)
     ]
+    assert cols_with_origin, "expected at least one column with meta.origin list in dim__lead.yml"
+    for col in cols_with_origin:
+        for entry in col["meta"]["origin"]:
+            assert isinstance(entry, dict), f"each origin entry should be a dict, got: {entry}"

--- a/trellis_datamodel/tests/test_manifest.py
+++ b/trellis_datamodel/tests/test_manifest.py
@@ -166,6 +166,62 @@ class TestGetManifest:
             f"Expected 'integer' from data_type key, got: {col.get('type')}"
         )
 
+    def test_get_models_reads_meta_origin(
+        self, test_client, temp_dir, mock_manifest_data, monkeypatch
+    ):
+        """Columns with meta.origin return structured origin on manifest read-back."""
+        from trellis_datamodel import config as cfg
+
+        mock_manifest_data["nodes"]["model.project.users"]["columns"]["revenue"] = {
+            "name": "revenue",
+            "data_type": "numeric",
+            "description": "Net sales",
+            "meta": {"origin": [{"DH1": "CORE.A"}]},
+        }
+        manifest_path = os.path.join(temp_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(mock_manifest_data, f)
+        monkeypatch.setattr(cfg, "MANIFEST_PATH", manifest_path)
+        monkeypatch.setattr(cfg, "CATALOG_PATH", "")
+
+        response = test_client.get("/api/manifest")
+        users = next(m for m in response.json()["models"] if m["name"] == "users")
+        col = next(c for c in users["columns"] if c["name"] == "revenue")
+        assert col["origin"] == [{"DH1": "CORE.A"}]
+        assert col["description"] == "Net sales"
+
+    def test_get_models_origin_description_fallback(
+        self, test_client, temp_dir, mock_manifest_data, monkeypatch
+    ):
+        """Legacy | Origin: description suffix is parsed into structured origin."""
+        from trellis_datamodel import config as cfg
+
+        mock_manifest_data["nodes"]["model.project.users"]["columns"]["revenue"] = {
+            "name": "revenue",
+            "data_type": "numeric",
+            "description": "Net sales | Origin: DH1: CORE.A",
+        }
+        mock_manifest_data["nodes"]["model.project.users"]["columns"]["cost"] = {
+            "name": "cost",
+            "data_type": "numeric",
+            "description": "Operating cost",
+        }
+        manifest_path = os.path.join(temp_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(mock_manifest_data, f)
+        monkeypatch.setattr(cfg, "MANIFEST_PATH", manifest_path)
+        monkeypatch.setattr(cfg, "CATALOG_PATH", "")
+
+        response = test_client.get("/api/manifest")
+        users = next(m for m in response.json()["models"] if m["name"] == "users")
+        revenue = next(c for c in users["columns"] if c["name"] == "revenue")
+        cost = next(c for c in users["columns"] if c["name"] == "cost")
+
+        assert revenue["origin"] == [{"DH1": "CORE.A"}]
+        assert revenue["description"] == "Net sales"
+        assert cost["origin"] == []
+        assert cost["description"] == "Operating cost"
+
     def test_filters_by_model_path(self, test_client, temp_dir, mock_manifest):
         # Update manifest to have models in different paths
         with open(mock_manifest, "r") as f:

--- a/trellis_datamodel/tests/test_origin.py
+++ b/trellis_datamodel/tests/test_origin.py
@@ -1,0 +1,45 @@
+"""Tests for origin parse/stringify utilities."""
+
+import pytest
+
+from trellis_datamodel.utils.origin import parse_origin, stringify_origin
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ([], []),
+        (
+            "DH1: CORE.T_SALES.AMOUNT | DH2: CBUS.AMOUNT",
+            [{"DH1": "CORE.T_SALES.AMOUNT"}, {"DH2": "CBUS.AMOUNT"}],
+        ),
+        ("DH1: CORE.A", [{"DH1": "CORE.A"}]),
+        ("SAP.SALES_AMOUNT_DC", [{"": "SAP.SALES_AMOUNT_DC"}]),
+        ([{"DH1": "CORE.A"}], [{"DH1": "CORE.A"}]),
+        ("DH1: schema.table:col", [{"DH1": "schema.table:col"}]),
+        ("   ", []),
+    ],
+)
+def test_parse_origin(raw, expected):
+    assert parse_origin(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("entries", "expected"),
+    [
+        (
+            [{"DH1": "CORE.A"}, {"DH2": "CBUS.B"}],
+            "DH1: CORE.A | DH2: CBUS.B",
+        ),
+        ([{"": "SAP.X"}], "SAP.X"),
+        ([], ""),
+    ],
+)
+def test_stringify_origin(entries, expected):
+    assert stringify_origin(entries) == expected
+
+
+def test_stringify_origin_round_trip():
+    structured = [{"DH1": "CORE.A"}, {"DH2": "CBUS.B"}]
+    assert parse_origin(stringify_origin(structured)) == structured

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -136,7 +136,18 @@ class TestReconcileEntityFields:
                 {"name": "revenue", "type": "numeric"},
             ],
         )
-        assert result[0].get("origin") == "DH1: SCHEMA.TABLE.COL"
+        assert result[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_reconcile_preserves_list_origin(self):
+        """Structured list origin on a draft field passes through unchanged."""
+        origin_list = [{"DH1": "CORE.A"}, {"DH2": "CBUS.B"}]
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "revenue", "datatype": "float", "origin": origin_list},
+            ],
+            manifest_columns=[],
+        )
+        assert result[0]["origin"] == origin_list
 
     def test_origin_parsed_from_manifest_description(self):
         """Origin embedded in manifest description is parsed into separate field."""

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -138,6 +138,41 @@ class TestReconcileEntityFields:
         )
         assert result[0].get("origin") == "DH1: SCHEMA.TABLE.COL"
 
+    def test_origin_parsed_from_manifest_description(self):
+        """Origin embedded in manifest description is parsed into separate field."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "Total revenue | Origin: DH1: SCHEMA.TABLE.COL"},
+            ],
+        )
+        assert result[0]["description"] == "Total revenue"
+        assert result[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_origin_only_parsed_from_manifest_description(self):
+        """Origin-only description (no preceding text) is parsed correctly."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "Origin: DH1: SCHEMA.TABLE.COL"},
+            ],
+        )
+        assert result[0]["description"] is None
+        assert result[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_stale_origin_removed_when_description_changes(self):
+        """If manifest description no longer contains origin, stale origin is removed."""
+        result = reconcile_entity_fields(
+            existing_fields=[
+                {"name": "revenue", "datatype": "float", "description": "Old desc", "origin": "OLD_ORIGIN"},
+            ],
+            manifest_columns=[
+                {"name": "revenue", "type": "numeric", "description": "New desc without origin"},
+            ],
+        )
+        assert result[0]["description"] == "New desc without origin"
+        assert "origin" not in result[0]
+
 
 class TestReconcileDataModel:
     """Unit tests for the reconcile_data_model function."""

--- a/trellis_datamodel/tests/test_yaml_handler.py
+++ b/trellis_datamodel/tests/test_yaml_handler.py
@@ -230,6 +230,57 @@ class TestYamlHandlerColumnOperations:
         assert len(cols) == 2
         assert cols[0]["name"] == "id"
         assert cols[0]["description"] == "Primary key"
+        assert "origin" not in cols[0]
+
+    def test_get_columns_parses_origin_from_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {
+                        "name": "revenue",
+                        "data_type": "float",
+                        "description": "Total revenue | Origin: DH1: SCHEMA.TABLE.COL",
+                    },
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] == "Total revenue"
+        assert cols[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_get_columns_parses_origin_only_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {
+                        "name": "revenue",
+                        "data_type": "float",
+                        "description": "Origin: DH1: SCHEMA.TABLE.COL",
+                    },
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] is None
+        assert cols[0]["origin"] == "DH1: SCHEMA.TABLE.COL"
+
+    def test_get_columns_no_origin_when_none_description(self):
+        handler = YamlHandler()
+        model = CommentedMap(
+            {
+                "name": "test",
+                "columns": [
+                    {"name": "id", "data_type": "int"},
+                ],
+            }
+        )
+        cols = handler.get_columns(model)
+        assert cols[0]["description"] is None
+        assert "origin" not in cols[0]
 
 
 class TestYamlHandlerRelationshipTests:

--- a/trellis_datamodel/utils/origin.py
+++ b/trellis_datamodel/utils/origin.py
@@ -1,0 +1,49 @@
+"""Parse and stringify origin metadata for entity attributes."""
+
+from __future__ import annotations
+
+OriginEntry = dict[str, str]
+
+
+def parse_origin(raw: object) -> list[OriginEntry]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        result: list[OriginEntry] = []
+        for entry in raw:
+            if isinstance(entry, dict):
+                result.append({str(k): str(v) for k, v in entry.items()})
+            elif isinstance(entry, str):
+                result.extend(_parse_origin_string(entry))
+        return result
+    if isinstance(raw, str):
+        return _parse_origin_string(raw)
+    return []
+
+
+def _parse_origin_string(value: str) -> list[OriginEntry]:
+    stripped = value.strip()
+    if not stripped:
+        return []
+
+    entries: list[OriginEntry] = []
+    for part in stripped.split(" | "):
+        segment = part.strip()
+        if not segment:
+            continue
+        if ": " in segment:
+            key, val = segment.split(": ", 1)
+            entries.append({key: val})
+        else:
+            entries.append({"": segment})
+    return entries
+
+
+def stringify_origin(entries: list[OriginEntry]) -> str:
+    parts: list[str] = []
+    for entry in entries:
+        if not entry:
+            continue
+        for key, value in entry.items():
+            parts.append(f"{key}: {value}" if key else value)
+    return " | ".join(parts)

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -505,6 +505,38 @@ class YamlHandler:
 
         model["columns"] = new_columns
 
+    _ORIGIN_SEPARATOR = " | Origin: "
+    _ORIGIN_PREFIX = "Origin: "
+
+    @staticmethod
+    def _parse_description_with_origin(
+        raw_description: str | None,
+    ) -> tuple[str | None, str | None]:
+        """Split a schema.yml description into (description, origin).
+
+        The write paths embed origin into the description as:
+          - "desc | Origin: value"  (both present)
+          - "Origin: value"         (only origin, no description)
+
+        This method reverses that encoding so the origin round-trips
+        through a dedicated field instead of staying glued to the
+        description.
+        """
+        if not raw_description:
+            return raw_description, None
+
+        sep_idx = raw_description.find(YamlHandler._ORIGIN_SEPARATOR)
+        if sep_idx != -1:
+            desc = raw_description[:sep_idx]
+            origin = raw_description[sep_idx + len(YamlHandler._ORIGIN_SEPARATOR) :]
+            return (desc or None), (origin or None)
+
+        if raw_description.startswith(YamlHandler._ORIGIN_PREFIX):
+            origin = raw_description[len(YamlHandler._ORIGIN_PREFIX) :]
+            return None, (origin or None)
+
+        return raw_description, None
+
     def get_columns(self, model: CommentedMap) -> List[Dict[str, Any]]:
         """
         Extract columns from a model as a list of dicts.
@@ -519,11 +551,16 @@ class YamlHandler:
         result = []
 
         for col in columns:
+            raw_description = col.get("description")
+            description, origin = self._parse_description_with_origin(raw_description)
+
             col_dict = {
                 "name": col.get("name"),
                 "data_type": col.get("data_type"),
-                "description": col.get("description"),
+                "description": description,
             }
+            if origin is not None:
+                col_dict["origin"] = origin
 
             # Extract tests (supports both dbt's tests and data_tests keys)
             collected_tests: list[dict[str, Any]] = []

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -451,6 +451,8 @@ class YamlHandler:
                 data_type=col_data.get("data_type"),
                 description=col_data.get("description"),
             )
+            if "meta" in col_data:
+                col["meta"] = col_data["meta"]
             new_columns.append(col)
 
         model["columns"] = new_columns
@@ -496,6 +498,8 @@ class YamlHandler:
                 data_type=col_data.get("data_type"),
                 description=col_data.get("description"),
             )
+            if "meta" in col_data:
+                col["meta"] = col_data["meta"]
             new_columns.append(col)
 
         incoming_set = set(incoming_names)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.0"
+version = "0.17.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.16.0b2"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.16.2"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.0b1"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Replaces the pipe-separated origin string on drafted fields with a structured YAML list of {source_id: path} objects throughout the stack.

What changed:
- data_model.yml — origin is now a list: [{DH1: CORE.TABLE.COL}, {DH2: CBUS.COL}]
- Materialization writes meta.origin to dbt schema.yml instead of concatenating into the column description
- Read-back populates origin from meta.origin; falls back to parsing the legacy | Origin: ... description suffix for existing compiled files
- EntityDetailModal shows origin entries as read-only stacked lines for both drafted and dbt-backed fields
- Excel and Markdown exports stringify the list back to the legacy KEY: VALUE | KEY: VALUE format

Backwards compatible: existing files with pipe-separated strings load and display correctly and are silently migrated to the list format on next save.