### PR TITLE
Fix/preserve dbt field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-07-27
+
+### Fixed
+- **Native dbt column types preserved on push (#111)**: `POST /api/dbt-schema` and `POST /api/sync-dbt-tests` previously wrote the drafted field's coarse UI type bucket (e.g. `text`) to `schema.yml` for dbt-sourced columns, downgrading precise declared types like `varchar(50)` to the generic bucket on every push.
+- **Declared `data_type` no longer clobbered by catalog-normalized types (#111)**: warehouses often report a declared type under a different spelling than it was written (e.g. Snowflake's catalog reports a declared `varchar` column as `TEXT`), so trusting the catalog value unconditionally still overwrote a divergent `schema.yml` value, just with a different value. `data_type` is now only backfilled when a column has no existing declared type; an existing value is never touched.
+- **Catalog type spellings canonicalized on backfill (#111)**: a dbt-sourced column synced for the first time (no prior `schema.yml` entry) is now backfilled with a canonical spelling (`TEXT` → `varchar`, `TIMESTAMP_NTZ` → `timestamp`) instead of the raw catalog value, so freshly-backfilled columns don't mix spellings with hand-declared ones across `schema.yml` files. Ambiguous types (`NUMBER`, which spans int/decimal/numeric without exposing precision/scale) are left as-is rather than guessed.
+
 ## [0.17.0] - 2026-07-24
 
 ### Added

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,6 +46,7 @@ export interface DraftedField {
     description?: string;
     origin?: OriginEntry[];
     source?: 'dbt' | 'draft';
+    dbt_data_type?: string; // exact warehouse type, preserved so push doesn't downgrade to the `datatype` bucket
 }
 
 export interface EntityData {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.1b3"
+version = "0.17.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.1b1"
+version = "0.17.1b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.1b2"
+version = "0.17.1b3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.0"
+version = "0.17.1b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -1071,7 +1071,7 @@ class DbtCoreAdapter:
                     f_origin = field.get("origin")
                     col_payload: dict[str, Any] = {
                         "name": f_name,
-                        "data_type": field.get("datatype"),
+                        "data_type": field.get("dbt_data_type") or field.get("datatype"),
                         "description": f_desc,
                     }
                     origin_meta = _origin_meta(f_origin)
@@ -1231,7 +1231,10 @@ class DbtCoreAdapter:
         for field in fields:
             desc = field.get("description")
             origin = field.get("origin")
-            col: dict = {"name": field["name"], "data_type": field["datatype"]}
+            col: dict = {
+                "name": field["name"],
+                "data_type": field.get("dbt_data_type") or field["datatype"],
+            }
             if desc:
                 col["description"] = desc
             origin_meta = _origin_meta(origin)

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -1071,9 +1071,18 @@ class DbtCoreAdapter:
                     f_origin = field.get("origin")
                     col_payload: dict[str, Any] = {
                         "name": f_name,
-                        "data_type": field.get("dbt_data_type") or field.get("datatype"),
                         "description": f_desc,
                     }
+                    if field.get("source") == "dbt":
+                        # dbt/the warehouse owns the declared type once it
+                        # exists in schema.yml — only backfill it the first
+                        # time this column is synced, never overwrite an
+                        # existing value (#111).
+                        col_payload["data_type_fallback"] = field.get(
+                            "dbt_data_type"
+                        ) or field.get("datatype")
+                    else:
+                        col_payload["data_type"] = field.get("datatype")
                     origin_meta = _origin_meta(f_origin)
                     if origin_meta:
                         col_payload["meta"] = origin_meta
@@ -1231,10 +1240,11 @@ class DbtCoreAdapter:
         for field in fields:
             desc = field.get("description")
             origin = field.get("origin")
-            col: dict = {
-                "name": field["name"],
-                "data_type": field.get("dbt_data_type") or field["datatype"],
-            }
+            col: dict = {"name": field["name"]}
+            if field.get("source") == "dbt":
+                col["data_type_fallback"] = field.get("dbt_data_type") or field["datatype"]
+            else:
+                col["data_type"] = field["datatype"]
             if desc:
                 col["description"] = desc
             origin_meta = _origin_meta(origin)

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -30,6 +30,26 @@ def _origin_meta(raw_origin: object) -> dict[str, Any] | None:
     return {"origin": parsed} if parsed else None
 
 
+# Catalog-reported type spellings that are unambiguous synonyms of a more
+# common declared-schema spelling (e.g. Snowflake's catalog reports a
+# declared "varchar" column as "TEXT"). Backfilling a new column straight
+# from the catalog value would otherwise leave schema.yml files with a mix
+# of spellings for the same type depending on sync history. NUMBER is
+# deliberately excluded: it collapses int/integer/decimal/numeric and the
+# catalog doesn't expose precision/scale to tell them apart, so canonicalizing
+# it would risk guessing the wrong declared type.
+_CATALOG_TYPE_ALIASES = {
+    "text": "varchar",
+    "timestamp_ntz": "timestamp",
+}
+
+
+def _canonicalize_catalog_type(raw_type: str | None) -> str | None:
+    if not raw_type:
+        return raw_type
+    return _CATALOG_TYPE_ALIASES.get(raw_type.lower(), raw_type)
+
+
 def _resolve_origin_from_column(
     col_data: dict[str, Any], description: str | None
 ) -> tuple[str | None, list[dict[str, str]]]:
@@ -1078,8 +1098,8 @@ class DbtCoreAdapter:
                         # exists in schema.yml — only backfill it the first
                         # time this column is synced, never overwrite an
                         # existing value (#111).
-                        col_payload["data_type_fallback"] = field.get(
-                            "dbt_data_type"
+                        col_payload["data_type_fallback"] = _canonicalize_catalog_type(
+                            field.get("dbt_data_type")
                         ) or field.get("datatype")
                     else:
                         col_payload["data_type"] = field.get("datatype")
@@ -1242,7 +1262,9 @@ class DbtCoreAdapter:
             origin = field.get("origin")
             col: dict = {"name": field["name"]}
             if field.get("source") == "dbt":
-                col["data_type_fallback"] = field.get("dbt_data_type") or field["datatype"]
+                col["data_type_fallback"] = _canonicalize_catalog_type(
+                    field.get("dbt_data_type")
+                ) or field["datatype"]
             else:
                 col["data_type"] = field["datatype"]
             if desc:

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -133,6 +133,14 @@ def reconcile_entity_fields(
         field["name"] = col_name
         field["datatype"] = _map_dbt_type(col.get("type"))
         field["source"] = "dbt"
+        raw_type = col.get("type")
+        if raw_type:
+            # Preserve the exact warehouse/dbt type (e.g. "varchar") alongside
+            # the coarse UI bucket above, so pushing back to dbt doesn't
+            # downgrade a precise type to the bucket's generic default (#111).
+            field["dbt_data_type"] = raw_type
+        elif "dbt_data_type" in field:
+            del field["dbt_data_type"]
         desc = col.get("description")
         if desc is not None:
             # Parse origin from description if embedded

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -111,6 +111,79 @@ def test_sync_dbt_tests_writes_meta_origin(
     assert "| Origin:" not in (col.get("description") or "")
 
 
+def test_push_to_dbt_preserves_native_column_type(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """Push to dbt must keep the dbt-native column type (e.g. varchar) instead of
+    overwriting it with Trellis's internal UI bucket type (e.g. text).
+
+    Regression test for GitHub issue #111: a bound entity's field type is
+    "varchar" in the compiled dbt project, but Trellis's data model only
+    tracks the coarse UI bucket ("text") for that field. Triggering
+    "Push to dbt" must not clobber the more precise, existing schema.yml
+    data_type with that bucket value.
+    """
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+        yaml.dump(
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "users",
+                        "columns": [
+                            {
+                                "name": "name",
+                                "data_type": "varchar",
+                                "description": "Full name",
+                            }
+                        ],
+                    }
+                ],
+            },
+            f,
+        )
+
+    # Mirrors what reconciliation currently writes to data_model.yml: the
+    # bucketed UI datatype ("text"), not the native dbt type ("varchar").
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.project.users",
+                "drafted_fields": [
+                    {
+                        "name": "name",
+                        "datatype": "text",
+                        "description": "Full name",
+                        "source": "dbt",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = next(c for c in schema["models"][0]["columns"] if c["name"] == "name")
+    assert col["data_type"] == "varchar", (
+        "Push to dbt overwrote the native dbt column type with the internal "
+        f"UI bucket type: {col['data_type']!r} (expected 'varchar')"
+    )
+
+
 def test_round_trip_demo_origin(monkeypatch, temp_dir):
     """Demo-style project: materialize structured origin to schema.yml and read back via get_models."""
     from trellis_datamodel import config as cfg

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -185,6 +185,123 @@ def test_push_to_dbt_preserves_native_column_type(
     )
 
 
+def test_push_to_dbt_does_not_overwrite_with_catalog_normalized_type(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """dbt/the warehouse can normalize a declared type to a synonym (e.g.
+    Snowflake reports a "varchar" column as "TEXT" in the catalog). Push to
+    dbt must not use that normalized value to clobber the type already
+    declared in schema.yml, even though it now differs from the field's
+    reconciled dbt_data_type.
+    """
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+        yaml.dump(
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "users",
+                        "columns": [
+                            {
+                                "name": "name",
+                                "data_type": "varchar",
+                                "description": "Full name",
+                            }
+                        ],
+                    }
+                ],
+            },
+            f,
+        )
+
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.project.users",
+                "drafted_fields": [
+                    {
+                        "name": "name",
+                        "datatype": "text",
+                        "dbt_data_type": "TEXT",
+                        "description": "Full name",
+                        "source": "dbt",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = next(c for c in schema["models"][0]["columns"] if c["name"] == "name")
+    assert col["data_type"] == "varchar", (
+        "Push to dbt overwrote the declared type with the catalog-normalized "
+        f"type: {col['data_type']!r} (expected 'varchar')"
+    )
+
+
+def test_push_to_dbt_backfills_missing_type_for_new_dbt_column(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """A dbt-sourced column synced for the first time (no prior schema.yml
+    entry) has no existing value to preserve, so it should be backfilled
+    with the native dbt_data_type rather than left blank or set to the
+    coarse UI bucket.
+    """
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+        yaml.dump({"version": 2, "models": [{"name": "users", "columns": []}]}, f)
+
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.project.users",
+                "drafted_fields": [
+                    {
+                        "name": "name",
+                        "datatype": "text",
+                        "dbt_data_type": "TEXT",
+                        "description": "Full name",
+                        "source": "dbt",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = next(c for c in schema["models"][0]["columns"] if c["name"] == "name")
+    assert col["data_type"] == "TEXT"
+
+
 def test_round_trip_demo_origin(monkeypatch, temp_dir):
     """Demo-style project: materialize structured origin to schema.yml and read back via get_models."""
     from trellis_datamodel import config as cfg

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -147,8 +147,8 @@ def test_push_to_dbt_preserves_native_column_type(
             f,
         )
 
-    # Mirrors what reconciliation currently writes to data_model.yml: the
-    # bucketed UI datatype ("text"), not the native dbt type ("varchar").
+    # Mirrors what reconciliation writes to data_model.yml: the bucketed UI
+    # datatype ("text") alongside the preserved native dbt type ("varchar").
     data_model = {
         "version": 0.1,
         "entities": [
@@ -160,6 +160,7 @@ def test_push_to_dbt_preserves_native_column_type(
                     {
                         "name": "name",
                         "datatype": "text",
+                        "dbt_data_type": "varchar",
                         "description": "Full name",
                         "source": "dbt",
                     }

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -260,7 +260,9 @@ def test_push_to_dbt_backfills_missing_type_for_new_dbt_column(
     """A dbt-sourced column synced for the first time (no prior schema.yml
     entry) has no existing value to preserve, so it should be backfilled
     with the native dbt_data_type rather than left blank or set to the
-    coarse UI bucket.
+    coarse UI bucket. The catalog's "TEXT" spelling is canonicalized to
+    "varchar" so freshly-backfilled columns don't mix spellings with
+    hand-declared ones across schema.yml files.
     """
     sql_dir = os.path.join(temp_dir, "models", "3_core")
     os.makedirs(sql_dir, exist_ok=True)
@@ -299,7 +301,54 @@ def test_push_to_dbt_backfills_missing_type_for_new_dbt_column(
     with open(yml_path, "r") as f:
         schema = yaml.safe_load(f)
     col = next(c for c in schema["models"][0]["columns"] if c["name"] == "name")
-    assert col["data_type"] == "TEXT"
+    assert col["data_type"] == "varchar"
+
+
+def test_push_to_dbt_does_not_canonicalize_ambiguous_number_type(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """NUMBER collapses int/integer/decimal/numeric and the catalog doesn't
+    expose precision/scale, so backfilling must not guess a declared
+    spelling for it — the raw catalog value is written as-is.
+    """
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+        yaml.dump({"version": 2, "models": [{"name": "users", "columns": []}]}, f)
+
+    data_model = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.project.users",
+                "drafted_fields": [
+                    {
+                        "name": "age",
+                        "datatype": "number",
+                        "dbt_data_type": "NUMBER",
+                        "description": "Age",
+                        "source": "dbt",
+                    }
+                ],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data_model, f)
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "r") as f:
+        schema = yaml.safe_load(f)
+    col = next(c for c in schema["models"][0]["columns"] if c["name"] == "age")
+    assert col["data_type"] == "NUMBER"
 
 
 def test_round_trip_demo_origin(monkeypatch, temp_dir):

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -56,8 +56,20 @@ class TestReconcileDbtEndpoint:
                     "label": "Users",
                     "dbt_model": "model.project.users",
                     "drafted_fields": [
-                        {"name": "id", "datatype": "int", "description": "Primary key", "source": "dbt"},
-                        {"name": "name", "datatype": "text", "description": "Full name", "source": "dbt"},
+                        {
+                            "name": "id",
+                            "datatype": "int",
+                            "dbt_data_type": "integer",
+                            "description": "Primary key",
+                            "source": "dbt",
+                        },
+                        {
+                            "name": "name",
+                            "datatype": "text",
+                            "dbt_data_type": "varchar",
+                            "description": "Full name",
+                            "source": "dbt",
+                        },
                     ],
                 }
             ],

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -49,6 +49,18 @@ class TestReconcileEntityFields:
         assert result[5]["datatype"] == "text"
         assert result[6]["datatype"] == "unknown"
 
+    def test_preserves_native_dbt_type_alongside_bucket(self):
+        """The raw dbt/warehouse type is preserved in dbt_data_type, not just
+        collapsed into the coarse datatype bucket (#111)."""
+        result = reconcile_entity_fields(
+            existing_fields=[],
+            manifest_columns=[
+                {"name": "label", "type": "varchar"},
+            ],
+        )
+        assert result[0]["datatype"] == "text"
+        assert result[0]["dbt_data_type"] == "varchar"
+
     def test_promotes_matching_draft(self):
         """A draft whose name matches a manifest column is promoted to source=dbt,
         with manifest metadata overwriting the draft's values."""
@@ -260,7 +272,13 @@ class TestReconcileDataModel:
                     "id": "users",
                     "dbt_model": "model.project.users",
                     "drafted_fields": [
-                        {"name": "id", "datatype": "int", "description": "PK", "source": "dbt"}
+                        {
+                            "name": "id",
+                            "datatype": "int",
+                            "dbt_data_type": "integer",
+                            "description": "PK",
+                            "source": "dbt",
+                        }
                     ],
                 }
             ]

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -428,6 +428,11 @@ class YamlHandler:
         ``columns_data``. Columns missing from the incoming list are dropped,
         so renames/deletions in the data model propagate to schema.yml.
         Final order follows ``columns_data``.
+
+        ``data_type`` is applied as a hard override; ``data_type_fallback``
+        only fills in a column that doesn't already declare a data_type
+        (used for dbt-sourced fields, where dbt/the warehouse — not
+        Trellis — owns the declared type once it exists, see #111).
         """
         existing_by_name: Dict[str, CommentedMap] = {}
         for col in model.get("columns", []) or []:
@@ -448,7 +453,7 @@ class YamlHandler:
 
             self.update_column(
                 col,
-                data_type=col_data.get("data_type"),
+                data_type=self._resolve_data_type(col, col_data),
                 description=col_data.get("description"),
             )
             if "meta" in col_data:
@@ -456,6 +461,21 @@ class YamlHandler:
             new_columns.append(col)
 
         model["columns"] = new_columns
+
+    @staticmethod
+    def _resolve_data_type(
+        col: CommentedMap, col_data: Dict[str, Any]
+    ) -> Optional[str]:
+        """Decide the data_type to write for a column update.
+
+        ``data_type`` always wins when present. Otherwise ``data_type_fallback``
+        is applied only if the column doesn't already declare one.
+        """
+        if "data_type" in col_data:
+            return col_data.get("data_type")
+        if not col.get("data_type"):
+            return col_data.get("data_type_fallback")
+        return None
 
     def merge_columns_non_destructive(
         self,
@@ -495,7 +515,7 @@ class YamlHandler:
                 col["name"] = col_name
             self.update_column(
                 col,
-                data_type=col_data.get("data_type"),
+                data_type=self._resolve_data_type(col, col_data),
                 description=col_data.get("description"),
             )
             if "meta" in col_data:

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.1b1"
+version = "0.17.1b2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.0"
+version = "0.17.1b1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.1b2"
+version = "0.17.1b3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.1b3"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
eady spreads unknown keys through unchanged on save.

Added a regression test (`test_push_to_dbt_preserves_native_column_type`) that reproduces the bug end-to-end via the `/api/sync-dbt-tests` endpoint, plus a focused reconciliation unit test. Updated two pre-existing idempotency tests whose fixtures simulated an "already reconciled" state that predates the new field.

Scope note: this only covers *bound* entities backed by a materialized dbt model, where the manifest/catalog already supplies the exact native type. Warehouse-specific type selection for brand-new, not-yet-materialized drafted fields is tracked separately in #83.

## Test plan
- [x] `uv run pytest` — 389 passed
- [x] `npm run check` — 0 errors
- [ ] Manual: bind an entity to a model with a `varchar`/`numeric`/etc. column, click "Push to dbt", confirm `schema.yml` keeps the native type instead of `text`/`float`

Let me know if you'd like any part trimmed (e.g. drop the scope note, or the manual test line) before you paste it in.