### PR TITLE
Fix/dbt tag reconciliation

### DIFF
--- a/.cursor/project.md
+++ b/.cursor/project.md
@@ -60,6 +60,8 @@ When Trellis and dbt disagree — on column existence, data types, or descriptio
 
 **Description is the one two-way attribute** of a materialized column. Users may edit it in Trellis; it writes back to `schema.yml` directly (the live source for descriptions). All other materialized column attributes are read-only.
 
+**Tags follow the same dbt-wins philosophy, with an additive-only exception.** dbt is authoritative for tags already in `schema.yml`; on push, Trellis additively unions `trellis_tags` (tags a user adds via the UI) onto the live tag list rather than replacing it. Push is additive-only in v1 — a tag already in `schema.yml` is never removed, even a Trellis-added tag the user has since removed from `trellis_tags` (to remove it, edit `schema.yml` directly; dbt then owns it going forward). On a bound entity, `tags` is a reconcile-owned mirror of `schema.yml` — refreshed on every reconcile, never hand-edited — the same mirroring principle already applied to `source: dbt` columns.
+
 ### Differentiation
 
 Trellis unique:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,5 +29,5 @@ jobs:
           path-to-signatures: ".github/cla/signatures.json"
           path-to-document: "CLA.md"
           branch: "cla-signatures"
-          allowlist: "timhiebenthal,tim.hiebenthal@a11.global,tim.hiebenthal@project-a.com,tim@hiebenthal.com,dependabot[bot],github-actions[bot]"
+          allowlist: "timhiebenthal,tim.hiebenthal@a11.global,tim.hiebenthal@project-a.com,tim@hiebenthal.com,tim.hiebenthal@a11.com,dependabot[bot],github-actions[bot]"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0-beta.1] - 2026-07-30
+## [0.18.0b1] - 2026-07-30
 
 ### Added
 - **`trellis_tags` on bound entities**: tags a user explicitly adds via the Trellis tag editor are now tracked separately from `tags`, which becomes a dbt-mirrored, reconcile-owned field (refreshed from `schema.yml`/the manifest on every reconcile, never hand-edited) — the same authority model already applied to `source: dbt` columns. The tag editor renders dbt-mirrored tags read-only and `trellis_tags` as removable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0-beta.1] - 2026-07-30
+
+### Added
+- **`trellis_tags` on bound entities**: tags a user explicitly adds via the Trellis tag editor are now tracked separately from `tags`, which becomes a dbt-mirrored, reconcile-owned field (refreshed from `schema.yml`/the manifest on every reconcile, never hand-edited) — the same authority model already applied to `source: dbt` columns. The tag editor renders dbt-mirrored tags read-only and `trellis_tags` as removable.
+- **`YamlHandler.merge_model_tags`/`merge_version_tags`**: additive-union tag writers that read the live file fresh immediately before writing, used everywhere Trellis pushes tags to `schema.yml`.
+
+### Fixed
+- **Tags added directly to `schema.yml` no longer silently deleted by Trellis pushes**: `sync_relationships`, `save_model_schema`, and `save_dbt_schema` previously called `update_model_tags`/`update_version_tags` with a cached, potentially stale tag list, doing a full replace on every push. A tag added outside Trellis (e.g. `nightly`, added directly to `schema.yml` by a dbt developer) was wiped the next time Trellis pushed an unrelated tag change. Push now additively unions `trellis_tags` onto the current file content instead.
+
+### Changed
+- **Tag removal is additive-only in this release**: removing a tag from `trellis_tags` in the Trellis UI does not remove it from `schema.yml` on push (documented v1 scope decision — durable removal tracking would require a second, push-time-only field written back to `data_model.yml`, judged too invasive for this iteration). To remove a Trellis-added tag, edit `schema.yml` directly; dbt then owns it going forward.
+- Entities with a pre-existing `tags` value from before this change are seeded into `trellis_tags` once on first reconcile, so those tags aren't lost under the new merge logic.
+
 ## [0.17.1] - 2026-07-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-30
+
+### Added
+- **`dbt_tags`/`ui_tags` on bound entities**: `dbt_tags` mirrors `schema.yml`/the manifest, refreshed on every reconcile and never hand-edited — the same authority model already applied to `source: dbt` columns. `ui_tags` holds only tags a user explicitly adds via the Trellis tag editor. `tags` itself is no longer a persisted field on a bound entity; it's computed at read time as the union of the two (new `compute_display_tags` helper, wired into `GET /api/data-model` and the Bus Matrix endpoint). Unbound entities are unaffected — `tags` remains their single, persisted, freely-editable field.
+- **`YamlHandler.merge_model_tags`/`merge_version_tags`**: additive-union tag writers that read the live `schema.yml` fresh immediately before writing, used everywhere Trellis pushes tags to dbt.
+
+### Fixed
+- **Tags added directly to `schema.yml` no longer silently deleted by Trellis pushes**: pushing tags previously did a full replace using a cached, potentially stale list. A tag added outside Trellis (e.g. `nightly`, added directly to `schema.yml` by a dbt developer) was wiped the next time Trellis pushed an unrelated tag change. Push now additively unions `ui_tags` onto the current file content instead.
+- **Bound-entity tags silently wiped on any autosave, and on saving from the entity detail modal**: two separate write paths sent an edit without a way for the backend to tell "no change" apart from "clear it," erasing reconciled tags on routine, unrelated saves. Both fixed to only ever write `ui_tags`, never the reconcile-owned `dbt_tags`/`tags`.
+- **Migration seed copying dbt's entire tag list into `ui_tags` on a second reconcile**: the one-time legacy-tag migration couldn't tell pre-fix user data apart from tags the manifest had already mirrored in an earlier run. Now only seeds when the existing value genuinely differs from what reconciliation would produce right now.
+
+### Changed
+- **Tag removal is additive-only in this release**: removing a tag from `ui_tags` in the Trellis UI does not remove it from `schema.yml` on push. Durable removal tracking would require a second, push-time-only field distinct from the continuously-autosaved `ui_tags` — judged too invasive for this iteration. To remove a Trellis-added tag, edit `schema.yml` directly; dbt then owns it going forward.
+- Entities with a pre-existing `tags` value from before this change are seeded into `ui_tags` once on first reconcile (if it represents real legacy data, not tags already mirrored from dbt), so nothing is lost under the new logic; the legacy key is retired afterward.
+- Bulk tag add/remove and the "Generate Entities" dialog's save path are updated to the same `dbt_tags`/`ui_tags` split, closing two write paths that would otherwise have hit the same tag-loss bug.
+
 ## [0.18.0b4] - 2026-07-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0b2] - 2026-07-30
+
+### Fixed
+- **Bound-entity `tags` silently wiped on every autosave**: `_split_model_and_layout` built each entity fresh from the incoming save payload with no fallback to the on-disk value for `tags`. Since autosave correctly omits `tags` for bound entities (it's reconcile-owned; only `trellis_tags` is sent), any autosave — not just a tag edit — erased the reconciled tags. Found during real-world validation against a live dbt project. Fixed by extending the existing `roles`-preservation mechanism to `tags`, scoped to bound entities only; an unbound entity's intentional "clear all tags" via omission still works as before.
+
 ## [0.18.0b1] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0b3] - 2026-07-30
+
+### Fixed
+- **Migration seed wrongly copying dbt's entire tag list into `trellis_tags`**: the one-time seed fired whenever `trellis_tags` was absent and `tags` was non-empty, with no way to tell legacy pre-fix data apart from tags already mirrored from the manifest by an earlier reconcile run. On a second reconcile, that meant copying dbt's full tag list into `trellis_tags`, wrongly marking it as user-added and defeating the read-only/removable tag-editor split. Now only seeds when the existing value genuinely differs from what reconciliation would produce right now.
+
+### Changed
+- **Renamed `tags`/`trellis_tags` to `dbt_tags`/`ui_tags` for clarity, and `tags` is no longer persisted for bound entities at all**: the prior naming — `tags` meaning "dbt-mirrored" for bound entities but "freely editable" for unbound, and `trellis_tags` for user-added tags — caused repeated confusion about which field meant what. `dbt_tags` (dbt-owned, reconcile-refreshed) and `ui_tags` (added via the Trellis UI) are now explicit. `tags` is computed at read time as their union (new `compute_display_tags` helper, wired into `GET /api/data-model` and the Bus Matrix endpoint) and is never written back to `data_model.yml` for a bound entity — a legacy `tags` key is retired on first reconcile after upgrading. Unbound entities are unaffected: `tags` remains their single, persisted, freely-editable field.
+- Two additional write paths that duplicated the pre-fix tag-persistence logic (and would have hit the same tag-loss bug) are fixed to match: bulk tag add/remove (`bulk-operations.ts`) and the "Generate Entities" dialog's save path.
+
 ## [0.18.0b2] - 2026-07-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0b4] - 2026-07-30
+
+### Fixed
+- **Tag edits from the entity detail modal silently lost for bound entities**: `handleSave` wrote the edited tag list straight to `tags` unconditionally — a fourth write path with the same category of bug as the autosave fix in `0.18.0b2`, since `tags` is no longer persisted for bound entities at all. Reported: adding a tag via the entity detail modal and clicking "Save Changes" never showed up in `data_model.yml`. Fixed to diff the edit against `dbt_tags` and write only `ui_tags` for bound entities, matching every other tag-editing surface.
+- **CLA allowlist**: added `tim.hiebenthal@a11.com`.
+
 ## [0.18.0b3] - 2026-07-30
 
 ### Fixed

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -5,6 +5,7 @@
 	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn, OriginEntry } from '$lib/types';
 	import { mergeFields } from '$lib/utils/merged-fields';
 	import type { MergedField } from '$lib/utils/merged-fields';
+	import { computeUiTagsAfterEdit } from '$lib/utils/entity-tags';
 	import type { Node } from '@xyflow/svelte';
 	import { getContext } from 'svelte';
 	import type { AutoSaveService } from '$lib/services/auto-save';
@@ -653,6 +654,16 @@
 		nodes.update((n) => {
 			return n.map((node) => {
 				if (node.id === currentEntity.id) {
+					const isBound = Boolean(node.data?.dbt_model);
+					// Bound entities: `tags` is a computed display union and reconcile-owned
+					// `dbt_tags` is read-only — an edit here only ever changes `ui_tags`.
+					// Unbound entities: `tags` remains the single freely-editable field.
+					const tagFields = isBound
+						? { ui_tags: (() => {
+								const uiTags = computeUiTagsAfterEdit((node.data as any)?.dbt_tags, entityTags);
+								return uiTags.length > 0 ? uiTags : undefined;
+							})() }
+						: { tags: entityTags.length > 0 ? entityTags : undefined };
 					return {
 						...node,
 						data: {
@@ -661,7 +672,7 @@
 							description: entityDescription.trim() || undefined,
 							domains: normalizedDomains.length > 0 ? normalizedDomains : undefined,
 							domain: primaryDomain || undefined,
-							tags: entityTags.length > 0 ? entityTags : undefined,
+							...tagFields,
 							source_system:
 								entitySourceSystems.length > 0 ? entitySourceSystems : undefined,
 							entity_type: entityType,

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -211,6 +211,83 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
   });
 });
 
+describe('EntityDetailModal — tag save behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    nodes.set([]);
+    dbtModels.set([]);
+    entityDetailModal.set({ open: false, entityId: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  function setupBoundEntityWithTags() {
+    nodes.set([{
+      id: 'node-1',
+      type: 'entity',
+      position: { x: 0, y: 0 },
+      data: {
+        label: 'Entity X',
+        dbt_model: 'model.proj.entity_x',
+        tags: ['nightly'],
+        dbt_tags: ['nightly'],
+        ui_tags: [],
+      } as any,
+    }] as any);
+    dbtModels.set([mockDbtModel]);
+    entityDetailModal.set({ open: true, entityId: 'node-1' });
+  }
+
+  it('adding a tag and clicking Save writes it to ui_tags, not the reconcile-owned tags field', async () => {
+    setupBoundEntityWithTags();
+    await renderModal();
+
+    // Domains / Tags / Source Systems inputs all share this placeholder — Tags is index 1.
+    const tagInput = screen.getAllByPlaceholderText('Type and press Enter')[1];
+    await fireEvent.input(tagInput, { target: { value: 'pii' } });
+    await fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+    const saveButton = screen.getByText('Save Changes').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+    await fireEvent.click(saveButton);
+
+    const savedNode = get(nodes).find((n) => n.id === 'node-1');
+    expect((savedNode?.data as any).ui_tags).toEqual(['pii']);
+    expect((savedNode?.data as any).dbt_tags).toEqual(['nightly']);
+    // `tags` is a display-only union refreshed by the next reconcile/reload —
+    // handleSave doesn't need to touch it. What matters is that autosave never
+    // sends it for bound entities regardless of its (possibly stale) local
+    // value; that's proven separately in auto-save.test.ts.
+  });
+
+  it('unbound entity still saves tags directly', async () => {
+    nodes.set([{
+      id: 'node-1',
+      type: 'entity',
+      position: { x: 0, y: 0 },
+      data: { label: 'Draft Entity', tags: ['draft-tag'] } as any,
+    }] as any);
+    dbtModels.set([]);
+    entityDetailModal.set({ open: true, entityId: 'node-1' });
+    await renderModal();
+
+    const tagInput = screen.getAllByPlaceholderText('Type and press Enter')[1];
+    await fireEvent.input(tagInput, { target: { value: 'new-tag' } });
+    await fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+    const saveButton = screen.getByText('Save Changes').closest('button') as HTMLButtonElement;
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+    await fireEvent.click(saveButton);
+
+    const savedNode = get(nodes).find((n) => n.id === 'node-1');
+    expect((savedNode?.data as any).tags).toEqual(['draft-tag', 'new-tag']);
+  });
+});
+
 describe('EntityDetailModal — Relationships section', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -41,6 +41,7 @@
     } from "$lib/utils";
     import { mergeFields } from "$lib/utils/merged-fields";
     import type { MergedField } from "$lib/utils/merged-fields";
+    import { computeTrellisTagsAfterEdit } from "$lib/utils/entity-tags";
     import { getContext } from "svelte";
     import { goto } from "$app/navigation";
     import TagEditor from "./TagEditor.svelte";
@@ -630,8 +631,24 @@
     }
 
     // Tag editing functionality
-    let entityTags = $derived(normalizeTags(data.tags));
-    
+    // For bound entities, the editor displays the union of the dbt-mirrored `tags`
+    // and the Trellis-authored `trellis_tags` (Requirement 4). Unbound entities have
+    // no schema.yml to mirror, so `tags` remains the single freely-editable field.
+    let entityTags = $derived(
+        isBound
+            ? normalizeTags([...(data.tags || []), ...((data.trellis_tags || []) as string[])])
+            : normalizeTags(data.tags),
+    );
+
+    // Tags present in the dbt-mirrored list but not in trellis_tags are dbt-owned:
+    // they render read-only in the tag editor (no remove affordance) because a Trellis
+    // push never removes a tag it doesn't own. Only meaningful for bound entities.
+    let readOnlyTags = $derived.by(() => {
+        if (!isBound) return [];
+        const trellisSet = new Set(normalizeTags(data.trellis_tags));
+        return normalizeTags(data.tags).filter((t) => !trellisSet.has(t));
+    });
+
     // Roles display (for dimensions)
     // EntityRole is an object with { role, label, source } — extract the role string
     // Deduplicate case-insensitively (e.g., "Creation Date" and "creation date" should be one)
@@ -652,21 +669,23 @@
 
         allSelectedIds.forEach((nodeId) => {
             const node = $nodes.find((n) => n.id === nodeId);
-            const currentTags = normalizeTags(node?.data?.tags);
-            const currentSchemaTags = normalizeTags(node?.data?._schemaTags);
+            const nodeIsBound = !!node?.data?.dbt_model;
 
-            // For the current node and bound models, use SchemaManager
-            if (nodeId === id && isBound && schemaManager) {
-                schemaManager.updateSchemaTags(newTags);
-                updateNodeData(nodeId, {
-                    tags: newTags,
-                    _schemaTags: newTags
-                });
+            if (nodeIsBound) {
+                // `tags` is a dbt-mirrored, reconcile-owned field for bound entities
+                // (schema.yml is authoritative) — never hand-written here. An edit in the
+                // tag editor only ever changes `trellis_tags`; a dbt-mirrored tag missing
+                // from `newTags` (e.g. the user tried to remove a read-only chip) is not
+                // treated as a removal, since dbt wins.
+                const trellisTags = computeTrellisTagsAfterEdit(node?.data?.tags, newTags);
+                updateNodeData(nodeId, { trellis_tags: trellisTags });
             } else {
-                // For unbound nodes or batch editing, just update node data directly
+                // Unbound entities have no schema.yml to mirror; `tags` is the single
+                // freely-editable field, and `trellis_tags` mirrors it 1:1 (see
+                // mapEntityTagsToNodeData in entity-tags.ts).
                 updateNodeData(nodeId, {
                     tags: newTags,
-                    _schemaTags: newTags
+                    trellis_tags: newTags,
                 });
             }
         });
@@ -1295,6 +1314,7 @@
                             >Tags</span>
                             <TagEditor
                                 tags={entityTags}
+                                readOnlyTags={readOnlyTags}
                                 canEdit={true}
                                 isBatchMode={isBatchEditing}
                                 onUpdate={(newTags) => handleTagsUpdate(newTags)}
@@ -1754,6 +1774,7 @@
                                 >Tags</span>
                             <TagEditor
                                 tags={entityTags}
+                                readOnlyTags={readOnlyTags}
                                 canEdit={true}
                                 isBatchMode={isBatchEditing}
                                 onUpdate={(newTags) => handleTagsUpdate(newTags)}

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -41,7 +41,7 @@
     } from "$lib/utils";
     import { mergeFields } from "$lib/utils/merged-fields";
     import type { MergedField } from "$lib/utils/merged-fields";
-    import { computeTrellisTagsAfterEdit } from "$lib/utils/entity-tags";
+    import { computeUiTagsAfterEdit } from "$lib/utils/entity-tags";
     import { getContext } from "svelte";
     import { goto } from "$app/navigation";
     import TagEditor from "./TagEditor.svelte";
@@ -631,23 +631,19 @@
     }
 
     // Tag editing functionality
-    // For bound entities, the editor displays the union of the dbt-mirrored `tags`
-    // and the Trellis-authored `trellis_tags` (Requirement 4). Unbound entities have
-    // no schema.yml to mirror, so `tags` remains the single freely-editable field.
+    // For bound entities, the editor displays the union of the dbt-mirrored
+    // `dbt_tags` and the Trellis-authored `ui_tags`. Unbound entities have no
+    // schema.yml to mirror, so `tags` remains the single freely-editable field.
     let entityTags = $derived(
         isBound
-            ? normalizeTags([...(data.tags || []), ...((data.trellis_tags || []) as string[])])
+            ? normalizeTags([...(data.dbt_tags || []), ...((data.ui_tags || []) as string[])])
             : normalizeTags(data.tags),
     );
 
-    // Tags present in the dbt-mirrored list but not in trellis_tags are dbt-owned:
-    // they render read-only in the tag editor (no remove affordance) because a Trellis
-    // push never removes a tag it doesn't own. Only meaningful for bound entities.
-    let readOnlyTags = $derived.by(() => {
-        if (!isBound) return [];
-        const trellisSet = new Set(normalizeTags(data.trellis_tags));
-        return normalizeTags(data.tags).filter((t) => !trellisSet.has(t));
-    });
+    // dbt_tags are always dbt-owned: they render read-only in the tag editor
+    // (no remove affordance) because a Trellis push never removes a tag it
+    // doesn't own. Only meaningful for bound entities.
+    let readOnlyTags = $derived(isBound ? normalizeTags(data.dbt_tags) : []);
 
     // Roles display (for dimensions)
     // EntityRole is an object with { role, label, source } — extract the role string
@@ -672,21 +668,17 @@
             const nodeIsBound = !!node?.data?.dbt_model;
 
             if (nodeIsBound) {
-                // `tags` is a dbt-mirrored, reconcile-owned field for bound entities
-                // (schema.yml is authoritative) — never hand-written here. An edit in the
-                // tag editor only ever changes `trellis_tags`; a dbt-mirrored tag missing
-                // from `newTags` (e.g. the user tried to remove a read-only chip) is not
-                // treated as a removal, since dbt wins.
-                const trellisTags = computeTrellisTagsAfterEdit(node?.data?.tags, newTags);
-                updateNodeData(nodeId, { trellis_tags: trellisTags });
+                // `dbt_tags` is a dbt-mirrored, reconcile-owned field for bound
+                // entities (schema.yml is authoritative) — never hand-written here.
+                // An edit in the tag editor only ever changes `ui_tags`; a
+                // dbt-mirrored tag missing from `newTags` (e.g. the user tried to
+                // remove a read-only chip) is not treated as a removal, since dbt wins.
+                const uiTags = computeUiTagsAfterEdit(node?.data?.dbt_tags, newTags);
+                updateNodeData(nodeId, { ui_tags: uiTags });
             } else {
-                // Unbound entities have no schema.yml to mirror; `tags` is the single
-                // freely-editable field, and `trellis_tags` mirrors it 1:1 (see
-                // mapEntityTagsToNodeData in entity-tags.ts).
-                updateNodeData(nodeId, {
-                    tags: newTags,
-                    trellis_tags: newTags,
-                });
+                // Unbound entities have no schema.yml to mirror; `tags` is the
+                // single freely-editable field.
+                updateNodeData(nodeId, { tags: newTags });
             }
         });
     }

--- a/frontend/src/lib/components/EntityNode.test.ts
+++ b/frontend/src/lib/components/EntityNode.test.ts
@@ -3,6 +3,7 @@ import { render } from '@testing-library/svelte';
 import { dbtModels, viewMode } from '$lib/stores';
 import EntityNode from './EntityNode.svelte';
 import type { EntityData } from '$lib/types';
+import { computeTrellisTagsAfterEdit } from '$lib/utils/entity-tags';
 
 // Mock heavy dependencies
 vi.mock('@xyflow/svelte', async () => {
@@ -134,5 +135,43 @@ describe('EntityNode — merged field rendering', () => {
         trellis_tags: ['pii'],
     } as EntityData;
     expect(data.trellis_tags).toEqual(['pii']);
+  });
+});
+
+describe('EntityNode — handleTagsUpdate provenance diff (via computeTrellisTagsAfterEdit)', () => {
+  // handleTagsUpdate delegates its dbt-mirrored-vs-trellis diff to this pure helper
+  // (frontend/src/lib/utils/entity-tags.ts). Rendering the full component and asserting on
+  // useSvelteFlow()'s updateNodeData isn't viable here: the mock in this file creates a fresh
+  // vi.fn() per render with no stable handle to assert against, and — once the read-only
+  // rendering fix lands — a dbt-mirrored chip has no remove button in the DOM to click at all,
+  // so the "user tries to remove a dbt-mirrored tag" scenario can't be driven through the UI
+  // post-fix. Testing the extracted diff logic directly proves the same behavior handleTagsUpdate
+  // relies on.
+
+  it('adding a tag via handleTagsUpdate appends only to trellis_tags, leaving dbt-mirrored tags untouched', () => {
+    // Bound node: data.tags = ['nightly'] (dbt-mirrored), data.trellis_tags = [].
+    // Tag editor widget currently shows the union ['nightly'] and the user types 'pii',
+    // so onUpdate fires with newTags = ['nightly', 'pii'].
+    const dbtMirroredTags = ['nightly'];
+    const newTags = ['nightly', 'pii'];
+
+    const trellisTags = computeTrellisTagsAfterEdit(dbtMirroredTags, newTags);
+
+    // dbt-mirrored 'nightly' is not in the result — it's tracked via `tags`, not `trellis_tags`.
+    expect(trellisTags).toEqual(['pii']);
+    expect(dbtMirroredTags).toEqual(['nightly']); // unchanged — not this function's to touch
+  });
+
+  it('removing a dbt-mirrored tag from the editor is a no-op on trellis_tags', () => {
+    // Bound node: data.tags = ['nightly'], data.trellis_tags = ['pii'].
+    // User tries to drop the 'nightly' chip from the widget, so onUpdate fires with
+    // newTags = ['pii'] (nightly missing) — but nightly was never Trellis's to remove.
+    const dbtMirroredTags = ['nightly'];
+    const newTags = ['pii'];
+
+    const trellisTags = computeTrellisTagsAfterEdit(dbtMirroredTags, newTags);
+
+    // trellis_tags is still ['pii'] — the attempted removal of the dbt-mirrored tag is a no-op.
+    expect(trellisTags).toEqual(['pii']);
   });
 });

--- a/frontend/src/lib/components/EntityNode.test.ts
+++ b/frontend/src/lib/components/EntityNode.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { dbtModels, viewMode } from '$lib/stores';
 import EntityNode from './EntityNode.svelte';
+import type { EntityData } from '$lib/types';
 
 // Mock heavy dependencies
 vi.mock('@xyflow/svelte', async () => {
@@ -124,5 +125,14 @@ describe('EntityNode — merged field rendering', () => {
       b => b.title?.toLowerCase().includes('materialize') || b.getAttribute('aria-label')?.toLowerCase().includes('materialize')
     );
     expect(materializeBtns.length).toBe(0);
+  });
+
+  it('accepts trellis_tags on EntityData without a type error', () => {
+    const data: EntityData = {
+        label: 'Users',
+        tags: ['nightly'],
+        trellis_tags: ['pii'],
+    } as EntityData;
+    expect(data.trellis_tags).toEqual(['pii']);
   });
 });

--- a/frontend/src/lib/components/EntityNode.test.ts
+++ b/frontend/src/lib/components/EntityNode.test.ts
@@ -3,7 +3,7 @@ import { render } from '@testing-library/svelte';
 import { dbtModels, viewMode } from '$lib/stores';
 import EntityNode from './EntityNode.svelte';
 import type { EntityData } from '$lib/types';
-import { computeTrellisTagsAfterEdit } from '$lib/utils/entity-tags';
+import { computeUiTagsAfterEdit } from '$lib/utils/entity-tags';
 
 // Mock heavy dependencies
 vi.mock('@xyflow/svelte', async () => {
@@ -128,18 +128,20 @@ describe('EntityNode — merged field rendering', () => {
     expect(materializeBtns.length).toBe(0);
   });
 
-  it('accepts trellis_tags on EntityData without a type error', () => {
+  it('accepts dbt_tags/ui_tags on EntityData without a type error', () => {
     const data: EntityData = {
         label: 'Users',
-        tags: ['nightly'],
-        trellis_tags: ['pii'],
+        tags: ['nightly', 'pii'],
+        dbt_tags: ['nightly'],
+        ui_tags: ['pii'],
     } as EntityData;
-    expect(data.trellis_tags).toEqual(['pii']);
+    expect(data.dbt_tags).toEqual(['nightly']);
+    expect(data.ui_tags).toEqual(['pii']);
   });
 });
 
-describe('EntityNode — handleTagsUpdate provenance diff (via computeTrellisTagsAfterEdit)', () => {
-  // handleTagsUpdate delegates its dbt-mirrored-vs-trellis diff to this pure helper
+describe('EntityNode — handleTagsUpdate provenance diff (via computeUiTagsAfterEdit)', () => {
+  // handleTagsUpdate delegates its dbt-mirrored-vs-ui diff to this pure helper
   // (frontend/src/lib/utils/entity-tags.ts). Rendering the full component and asserting on
   // useSvelteFlow()'s updateNodeData isn't viable here: the mock in this file creates a fresh
   // vi.fn() per render with no stable handle to assert against, and — once the read-only
@@ -148,30 +150,30 @@ describe('EntityNode — handleTagsUpdate provenance diff (via computeTrellisTag
   // post-fix. Testing the extracted diff logic directly proves the same behavior handleTagsUpdate
   // relies on.
 
-  it('adding a tag via handleTagsUpdate appends only to trellis_tags, leaving dbt-mirrored tags untouched', () => {
-    // Bound node: data.tags = ['nightly'] (dbt-mirrored), data.trellis_tags = [].
+  it('adding a tag via handleTagsUpdate appends only to ui_tags, leaving dbt_tags untouched', () => {
+    // Bound node: data.dbt_tags = ['nightly'], data.ui_tags = [].
     // Tag editor widget currently shows the union ['nightly'] and the user types 'pii',
     // so onUpdate fires with newTags = ['nightly', 'pii'].
-    const dbtMirroredTags = ['nightly'];
+    const dbtTags = ['nightly'];
     const newTags = ['nightly', 'pii'];
 
-    const trellisTags = computeTrellisTagsAfterEdit(dbtMirroredTags, newTags);
+    const uiTags = computeUiTagsAfterEdit(dbtTags, newTags);
 
-    // dbt-mirrored 'nightly' is not in the result — it's tracked via `tags`, not `trellis_tags`.
-    expect(trellisTags).toEqual(['pii']);
-    expect(dbtMirroredTags).toEqual(['nightly']); // unchanged — not this function's to touch
+    // dbt-mirrored 'nightly' is not in the result — it's tracked via `dbt_tags`, not `ui_tags`.
+    expect(uiTags).toEqual(['pii']);
+    expect(dbtTags).toEqual(['nightly']); // unchanged — not this function's to touch
   });
 
-  it('removing a dbt-mirrored tag from the editor is a no-op on trellis_tags', () => {
-    // Bound node: data.tags = ['nightly'], data.trellis_tags = ['pii'].
+  it('removing a dbt-mirrored tag from the editor is a no-op on ui_tags', () => {
+    // Bound node: data.dbt_tags = ['nightly'], data.ui_tags = ['pii'].
     // User tries to drop the 'nightly' chip from the widget, so onUpdate fires with
     // newTags = ['pii'] (nightly missing) — but nightly was never Trellis's to remove.
-    const dbtMirroredTags = ['nightly'];
+    const dbtTags = ['nightly'];
     const newTags = ['pii'];
 
-    const trellisTags = computeTrellisTagsAfterEdit(dbtMirroredTags, newTags);
+    const uiTags = computeUiTagsAfterEdit(dbtTags, newTags);
 
-    // trellis_tags is still ['pii'] — the attempted removal of the dbt-mirrored tag is a no-op.
-    expect(trellisTags).toEqual(['pii']);
+    // ui_tags is still ['pii'] — the attempted removal of the dbt-mirrored tag is a no-op.
+    expect(uiTags).toEqual(['pii']);
   });
 });

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -965,16 +965,8 @@
                 .filter((n) => n.type === 'entity')
                 .map((n) => {
                     const displayTags = normalizeTags(n.data?.tags);
-                    const schemaTags = normalizeTags((n.data as any)?._schemaTags);
+                    const uiTags = normalizeTags((n.data as any)?.ui_tags);
                     const isBound = Boolean(n.data?.dbt_model);
-
-                    const tagsToPersist = isBound
-                        ? schemaTags.length > 0
-                            ? schemaTags
-                            : undefined
-                        : displayTags.length > 0
-                            ? displayTags
-                            : undefined;
 
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const domain = ((n.data as any)?.domain) as string | undefined;
@@ -993,7 +985,12 @@
                         width: n.data?.width as number | undefined,
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
-                        tags: tagsToPersist,
+                        // Bound entities: `dbt_tags`/`tags` mirror schema.yml and are
+                        // reconcile-owned; never hand-written here, only `ui_tags`.
+                        // Unbound entities: `tags` remains the single freely-editable field.
+                        ...(isBound
+                            ? { ui_tags: uiTags.length > 0 ? uiTags : undefined }
+                            : { tags: displayTags.length > 0 ? displayTags : undefined }),
                     };
                     // Only include entity_type for dimensional modeling
                     if (isDimensional) {

--- a/frontend/src/lib/components/TagEditor.svelte
+++ b/frontend/src/lib/components/TagEditor.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
     import { normalizeTags } from '$lib/utils';
 
-    let { tags = [], canEdit = true, isBatchMode = false, onUpdate }: {
+    let { tags = [], readOnlyTags = [], canEdit = true, isBatchMode = false, onUpdate }: {
         tags?: string[];
+        /** Tags rendered without a remove affordance regardless of `canEdit` (e.g.
+         * dbt-mirrored tags — dbt is authoritative, so Trellis never removes them). */
+        readOnlyTags?: string[];
         canEdit?: boolean;
         isBatchMode?: boolean;
         onUpdate: (newTags: string[]) => void;
@@ -12,6 +15,7 @@
     let showTagInput = $state(false);
 
     let normalizedTags = $derived(normalizeTags(tags));
+    let normalizedReadOnlyTags = $derived(new Set(normalizeTags(readOnlyTags)));
 
     function handleAddTag(tag: string) {
         const trimmed = tag.trim();
@@ -64,11 +68,17 @@
 
 <div class="tag-editor flex flex-wrap gap-1">
     {#each normalizedTags as tag}
+        {@const isReadOnly = normalizedReadOnlyTags.has(tag)}
         <div
-            class="tag flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded group"
+            class="tag flex items-center gap-1 px-2 py-0.5 text-xs rounded group"
+            class:bg-blue-50={!isReadOnly}
+            class:text-blue-700={!isReadOnly}
+            class:bg-gray-100={isReadOnly}
+            class:text-gray-600={isReadOnly}
+            title={isReadOnly ? 'Managed by dbt (schema.yml) — cannot be removed here' : undefined}
         >
             {tag}
-            {#if canEdit}
+            {#if canEdit && !isReadOnly}
                 <button
                     onmousedown={(e) => e.preventDefault()}
                     onclick={() => handleRemoveTag(tag)}

--- a/frontend/src/lib/services/auto-save.test.ts
+++ b/frontend/src/lib/services/auto-save.test.ts
@@ -465,7 +465,7 @@ describe('AutoSaveService', () => {
             expect(dataModelArg.entities[0].id).toBe('entity1');
         });
 
-        it('persists trellis_tags for a bound entity instead of guessing via _schemaTags', () => {
+        it('persists ui_tags for a bound entity, never the reconcile-owned tags field', () => {
             const nodes: Node[] = [
                 {
                     id: 'entity1',
@@ -474,8 +474,9 @@ describe('AutoSaveService', () => {
                     data: {
                         label: 'Entity 1',
                         dbt_model: 'model1',
-                        tags: ['nightly'],
-                        trellis_tags: ['pii'],
+                        tags: ['nightly', 'pii'],
+                        dbt_tags: ['nightly'],
+                        ui_tags: ['pii'],
                     },
                 },
             ];
@@ -487,10 +488,11 @@ describe('AutoSaveService', () => {
             const dataModelArg = vi.mocked(apiSaveDataModel).mock.calls[0][0];
             const entity = dataModelArg.entities[0];
 
-            // Bound entities persist trellis_tags; the mirrored `tags` field is
-            // reconcile-owned and must never be hand-written by autosave.
-            expect(entity.trellis_tags).toEqual(['pii']);
+            // Bound entities persist ui_tags; the mirrored `tags`/`dbt_tags` fields
+            // are reconcile-owned and must never be hand-written by autosave.
+            expect(entity.ui_tags).toEqual(['pii']);
             expect(entity.tags).toBeUndefined();
+            expect(entity.dbt_tags).toBeUndefined();
         });
 
         it('unbound entity still persists tags as the single freely-editable field', () => {

--- a/frontend/src/lib/services/auto-save.test.ts
+++ b/frontend/src/lib/services/auto-save.test.ts
@@ -465,7 +465,7 @@ describe('AutoSaveService', () => {
             expect(dataModelArg.entities[0].id).toBe('entity1');
         });
 
-        it('should handle bound model entities', () => {
+        it('persists trellis_tags for a bound entity instead of guessing via _schemaTags', () => {
             const nodes: Node[] = [
                 {
                     id: 'entity1',
@@ -474,8 +474,8 @@ describe('AutoSaveService', () => {
                     data: {
                         label: 'Entity 1',
                         dbt_model: 'model1',
-                        tags: ['tag1'],
-                        _schemaTags: ['schema-tag'],
+                        tags: ['nightly'],
+                        trellis_tags: ['pii'],
                     },
                 },
             ];
@@ -487,8 +487,33 @@ describe('AutoSaveService', () => {
             const dataModelArg = vi.mocked(apiSaveDataModel).mock.calls[0][0];
             const entity = dataModelArg.entities[0];
 
-            // Bound entities should persist only schema tags
-            expect(entity.tags).toEqual(['schema-tag']);
+            // Bound entities persist trellis_tags; the mirrored `tags` field is
+            // reconcile-owned and must never be hand-written by autosave.
+            expect(entity.trellis_tags).toEqual(['pii']);
+            expect(entity.tags).toBeUndefined();
+        });
+
+        it('unbound entity still persists tags as the single freely-editable field', () => {
+            const nodes: Node[] = [
+                {
+                    id: 'entity1',
+                    type: 'entity',
+                    position: { x: 0, y: 0 },
+                    data: {
+                        label: 'Entity 1',
+                        tags: ['draft-tag'],
+                    },
+                },
+            ];
+            const edges: Edge[] = [];
+
+            service.save(nodes, edges);
+            vi.advanceTimersByTime(400);
+
+            const dataModelArg = vi.mocked(apiSaveDataModel).mock.calls[0][0];
+            const entity = dataModelArg.entities[0];
+
+            expect(entity.tags).toEqual(['draft-tag']);
         });
 
         it('should handle unbound model entities', () => {

--- a/frontend/src/lib/services/auto-save.ts
+++ b/frontend/src/lib/services/auto-save.ts
@@ -244,7 +244,7 @@ export class AutoSaveService {
                 .map((n) => {
                     const displayTags = normalizeTags(n.data?.tags);
                     const isBound = Boolean(n.data?.dbt_model);
-                    const trellisTags = normalizeTags((n.data as any)?.trellis_tags);
+                    const uiTags = normalizeTags((n.data as any)?.ui_tags);
 
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const annotation_type = ((n.data as any)?.annotation_type) as string | undefined;
@@ -263,11 +263,12 @@ export class AutoSaveService {
                         width: n.data?.width as number | undefined,
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
-                        // Bound entities: `tags` mirrors schema.yml and is reconcile-owned;
-                        // autosave must never write it, only `trellis_tags` (user-added).
-                        // Unbound entities: `tags` remains the single freely-editable field.
+                        // Bound entities: `dbt_tags`/`tags` mirror schema.yml and are
+                        // reconcile-owned; autosave must never write them, only
+                        // `ui_tags` (user-added). Unbound entities: `tags` remains
+                        // the single freely-editable field.
                         ...(isBound
-                            ? { trellis_tags: trellisTags.length > 0 ? trellisTags : undefined }
+                            ? { ui_tags: uiTags.length > 0 ? uiTags : undefined }
                             : { tags: displayTags.length > 0 ? displayTags : undefined }),
                     };
                     // Only include entity_type for dimensional modeling

--- a/frontend/src/lib/services/auto-save.ts
+++ b/frontend/src/lib/services/auto-save.ts
@@ -243,18 +243,8 @@ export class AutoSaveService {
                 .filter((n) => n.type === 'entity')
                 .map((n) => {
                     const displayTags = normalizeTags(n.data?.tags);
-                    const schemaTags = normalizeTags((n.data as any)?._schemaTags);
                     const isBound = Boolean(n.data?.dbt_model);
-
-                    // For bound models, persist only explicit schema tags (user-defined).
-                    // Inherited/manifest tags live in _manifestTags and should not be written back.
-                    const tagsToPersist = isBound
-                        ? schemaTags.length > 0
-                            ? schemaTags
-                            : undefined
-                        : displayTags.length > 0
-                            ? displayTags
-                            : undefined;
+                    const trellisTags = normalizeTags((n.data as any)?.trellis_tags);
 
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const annotation_type = ((n.data as any)?.annotation_type) as string | undefined;
@@ -273,8 +263,12 @@ export class AutoSaveService {
                         width: n.data?.width as number | undefined,
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
-                        // Persist display tags only; schema writes rely on _schemaTags.
-                        tags: tagsToPersist,
+                        // Bound entities: `tags` mirrors schema.yml and is reconcile-owned;
+                        // autosave must never write it, only `trellis_tags` (user-added).
+                        // Unbound entities: `tags` remains the single freely-editable field.
+                        ...(isBound
+                            ? { trellis_tags: trellisTags.length > 0 ? trellisTags : undefined }
+                            : { tags: displayTags.length > 0 ? displayTags : undefined }),
                     };
                     // Only include entity_type for dimensional modeling
                     if (isDimensional) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -60,6 +60,7 @@ export interface EntityData {
     collapsed?: boolean;
     folder?: string; // relative folder path (excluding main path)
     tags?: string[];
+    trellis_tags?: string[]; // Tags explicitly added by the user via the Trellis tag editor (separate from dbt-mirrored `tags`)
     entity_type?: "fact" | "dimension" | "unclassified"; // Entity type for dimensional modeling
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)
     source_system?: string[]; // Array of source system names (bound = derived from lineage, unbound = persisted)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -59,16 +59,17 @@ export interface EntityData {
     panelHeight?: number;
     collapsed?: boolean;
     folder?: string; // relative folder path (excluding main path)
+    // For a bound entity, `tags` is a computed display union (dbt_tags + ui_tags)
+    // sent by the backend — never persisted, never hand-edited. Unbound entities
+    // persist `tags` directly as their single, freely-editable field.
     tags?: string[];
-    trellis_tags?: string[]; // Tags explicitly added by the user via the Trellis tag editor (separate from dbt-mirrored `tags`)
+    dbt_tags?: string[]; // Bound entities only: dbt-mirrored, reconcile-owned, read-only
+    ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified"; // Entity type for dimensional modeling
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)
     source_system?: string[]; // Array of source system names (bound = derived from lineage, unbound = persisted)
     domain?: string; // Optional business domain (supports entities created outside business events)
     domains?: string[]; // Optional multi-domain assignment (dimension can belong to many)
-    // Internal tracking for tag sources (not persisted to YAML)
-    _schemaTags?: string[]; // Tags explicitly defined in schema.yml
-    _manifestTags?: string[]; // Tags from manifest (may include inherited tags)
 }
 
 /**
@@ -86,7 +87,9 @@ export interface Entity {
     width?: number;
     panel_height?: number;
     collapsed?: boolean;
-    tags?: string[];
+    tags?: string[]; // Unbound entities only: single, freely-editable field
+    dbt_tags?: string[]; // Bound entities only: dbt-mirrored, reconcile-owned
+    ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified";
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)
     source_system?: string[]; // Only for unbound entities (mock sources)

--- a/frontend/src/lib/utils/bulk-operations.test.ts
+++ b/frontend/src/lib/utils/bulk-operations.test.ts
@@ -292,6 +292,49 @@ describe('bulk-operations', () => {
 			const updatedNodes = get(nodesStore);
 			expect(updatedNodes[0].data.tags).toEqual(['pii']); // Replaces invalid value
 		});
+
+		it('writes to ui_tags for a bound entity, never the reconcile-owned tags field', () => {
+			const nodes: Node[] = [
+				{
+					...createEntityNode('1', 'Customer'),
+					data: {
+						label: 'Customer',
+						dbt_model: 'model.proj.customer',
+						tags: ['nightly'],
+						dbt_tags: ['nightly'],
+						ui_tags: [],
+					},
+				},
+			];
+			nodesStore.set(nodes);
+
+			bulkAddTags(['1'], ['pii']);
+
+			const updatedNodes = get(nodesStore);
+			expect(updatedNodes[0].data.ui_tags).toEqual(['pii']);
+			expect(updatedNodes[0].data.tags).toEqual(['nightly']);
+			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
+		});
+
+		it('adding a tag already owned by dbt is a no-op on ui_tags for a bound entity', () => {
+			const nodes: Node[] = [
+				{
+					...createEntityNode('1', 'Customer'),
+					data: {
+						label: 'Customer',
+						dbt_model: 'model.proj.customer',
+						dbt_tags: ['nightly'],
+						ui_tags: [],
+					},
+				},
+			];
+			nodesStore.set(nodes);
+
+			bulkAddTags(['1'], ['nightly']);
+
+			const updatedNodes = get(nodesStore);
+			expect(updatedNodes[0].data.ui_tags).toEqual([]);
+		});
 	});
 
 	describe('bulkRemoveTags', () => {
@@ -429,6 +472,50 @@ describe('bulk-operations', () => {
 			const updatedNodes = get(nodesStore);
 			// Should not crash, tags remain unchanged (not an array)
 			expect(updatedNodes[0].data.tags).toBe('not-an-array');
+		});
+
+		it('removes from ui_tags for a bound entity, never touching dbt_tags/tags', () => {
+			const nodes: Node[] = [
+				{
+					...createEntityNode('1', 'Customer'),
+					data: {
+						label: 'Customer',
+						dbt_model: 'model.proj.customer',
+						tags: ['nightly', 'pii'],
+						dbt_tags: ['nightly'],
+						ui_tags: ['pii'],
+					},
+				},
+			];
+			nodesStore.set(nodes);
+
+			bulkRemoveTags(['1'], ['pii']);
+
+			const updatedNodes = get(nodesStore);
+			expect(updatedNodes[0].data.ui_tags).toBeUndefined();
+			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
+			expect(updatedNodes[0].data.tags).toEqual(['nightly', 'pii']);
+		});
+
+		it('removing a dbt-owned tag from a bound entity is a no-op — it was never in ui_tags', () => {
+			const nodes: Node[] = [
+				{
+					...createEntityNode('1', 'Customer'),
+					data: {
+						label: 'Customer',
+						dbt_model: 'model.proj.customer',
+						dbt_tags: ['nightly'],
+						ui_tags: ['pii'],
+					},
+				},
+			];
+			nodesStore.set(nodes);
+
+			bulkRemoveTags(['1'], ['nightly']);
+
+			const updatedNodes = get(nodesStore);
+			expect(updatedNodes[0].data.ui_tags).toEqual(['pii']);
+			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
 		});
 	});
 

--- a/frontend/src/lib/utils/bulk-operations.ts
+++ b/frontend/src/lib/utils/bulk-operations.ts
@@ -46,6 +46,12 @@ export function bulkAssignDomain(entityIds: string[], domain: string): void {
  * Bulk add tags to multiple entities
  * Avoids duplicates within each entity's tag list
  * Updates nodes store in-place, calls pushHistory() once for undo/redo
+ *
+ * Bound entities have no `tags` field to write — it's a reconcile-owned,
+ * computed display union. Additions there go to `ui_tags` instead (skipping
+ * any tag already dbt-owned, since that's not the user's to track). Unbound
+ * entities keep using plain `tags`, their single freely-editable field.
+ *
  * @param entityIds - Array of entity IDs to update
  * @param tagsToAdd - Array of tags to add
  */
@@ -57,12 +63,15 @@ export function bulkAddTags(entityIds: string[], tagsToAdd: string[]): void {
 
 	const updatedNodes = currentNodes.map((node) => {
 		if (entityIds.includes(node.id) && node.type === 'entity') {
-			const currentTags = node.data?.tags || [];
+			const isBound = Boolean(node.data?.dbt_model);
+			const tagField = isBound ? 'ui_tags' : 'tags';
+			const dbtTags: string[] = isBound ? ((node.data as any)?.dbt_tags || []) : [];
+			const currentTags = (node.data as any)?.[tagField] || [];
 			const newTags = Array.isArray(currentTags) ? [...currentTags] : [];
 
-			// Add tags, avoiding duplicates
+			// Add tags, avoiding duplicates and tags already dbt-owned
 			for (const tag of tagsToAdd) {
-				if (!newTags.includes(tag)) {
+				if (!newTags.includes(tag) && !dbtTags.includes(tag)) {
 					newTags.push(tag);
 					modified = true;
 				}
@@ -72,7 +81,7 @@ export function bulkAddTags(entityIds: string[], tagsToAdd: string[]): void {
 				...node,
 				data: {
 					...node.data,
-					tags: newTags.length > 0 ? newTags : undefined,
+					[tagField]: newTags.length > 0 ? newTags : undefined,
 				},
 			};
 		}
@@ -88,6 +97,12 @@ export function bulkAddTags(entityIds: string[], tagsToAdd: string[]): void {
 /**
  * Bulk remove tags from multiple entities
  * Updates nodes store in-place, calls pushHistory() once for undo/redo
+ *
+ * Bound entities: removal only ever affects `ui_tags` — a dbt-owned tag in
+ * `tagsToRemove` naturally has no effect, since it was never in `ui_tags` to
+ * begin with (dbt wins; removing it is a schema.yml-side operation).
+ * Unbound entities keep using plain `tags`.
+ *
  * @param entityIds - Array of entity IDs to update
  * @param tagsToRemove - Array of tags to remove
  */
@@ -99,19 +114,21 @@ export function bulkRemoveTags(entityIds: string[], tagsToRemove: string[]): voi
 
 	const updatedNodes = currentNodes.map((node) => {
 		if (entityIds.includes(node.id) && node.type === 'entity') {
-			const currentTags = node.data?.tags;
+			const isBound = Boolean(node.data?.dbt_model);
+			const tagField = isBound ? 'ui_tags' : 'tags';
+			const currentTags = (node.data as any)?.[tagField];
 			if (!Array.isArray(currentTags)) return node;
 
 			// If current tags array is empty, set to undefined
 			if (currentTags.length === 0) {
-				if (node.data?.tags !== undefined) {
+				if ((node.data as any)?.[tagField] !== undefined) {
 					modified = true;
 				}
 				return {
 					...node,
 					data: {
 						...node.data,
-						tags: undefined,
+						[tagField]: undefined,
 					},
 				};
 			}
@@ -128,7 +145,7 @@ export function bulkRemoveTags(entityIds: string[], tagsToRemove: string[]): voi
 				...node,
 				data: {
 					...node.data,
-					tags: newTags.length > 0 ? newTags : undefined,
+					[tagField]: newTags.length > 0 ? newTags : undefined,
 				},
 			};
 		}

--- a/frontend/src/lib/utils/entity-tags.test.ts
+++ b/frontend/src/lib/utils/entity-tags.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { mapEntityTagsToNodeData } from './entity-tags';
+
+describe('mapEntityTagsToNodeData', () => {
+    it('splits dbt-mirrored tags and trellis_tags for a bound entity without resetting trellis_tags', () => {
+        const entity = { dbt_model: 'model.proj.users', tags: ['nightly'], trellis_tags: ['pii'] };
+        const result = mapEntityTagsToNodeData(entity);
+        expect(result.tags).toEqual(['nightly']);
+        expect(result.trellis_tags).toEqual(['pii']);
+    });
+
+    it('defaults trellis_tags to [] only when genuinely absent', () => {
+        const entity = { dbt_model: 'model.proj.users', tags: ['nightly'] };
+        const result = mapEntityTagsToNodeData(entity);
+        expect(result.trellis_tags).toEqual([]);
+    });
+
+    it('unbound entity treats tags as the single freely-editable field', () => {
+        const entity = { tags: ['draft-tag'] };
+        const result = mapEntityTagsToNodeData(entity);
+        expect(result.tags).toEqual(['draft-tag']);
+        expect(result.trellis_tags).toEqual(['draft-tag']);
+    });
+});

--- a/frontend/src/lib/utils/entity-tags.test.ts
+++ b/frontend/src/lib/utils/entity-tags.test.ts
@@ -1,24 +1,41 @@
 import { describe, it, expect } from 'vitest';
-import { mapEntityTagsToNodeData } from './entity-tags';
+import { mapEntityTagsToNodeData, computeUiTagsAfterEdit } from './entity-tags';
 
 describe('mapEntityTagsToNodeData', () => {
-    it('splits dbt-mirrored tags and trellis_tags for a bound entity without resetting trellis_tags', () => {
-        const entity = { dbt_model: 'model.proj.users', tags: ['nightly'], trellis_tags: ['pii'] };
+    it('splits dbt_tags and ui_tags for a bound entity, plus the display tags union', () => {
+        const entity = { dbt_model: 'model.proj.users', tags: ['nightly', 'pii'], dbt_tags: ['nightly'], ui_tags: ['pii'] };
         const result = mapEntityTagsToNodeData(entity);
-        expect(result.tags).toEqual(['nightly']);
-        expect(result.trellis_tags).toEqual(['pii']);
+        expect(result.tags).toEqual(['nightly', 'pii']);
+        expect(result.dbt_tags).toEqual(['nightly']);
+        expect(result.ui_tags).toEqual(['pii']);
     });
 
-    it('defaults trellis_tags to [] only when genuinely absent', () => {
+    it('defaults dbt_tags/ui_tags to [] only when genuinely absent', () => {
         const entity = { dbt_model: 'model.proj.users', tags: ['nightly'] };
         const result = mapEntityTagsToNodeData(entity);
-        expect(result.trellis_tags).toEqual([]);
+        expect(result.dbt_tags).toEqual([]);
+        expect(result.ui_tags).toEqual([]);
     });
 
-    it('unbound entity treats tags as the single freely-editable field', () => {
+    it('unbound entity treats tags as the single freely-editable field, dbt_tags/ui_tags unused', () => {
         const entity = { tags: ['draft-tag'] };
         const result = mapEntityTagsToNodeData(entity);
         expect(result.tags).toEqual(['draft-tag']);
-        expect(result.trellis_tags).toEqual(['draft-tag']);
+        expect(result.dbt_tags).toEqual([]);
+        expect(result.ui_tags).toEqual([]);
+    });
+});
+
+describe('computeUiTagsAfterEdit', () => {
+    it('appends only the delta not already dbt-mirrored', () => {
+        expect(computeUiTagsAfterEdit(['nightly'], ['nightly', 'pii'])).toEqual(['pii']);
+    });
+
+    it('removing a dbt-mirrored tag from the widget is a no-op — it is not tracked as a removal', () => {
+        expect(computeUiTagsAfterEdit(['nightly'], ['pii'])).toEqual(['pii']);
+    });
+
+    it('removing a ui tag is reflected since the diff is keyed off newTags alone', () => {
+        expect(computeUiTagsAfterEdit(['nightly'], [])).toEqual([]);
     });
 });

--- a/frontend/src/lib/utils/entity-tags.ts
+++ b/frontend/src/lib/utils/entity-tags.ts
@@ -1,28 +1,36 @@
 import { normalizeTags } from '$lib/utils';
 
-export function mapEntityTagsToNodeData(entity: { dbt_model?: string; tags?: unknown; trellis_tags?: unknown }): {
+/**
+ * Split an entity's tag fields into node data. `tags` is the backend-computed
+ * display union (dbt_tags + ui_tags) for bound entities — read-only, never
+ * hand-edited. `dbt_tags`/`ui_tags` are only meaningful for bound entities;
+ * unbound entities have no schema.yml to mirror and use plain `tags` as their
+ * single, freely-editable field instead.
+ */
+export function mapEntityTagsToNodeData(entity: { dbt_model?: string; tags?: unknown; dbt_tags?: unknown; ui_tags?: unknown }): {
     tags: string[];
-    trellis_tags: string[];
+    dbt_tags: string[];
+    ui_tags: string[];
 } {
     const tags = normalizeTags(entity.tags);
     if (!entity.dbt_model) {
-        return { tags, trellis_tags: tags };
+        return { tags, dbt_tags: [], ui_tags: [] };
     }
-    return { tags, trellis_tags: normalizeTags(entity.trellis_tags) };
+    return { tags, dbt_tags: normalizeTags(entity.dbt_tags), ui_tags: normalizeTags(entity.ui_tags) };
 }
 
 /**
- * Given the tags currently mirrored from dbt (schema.yml) and the full tag list a
- * user's edit in the tag-editor widget implies (`newTags` — the widget's post-edit
- * state), compute the resulting `trellis_tags`.
+ * Given a bound entity's dbt-mirrored tags and the full tag list a user's edit
+ * in the tag-editor widget implies (`newTags` — the widget's post-edit state),
+ * compute the resulting `ui_tags`.
  *
  * Only tags not already dbt-mirrored are Trellis's to track: a dbt-mirrored tag is
  * never removable via this path (dbt wins), so its absence from `newTags` — e.g. a
  * user trying to drop a read-only chip — is not treated as a removal. Anything the
- * user actually removed from `trellis_tags` (tags absent from `newTags` that aren't
+ * user actually removed from `ui_tags` (tags absent from `newTags` that aren't
  * dbt-mirrored either) is dropped, since the diff is keyed off `newTags` alone.
  */
-export function computeTrellisTagsAfterEdit(dbtMirroredTags: unknown, newTags: unknown): string[] {
-    const dbtMirrored = new Set(normalizeTags(dbtMirroredTags));
+export function computeUiTagsAfterEdit(dbtTags: unknown, newTags: unknown): string[] {
+    const dbtMirrored = new Set(normalizeTags(dbtTags));
     return normalizeTags(newTags).filter((t) => !dbtMirrored.has(t));
 }

--- a/frontend/src/lib/utils/entity-tags.ts
+++ b/frontend/src/lib/utils/entity-tags.ts
@@ -10,3 +10,19 @@ export function mapEntityTagsToNodeData(entity: { dbt_model?: string; tags?: unk
     }
     return { tags, trellis_tags: normalizeTags(entity.trellis_tags) };
 }
+
+/**
+ * Given the tags currently mirrored from dbt (schema.yml) and the full tag list a
+ * user's edit in the tag-editor widget implies (`newTags` — the widget's post-edit
+ * state), compute the resulting `trellis_tags`.
+ *
+ * Only tags not already dbt-mirrored are Trellis's to track: a dbt-mirrored tag is
+ * never removable via this path (dbt wins), so its absence from `newTags` — e.g. a
+ * user trying to drop a read-only chip — is not treated as a removal. Anything the
+ * user actually removed from `trellis_tags` (tags absent from `newTags` that aren't
+ * dbt-mirrored either) is dropped, since the diff is keyed off `newTags` alone.
+ */
+export function computeTrellisTagsAfterEdit(dbtMirroredTags: unknown, newTags: unknown): string[] {
+    const dbtMirrored = new Set(normalizeTags(dbtMirroredTags));
+    return normalizeTags(newTags).filter((t) => !dbtMirrored.has(t));
+}

--- a/frontend/src/lib/utils/entity-tags.ts
+++ b/frontend/src/lib/utils/entity-tags.ts
@@ -1,0 +1,12 @@
+import { normalizeTags } from '$lib/utils';
+
+export function mapEntityTagsToNodeData(entity: { dbt_model?: string; tags?: unknown; trellis_tags?: unknown }): {
+    tags: string[];
+    trellis_tags: string[];
+} {
+    const tags = normalizeTags(entity.tags);
+    if (!entity.dbt_model) {
+        return { tags, trellis_tags: tags };
+    }
+    return { tags, trellis_tags: normalizeTags(entity.trellis_tags) };
+}

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -602,7 +602,7 @@ import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
                 // Map data model to Svelte Flow format with metadata
                 const entityNodes = (dataModel.entities || []).map((e: any) => {
                     const metadata = getEntityMetadata(e);
-                    const { tags, trellis_tags } = mapEntityTagsToNodeData(e);
+                    const { tags, dbt_tags, ui_tags } = mapEntityTagsToNodeData(e);
                     const modelName = metadata.model ? metadata.model.name : e.id;
                     return {
                         id: e.id,
@@ -620,7 +620,8 @@ import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
                             collapsed: e.collapsed ?? false,
                             folder: metadata.folder,
                             tags,
-                            trellis_tags,
+                            dbt_tags,
+                            ui_tags,
                             entity_type: e.entity_type,
                             source_system: e.source_system,
                             annotation_type: e.annotation_type,

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -45,6 +45,7 @@ import {
     formatModelNameForLabel,
     getLabelPrefixesFromConfig,
 } from "$lib/utils";
+import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
     import { applyDagreLayout } from "$lib/layout";
     import Sidebar from "$lib/components/Sidebar.svelte";
     import ConfigInfoModal from "$lib/components/ConfigInfoModal.svelte";
@@ -601,8 +602,7 @@ import {
                 // Map data model to Svelte Flow format with metadata
                 const entityNodes = (dataModel.entities || []).map((e: any) => {
                     const metadata = getEntityMetadata(e);
-                    const entityTags = normalizeTags(e.tags);
-                    const hasDbtBinding = Boolean(e.dbt_model);
+                    const { tags, trellis_tags } = mapEntityTagsToNodeData(e);
                     const modelName = metadata.model ? metadata.model.name : e.id;
                     return {
                         id: e.id,
@@ -619,9 +619,8 @@ import {
                             panelHeight: e.panel_height ?? e.panelHeight ?? 200,
                             collapsed: e.collapsed ?? false,
                             folder: metadata.folder,
-                            tags: entityTags,
-                            _schemaTags: hasDbtBinding ? [] : entityTags,
-                            _manifestTags: hasDbtBinding ? entityTags : [],
+                            tags,
+                            trellis_tags,
                             entity_type: e.entity_type,
                             source_system: e.source_system,
                             annotation_type: e.annotation_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0b3"
+version = "0.18.0b4"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0-beta.1"
+version = "0.18.0b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0b2"
+version = "0.18.0b3"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.17.1"
+version = "0.18.0-beta.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0b4"
+version = "0.18.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0b1"
+version = "0.18.0b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -671,7 +671,12 @@ class DbtCoreAdapter:
         tags: Optional[list[str]] = None,
         version: Optional[int] = None,
     ) -> Path:
-        """Save/update the schema definition for a model."""
+        """Save/update the schema definition for a model.
+
+        `tags`, when provided, are Trellis-authored tags to additively union
+        onto whatever is already in schema.yml — never a full replacement of
+        the live tag list.
+        """
         if not os.path.exists(self.manifest_path):
             raise FileNotFoundError(f"Manifest not found at {self.manifest_path}")
 
@@ -711,7 +716,7 @@ class DbtCoreAdapter:
             self.yaml_handler.update_columns_batch(version_entry, columns)
 
             if tags is not None:
-                self.yaml_handler.update_version_tags(version_entry, tags)
+                self.yaml_handler.merge_version_tags(version_entry, tags)
         else:
             # Non-versioned model
             if description is not None:
@@ -720,7 +725,7 @@ class DbtCoreAdapter:
             self.yaml_handler.update_columns_batch(model_entry, columns)
 
             if tags is not None:
-                self.yaml_handler.update_model_tags(model_entry, tags)
+                self.yaml_handler.merge_model_tags(model_entry, tags)
 
         self.yaml_handler.save_file(yml_path, data)
         return Path(yml_path)
@@ -1072,9 +1077,9 @@ class DbtCoreAdapter:
                 )
 
             # Sync Tags
-            entity_tags = entity.get("tags")
-            if entity_tags is not None:
-                self.yaml_handler.update_model_tags(model_entry, entity_tags)
+            trellis_tags = entity.get("trellis_tags")
+            if trellis_tags is not None:
+                self.yaml_handler.merge_model_tags(model_entry, trellis_tags)
 
             # Sync Drafted Fields. When drafted_fields is provided we treat it as
             # the authoritative column list — fields removed/renamed in the data
@@ -1170,6 +1175,10 @@ class DbtCoreAdapter:
         Generate and save a dbt schema YAML file for drafted fields.
 
         This is used for creating new schema files from the data model editor.
+
+        `tags`, when provided, are Trellis-authored tags to additively union
+        onto whatever is already in schema.yml — never a full replacement of
+        the live tag list.
         """
         data_model = self._load_data_model()
 
@@ -1309,7 +1318,7 @@ class DbtCoreAdapter:
                     version_entry, entity_description
                 )
             if tags is not None:
-                self.yaml_handler.update_version_tags(version_entry, tags)
+                self.yaml_handler.merge_version_tags(version_entry, tags)
 
             schema_entry = version_entry
         else:
@@ -1322,7 +1331,7 @@ class DbtCoreAdapter:
             self.yaml_handler.merge_columns_non_destructive(model_entry, columns)
 
             if tags is not None:
-                self.yaml_handler.update_model_tags(model_entry, tags)
+                self.yaml_handler.merge_model_tags(model_entry, tags)
 
             schema_entry = model_entry
 

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -1077,9 +1077,9 @@ class DbtCoreAdapter:
                 )
 
             # Sync Tags
-            trellis_tags = entity.get("trellis_tags")
-            if trellis_tags is not None:
-                self.yaml_handler.merge_model_tags(model_entry, trellis_tags)
+            ui_tags = entity.get("ui_tags")
+            if ui_tags is not None:
+                self.yaml_handler.merge_model_tags(model_entry, ui_tags)
 
             # Sync Drafted Fields. When drafted_fields is provided we treat it as
             # the authoritative column list — fields removed/renamed in the data

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -334,6 +334,18 @@ def _split_model_and_layout(
             if existing_entity_id and "roles" in existing_entity:
                 existing_roles_by_id[existing_entity_id] = existing_entity.get("roles")
 
+    # Preserve a bound entity's reconcile-owned `tags` when auto-save omits it.
+    # `tags` mirrors schema.yml and is never intentionally sent by auto-save.ts
+    # for bound entities (only trellis_tags is) — omission here must not be
+    # read as "clear it", unlike unbound entities where tags is freely editable
+    # and an omission does mean the user cleared it.
+    existing_tags_by_id: Dict[str, Any] = {}
+    if existing_model_data:
+        for existing_entity in existing_model_data.get("entities", []):
+            existing_entity_id = existing_entity.get("id")
+            if existing_entity_id and "tags" in existing_entity:
+                existing_tags_by_id[existing_entity_id] = existing_entity.get("tags")
+
     # Split entities
     entities = content.get("entities", [])
     seen_entity_ids: set = set()
@@ -366,6 +378,8 @@ def _split_model_and_layout(
             model_entity["drafted_fields"] = drafted_fields
         if "tags" in entity:
             model_entity["tags"] = entity["tags"]
+        elif entity.get("dbt_model") and entity_id in existing_tags_by_id:
+            model_entity["tags"] = existing_tags_by_id[entity_id]
         if "trellis_tags" in entity:
             model_entity["trellis_tags"] = entity["trellis_tags"]
         if "domain" in entity:

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -366,6 +366,8 @@ def _split_model_and_layout(
             model_entity["drafted_fields"] = drafted_fields
         if "tags" in entity:
             model_entity["tags"] = entity["tags"]
+        if "trellis_tags" in entity:
+            model_entity["trellis_tags"] = entity["trellis_tags"]
         if "domain" in entity:
             model_entity["domain"] = entity["domain"]
         if "domains" in entity:

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -8,6 +8,7 @@ from trellis_datamodel import config as cfg
 from trellis_datamodel.exceptions import ValidationError
 from trellis_datamodel.models.schemas import DataModelUpdate
 from trellis_datamodel.services.lineage import extract_source_systems_for_model
+from trellis_datamodel.services.reconciliation import compute_display_tags
 from trellis_datamodel.adapters import get_adapter
 from trellis_datamodel.utils.yaml_handler import YamlHandler
 from trellis_datamodel.utils.origin import parse_origin
@@ -252,6 +253,11 @@ async def get_data_model():
             dbt_model = entity.get("dbt_model")
             additional_models = entity.get("additional_models", [])
 
+            # `tags` for display/export is computed here, never persisted:
+            # the union of dbt_tags + ui_tags for bound entities, or the
+            # entity's own `tags` field for unbound entities.
+            entity["tags"] = compute_display_tags(entity)
+
             if dbt_model:
                 # Bound entity: extract source systems from lineage
                 # Extract for primary model
@@ -334,17 +340,17 @@ def _split_model_and_layout(
             if existing_entity_id and "roles" in existing_entity:
                 existing_roles_by_id[existing_entity_id] = existing_entity.get("roles")
 
-    # Preserve a bound entity's reconcile-owned `tags` when auto-save omits it.
-    # `tags` mirrors schema.yml and is never intentionally sent by auto-save.ts
-    # for bound entities (only trellis_tags is) — omission here must not be
-    # read as "clear it", unlike unbound entities where tags is freely editable
-    # and an omission does mean the user cleared it.
-    existing_tags_by_id: Dict[str, Any] = {}
+    # Preserve a bound entity's reconcile-owned `dbt_tags` when auto-save
+    # omits it. `dbt_tags` mirrors schema.yml and is never intentionally
+    # sent by auto-save.ts for bound entities (only ui_tags is) — omission
+    # here must not be read as "clear it", unlike unbound entities where
+    # `tags` is freely editable and an omission does mean the user cleared it.
+    existing_dbt_tags_by_id: Dict[str, Any] = {}
     if existing_model_data:
         for existing_entity in existing_model_data.get("entities", []):
             existing_entity_id = existing_entity.get("id")
-            if existing_entity_id and "tags" in existing_entity:
-                existing_tags_by_id[existing_entity_id] = existing_entity.get("tags")
+            if existing_entity_id and "dbt_tags" in existing_entity:
+                existing_dbt_tags_by_id[existing_entity_id] = existing_entity.get("dbt_tags")
 
     # Split entities
     entities = content.get("entities", [])
@@ -376,12 +382,17 @@ def _split_model_and_layout(
                 _normalize_field_origin(normalized)
                 drafted_fields.append(normalized)
             model_entity["drafted_fields"] = drafted_fields
-        if "tags" in entity:
+        # `tags` is only a persisted field for unbound entities (their single,
+        # freely-editable tag list). Bound entities never persist `tags` —
+        # only `dbt_tags` (reconcile-owned) and `ui_tags` (user-added).
+        if "tags" in entity and not entity.get("dbt_model"):
             model_entity["tags"] = entity["tags"]
-        elif entity.get("dbt_model") and entity_id in existing_tags_by_id:
-            model_entity["tags"] = existing_tags_by_id[entity_id]
-        if "trellis_tags" in entity:
-            model_entity["trellis_tags"] = entity["trellis_tags"]
+        if "dbt_tags" in entity:
+            model_entity["dbt_tags"] = entity["dbt_tags"]
+        elif entity.get("dbt_model") and entity_id in existing_dbt_tags_by_id:
+            model_entity["dbt_tags"] = existing_dbt_tags_by_id[entity_id]
+        if "ui_tags" in entity:
+            model_entity["ui_tags"] = entity["ui_tags"]
         if "domain" in entity:
             model_entity["domain"] = entity["domain"]
         if "domains" in entity:

--- a/trellis_datamodel/services/bus_matrix.py
+++ b/trellis_datamodel/services/bus_matrix.py
@@ -21,6 +21,7 @@ import yaml
 
 from trellis_datamodel import config as cfg
 from trellis_datamodel.exceptions import ConfigurationError, FileOperationError
+from trellis_datamodel.services.reconciliation import compute_display_tags
 
 
 def get_bus_matrix(
@@ -68,6 +69,14 @@ def get_bus_matrix(
 
     dimensions = [e for e in entities if e.get("entity_type") == "dimension"]
     facts = [e for e in entities if e.get("entity_type") == "fact"]
+
+    # `tags` for display/filtering is computed here, never persisted: the
+    # union of dbt_tags + ui_tags for bound entities, or the entity's own
+    # `tags` field for unbound entities.
+    for d in dimensions:
+        d["tags"] = compute_display_tags(d)
+    for f in facts:
+        f["tags"] = compute_display_tags(f)
 
     # Apply tag filter if specified
     if tag:

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -223,19 +223,28 @@ def reconcile_data_model(
             entity["drafted_fields"] = reconciled
             changed = True
 
-        # One-time migration seed: an entity with a pre-existing `tags` value
-        # and no `trellis_tags` key (populated by the old, pre-fix UI path)
-        # is seeded once so its tags aren't lost on the first push under the
-        # new merge logic. Checks genuine key absence, not falsiness — an
-        # entity with `trellis_tags: []` must NOT be re-seeded (explicit user
-        # removal must stick).
-        if "trellis_tags" not in entity and entity.get("tags"):
-            entity["trellis_tags"] = list(entity["tags"])
-            changed = True
-
         manifest_tags = manifest_tags_by_id.get(dbt_model) if dbt_model in manifest_by_id else None
         existing_tags = entity.get("tags") or []
         reconciled_tags = reconcile_entity_tags(existing_tags, manifest_tags)
+
+        # One-time migration seed: an entity's pre-existing `tags` value is
+        # legacy, pre-fix, user-curated data ONLY if it differs from what dbt
+        # reconciliation produces right now. If it already matches, `tags`
+        # was already reconciled by this same logic in an earlier run — it is
+        # dbt's own tag list, not something the user added, and must NOT be
+        # copied into trellis_tags (that would wrongly mark dbt's tags as
+        # Trellis-authored and defeat the read-only/removable UI split).
+        # Checks genuine key absence, not falsiness — an entity with
+        # `trellis_tags: []` must NOT be re-seeded (explicit user removal
+        # must stick).
+        if (
+            "trellis_tags" not in entity
+            and existing_tags
+            and existing_tags != reconciled_tags
+        ):
+            entity["trellis_tags"] = list(existing_tags)
+            changed = True
+
         if reconciled_tags != existing_tags:
             entity["tags"] = reconciled_tags
             changed = True

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -223,6 +223,16 @@ def reconcile_data_model(
             entity["drafted_fields"] = reconciled
             changed = True
 
+        # One-time migration seed: an entity with a pre-existing `tags` value
+        # and no `trellis_tags` key (populated by the old, pre-fix UI path)
+        # is seeded once so its tags aren't lost on the first push under the
+        # new merge logic. Checks genuine key absence, not falsiness — an
+        # entity with `trellis_tags: []` must NOT be re-seeded (explicit user
+        # removal must stick).
+        if "trellis_tags" not in entity and entity.get("tags"):
+            entity["trellis_tags"] = list(entity["tags"])
+            changed = True
+
         manifest_tags = manifest_tags_by_id.get(dbt_model) if dbt_model in manifest_by_id else None
         existing_tags = entity.get("tags") or []
         reconciled_tags = reconcile_entity_tags(existing_tags, manifest_tags)

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -169,13 +169,34 @@ def reconcile_entity_tags(
     existing_tags: list[str],
     manifest_tags: list[str] | None,
 ) -> list[str]:
-    """dbt is authoritative for the mirrored `tags` field.
+    """dbt is authoritative for the mirrored `dbt_tags` field.
     manifest_tags=None -> model absent from manifest, non-destructive (unchanged).
     manifest_tags=[] (present, no tags) -> mirrored tags cleared.
     """
     if manifest_tags is None:
         return existing_tags
     return list(manifest_tags)
+
+
+def compute_display_tags(entity: dict[str, Any]) -> list[str]:
+    """The tag list to show/export for an entity — never persisted.
+
+    Bound entities: the union of `dbt_tags` (dbt-owned, reconcile-refreshed)
+    and `ui_tags` (user-added via the Trellis tag editor), deduplicated,
+    dbt_tags first. Unbound entities have no schema.yml to mirror — `tags`
+    is their single, freely-editable, already-authoritative field.
+    """
+    if entity.get("dbt_model"):
+        dbt_tags = entity.get("dbt_tags") or []
+        ui_tags = entity.get("ui_tags") or []
+        seen: set[str] = set()
+        result: list[str] = []
+        for tag in [*dbt_tags, *ui_tags]:
+            if tag not in seen:
+                seen.add(tag)
+                result.append(tag)
+        return result
+    return entity.get("tags") or []
 
 
 def reconcile_data_model(
@@ -224,29 +245,32 @@ def reconcile_data_model(
             changed = True
 
         manifest_tags = manifest_tags_by_id.get(dbt_model) if dbt_model in manifest_by_id else None
-        existing_tags = entity.get("tags") or []
-        reconciled_tags = reconcile_entity_tags(existing_tags, manifest_tags)
+        legacy_tags = entity.get("tags") or []
+        existing_dbt_tags = entity.get("dbt_tags") or []
+        reconciled_dbt_tags = reconcile_entity_tags(existing_dbt_tags, manifest_tags)
 
-        # One-time migration seed: an entity's pre-existing `tags` value is
-        # legacy, pre-fix, user-curated data ONLY if it differs from what dbt
-        # reconciliation produces right now. If it already matches, `tags`
-        # was already reconciled by this same logic in an earlier run — it is
-        # dbt's own tag list, not something the user added, and must NOT be
-        # copied into trellis_tags (that would wrongly mark dbt's tags as
+        # One-time migration: a bound entity's legacy `tags` value (from
+        # before the dbt_tags/ui_tags split existed) is folded into ui_tags
+        # ONLY if it represents real legacy/user-curated data — i.e. it
+        # differs from what dbt reconciliation says right now. A value that
+        # already matches is dbt's own tag list from an earlier run under
+        # the old field name, not something the user added, and must NOT be
+        # copied into ui_tags (that would wrongly mark dbt's tags as
         # Trellis-authored and defeat the read-only/removable UI split).
-        # Checks genuine key absence, not falsiness — an entity with
-        # `trellis_tags: []` must NOT be re-seeded (explicit user removal
-        # must stick).
-        if (
-            "trellis_tags" not in entity
-            and existing_tags
-            and existing_tags != reconciled_tags
-        ):
-            entity["trellis_tags"] = list(existing_tags)
+        # The legacy `tags` key itself is always retired afterward — bound
+        # entities never persist `tags` going forward, only dbt_tags/ui_tags.
+        if "tags" in entity:
+            if (
+                "ui_tags" not in entity
+                and legacy_tags
+                and legacy_tags != reconciled_dbt_tags
+            ):
+                entity["ui_tags"] = list(legacy_tags)
+            del entity["tags"]
             changed = True
 
-        if reconciled_tags != existing_tags:
-            entity["tags"] = reconciled_tags
+        if reconciled_dbt_tags != existing_dbt_tags:
+            entity["dbt_tags"] = reconciled_dbt_tags
             changed = True
 
     return result, changed

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -165,6 +165,19 @@ def reconcile_entity_fields(
     return result
 
 
+def reconcile_entity_tags(
+    existing_tags: list[str],
+    manifest_tags: list[str] | None,
+) -> list[str]:
+    """dbt is authoritative for the mirrored `tags` field.
+    manifest_tags=None -> model absent from manifest, non-destructive (unchanged).
+    manifest_tags=[] (present, no tags) -> mirrored tags cleared.
+    """
+    if manifest_tags is None:
+        return existing_tags
+    return list(manifest_tags)
+
+
 def reconcile_data_model(
     data_model: dict[str, Any],
     manifest_models: list[dict[str, Any]],
@@ -183,10 +196,12 @@ def reconcile_data_model(
     """
     # Index manifest by unique_id for O(1) lookup
     manifest_by_id: dict[str, list[dict[str, Any]]] = {}
+    manifest_tags_by_id: dict[str, list[str]] = {}
     for model in manifest_models:
         uid = model.get("unique_id")
         if uid:
             manifest_by_id[uid] = model.get("columns") or []
+            manifest_tags_by_id[uid] = model.get("tags") or []
 
     result = copy.deepcopy(data_model)
     changed = False
@@ -206,6 +221,13 @@ def reconcile_data_model(
 
         if reconciled != existing:
             entity["drafted_fields"] = reconciled
+            changed = True
+
+        manifest_tags = manifest_tags_by_id.get(dbt_model) if dbt_model in manifest_by_id else None
+        existing_tags = entity.get("tags") or []
+        reconciled_tags = reconcile_entity_tags(existing_tags, manifest_tags)
+        if reconciled_tags != existing_tags:
+            entity["tags"] = reconciled_tags
             changed = True
 
     return result, changed

--- a/trellis_datamodel/tests/test_bus_matrix.py
+++ b/trellis_datamodel/tests/test_bus_matrix.py
@@ -157,6 +157,39 @@ class TestBusMatrixEndpoint:
         for fact in result["facts"]:
             assert "core" in fact.get("tags", [])
 
+    def test_tag_filtering_uses_computed_union_for_bound_entities(
+        self, temp_data_model_path, enable_bus_matrix
+    ):
+        """A bound dimension's tags for filtering/display are the union of
+        dbt_tags and ui_tags — never a persisted `tags` field."""
+        data = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "dim_bound",
+                    "entity_type": "dimension",
+                    "dbt_model": "model.proj.dim_bound",
+                    "dbt_tags": ["nightly"],
+                    "ui_tags": ["pii"],
+                },
+                {
+                    "id": "fct_unrelated",
+                    "entity_type": "fact",
+                    "tags": ["other"],
+                },
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data, f)
+
+        result = get_bus_matrix(tag="pii")
+        assert [d["id"] for d in result["dimensions"]] == ["dim_bound"]
+        assert result["dimensions"][0]["tags"] == ["nightly", "pii"]
+
+        result_nightly = get_bus_matrix(tag="nightly")
+        assert [d["id"] for d in result_nightly["dimensions"]] == ["dim_bound"]
+
     def test_multiple_connections(self, sample_data_model, enable_bus_matrix):
         """Test handling of multiple connections between same dimension and fact."""
         # Add duplicate relationship to data model

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -412,3 +412,82 @@ def test_split_preserves_trellis_tags_key():
     orders_entity = next(e for e in model_data["entities"] if e["id"] == "orders")
     assert orders_entity["tags"] == ["nightly"]
     assert "trellis_tags" not in orders_entity
+
+
+def test_split_preserves_bound_entity_tags_when_omitted_by_autosave():
+    """`tags` on a bound entity is reconcile-owned: auto-save.ts deliberately never
+    sends it (it only ever sends trellis_tags for bound entities). Omitting the key
+    must NOT wipe the previously-reconciled tags already on disk — it must be
+    preserved from existing_model_data, mirroring the `roles` preservation pattern.
+    """
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    existing_model_data = {
+        "entities": [
+            {
+                "id": "users",
+                "dbt_model": "model.proj.users",
+                "tags": ["nightly", "customer_360"],
+            },
+        ]
+    }
+
+    # Exactly what auto-save.ts sends today for a bound entity: trellis_tags only,
+    # no "tags" key at all.
+    incoming_content = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "trellis_tags": ["pii"],
+                "position": {"x": 0, "y": 0},
+            },
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(
+        incoming_content, existing_model_data
+    )
+
+    users_entity = model_data["entities"][0]
+    assert users_entity["tags"] == ["nightly", "customer_360"], (
+        f"bound entity's reconcile-owned tags were wiped on autosave; got: {users_entity.get('tags')}"
+    )
+    assert users_entity["trellis_tags"] == ["pii"]
+
+
+def test_split_does_not_preserve_tags_for_unbound_entity_when_omitted():
+    """Unbound entities have no schema.yml to reconcile against — `tags` is their
+    single freely-editable field. Clearing it to empty is sent as an omitted key
+    (see auto-save.ts's `displayTags.length > 0 ? displayTags : undefined`), and
+    that must genuinely clear it, not resurrect the old value from disk.
+    """
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    existing_model_data = {
+        "entities": [
+            {"id": "draft_entity", "tags": ["old-draft-tag"]},
+        ]
+    }
+
+    # User cleared all tags in the UI for this unbound entity — auto-save.ts omits
+    # the key entirely rather than sending an empty list.
+    incoming_content = {
+        "version": 0.1,
+        "entities": [
+            {"id": "draft_entity", "label": "Draft Entity", "position": {"x": 0, "y": 0}},
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(
+        incoming_content, existing_model_data
+    )
+
+    entity = model_data["entities"][0]
+    assert "tags" not in entity, (
+        f"unbound entity's intentionally-cleared tags were resurrected; got: {entity.get('tags')}"
+    )

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -65,7 +65,56 @@ class TestGetDataModel:
         assert response.status_code == 200
         data = response.json()
         assert data["entities"] == []
-        assert data["relationships"] == []
+
+    def test_computes_display_tags_for_bound_entity(
+        self, test_client, temp_data_model_path
+    ):
+        """GET /api/data-model injects a computed `tags` union (dbt_tags +
+        ui_tags) for bound entities, without persisting it back to disk."""
+        model_data = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.proj.users",
+                    "dbt_tags": ["nightly", "customer_360"],
+                    "ui_tags": ["pii"],
+                },
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(model_data, f)
+
+        response = test_client.get("/api/data-model")
+        assert response.status_code == 200
+        entity = response.json()["entities"][0]
+        assert entity["tags"] == ["nightly", "customer_360", "pii"]
+
+        with open(temp_data_model_path, "r") as f:
+            on_disk = yaml.safe_load(f)
+        assert "tags" not in on_disk["entities"][0], (
+            "computed display tags must never be written back to data_model.yml"
+        )
+
+    def test_unbound_entity_display_tags_are_its_own_tags_field(
+        self, test_client, temp_data_model_path
+    ):
+        model_data = {
+            "version": 0.1,
+            "entities": [
+                {"id": "draft", "label": "Draft", "tags": ["draft-tag"]},
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(model_data, f)
+
+        response = test_client.get("/api/data-model")
+        assert response.status_code == 200
+        entity = response.json()["entities"][0]
+        assert entity["tags"] == ["draft-tag"]
 
 
 class TestSaveDataModel:
@@ -372,12 +421,11 @@ def test_save_data_model_writes_origin_list(test_client, temp_data_model_path):
     ]
 
 
-def test_split_preserves_trellis_tags_key():
-    """trellis_tags round-trips through the model/layout split the same way
-    `tags` already does: present in the split-out model entity when the
+def test_split_preserves_ui_tags_key():
+    """ui_tags round-trips through the model/layout split the same way
+    `dbt_tags` already does: present in the split-out model entity when the
     incoming entity carries the key, and simply absent (not raising, not
-    defaulted) when the incoming entity omits it — mirroring the existing
-    `if "tags" in entity: model_entity["tags"] = entity["tags"]` pattern.
+    defaulted) when the incoming entity omits it.
     """
     from trellis_datamodel.routes.data_model import _split_model_and_layout
 
@@ -388,16 +436,16 @@ def test_split_preserves_trellis_tags_key():
                 "id": "users",
                 "label": "Users",
                 "dbt_model": "model.proj.users",
-                "tags": ["nightly"],
-                "trellis_tags": ["pii"],
+                "dbt_tags": ["nightly"],
+                "ui_tags": ["pii"],
                 "position": {"x": 0, "y": 0},
             },
             {
                 "id": "orders",
                 "label": "Orders",
                 "dbt_model": "model.proj.orders",
-                "tags": ["nightly"],
-                # trellis_tags intentionally omitted
+                "dbt_tags": ["nightly"],
+                # ui_tags intentionally omitted
             },
         ],
         "relationships": [],
@@ -406,18 +454,18 @@ def test_split_preserves_trellis_tags_key():
     model_data, _layout_data = _split_model_and_layout(content)
 
     users_entity = next(e for e in model_data["entities"] if e["id"] == "users")
-    assert users_entity["tags"] == ["nightly"]
-    assert users_entity["trellis_tags"] == ["pii"]
+    assert users_entity["dbt_tags"] == ["nightly"]
+    assert users_entity["ui_tags"] == ["pii"]
 
     orders_entity = next(e for e in model_data["entities"] if e["id"] == "orders")
-    assert orders_entity["tags"] == ["nightly"]
-    assert "trellis_tags" not in orders_entity
+    assert orders_entity["dbt_tags"] == ["nightly"]
+    assert "ui_tags" not in orders_entity
 
 
-def test_split_preserves_bound_entity_tags_when_omitted_by_autosave():
-    """`tags` on a bound entity is reconcile-owned: auto-save.ts deliberately never
-    sends it (it only ever sends trellis_tags for bound entities). Omitting the key
-    must NOT wipe the previously-reconciled tags already on disk — it must be
+def test_split_preserves_bound_entity_dbt_tags_when_omitted_by_autosave():
+    """`dbt_tags` on a bound entity is reconcile-owned: auto-save.ts deliberately
+    never sends it (it only ever sends ui_tags for bound entities). Omitting the
+    key must NOT wipe the previously-reconciled tags already on disk — it must be
     preserved from existing_model_data, mirroring the `roles` preservation pattern.
     """
     from trellis_datamodel.routes.data_model import _split_model_and_layout
@@ -427,13 +475,13 @@ def test_split_preserves_bound_entity_tags_when_omitted_by_autosave():
             {
                 "id": "users",
                 "dbt_model": "model.proj.users",
-                "tags": ["nightly", "customer_360"],
+                "dbt_tags": ["nightly", "customer_360"],
             },
         ]
     }
 
-    # Exactly what auto-save.ts sends today for a bound entity: trellis_tags only,
-    # no "tags" key at all.
+    # Exactly what auto-save.ts sends today for a bound entity: ui_tags only,
+    # no "dbt_tags" key at all.
     incoming_content = {
         "version": 0.1,
         "entities": [
@@ -441,7 +489,7 @@ def test_split_preserves_bound_entity_tags_when_omitted_by_autosave():
                 "id": "users",
                 "label": "Users",
                 "dbt_model": "model.proj.users",
-                "trellis_tags": ["pii"],
+                "ui_tags": ["pii"],
                 "position": {"x": 0, "y": 0},
             },
         ],
@@ -453,10 +501,35 @@ def test_split_preserves_bound_entity_tags_when_omitted_by_autosave():
     )
 
     users_entity = model_data["entities"][0]
-    assert users_entity["tags"] == ["nightly", "customer_360"], (
-        f"bound entity's reconcile-owned tags were wiped on autosave; got: {users_entity.get('tags')}"
+    assert users_entity["dbt_tags"] == ["nightly", "customer_360"], (
+        f"bound entity's reconcile-owned dbt_tags were wiped on autosave; got: {users_entity.get('dbt_tags')}"
     )
-    assert users_entity["trellis_tags"] == ["pii"]
+    assert users_entity["ui_tags"] == ["pii"]
+
+
+def test_split_never_persists_tags_for_bound_entity_even_if_sent():
+    """Bound entities never persist a `tags` key at all, even if a stale
+    client sends one — only unbound entities use plain `tags`."""
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    incoming_content = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "tags": ["legacy-stale-value"],
+                "position": {"x": 0, "y": 0},
+            },
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(incoming_content)
+
+    users_entity = model_data["entities"][0]
+    assert "tags" not in users_entity
 
 
 def test_split_does_not_preserve_tags_for_unbound_entity_when_omitted():

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -370,3 +370,45 @@ def test_save_data_model_writes_origin_list(test_client, temp_data_model_path):
         {"DH1": "CORE.A"},
         {"DH2": "CBUS.B"},
     ]
+
+
+def test_split_preserves_trellis_tags_key():
+    """trellis_tags round-trips through the model/layout split the same way
+    `tags` already does: present in the split-out model entity when the
+    incoming entity carries the key, and simply absent (not raising, not
+    defaulted) when the incoming entity omits it — mirroring the existing
+    `if "tags" in entity: model_entity["tags"] = entity["tags"]` pattern.
+    """
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    content = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "tags": ["nightly"],
+                "trellis_tags": ["pii"],
+                "position": {"x": 0, "y": 0},
+            },
+            {
+                "id": "orders",
+                "label": "Orders",
+                "dbt_model": "model.proj.orders",
+                "tags": ["nightly"],
+                # trellis_tags intentionally omitted
+            },
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(content)
+
+    users_entity = next(e for e in model_data["entities"] if e["id"] == "users")
+    assert users_entity["tags"] == ["nightly"]
+    assert users_entity["trellis_tags"] == ["pii"]
+
+    orders_entity = next(e for e in model_data["entities"] if e["id"] == "orders")
+    assert orders_entity["tags"] == ["nightly"]
+    assert "trellis_tags" not in orders_entity

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -1338,7 +1338,7 @@ def test_sync_relationships_preserves_dbt_only_tag_when_pushing_trellis_tag(
                         "id": "users",
                         "label": "Users",
                         "dbt_model": "model.project.users",
-                        "trellis_tags": ["pii"],
+                        "ui_tags": ["pii"],
                     }
                 ],
                 "relationships": [],
@@ -1360,8 +1360,8 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
     test_client, temp_dir, temp_data_model_path, mock_manifest
 ):
     """End-to-end: schema.yml has 'nightly' (dbt-only). User adds 'pii' via
-    trellis_tags. Push adds 'pii' without touching 'nightly'. Push is
-    additive-only for v1: removing 'pii' from trellis_tags and pushing again
+    ui_tags. Push adds 'pii' without touching 'nightly'. Push is
+    additive-only for v1: removing 'pii' from ui_tags and pushing again
     does NOT remove it from schema.yml (documented v1 limitation)."""
     sql_dir = os.path.join(temp_dir, "models", "3_core")
     os.makedirs(sql_dir, exist_ok=True)
@@ -1382,7 +1382,7 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
         yaml.dump(
             {
                 "entities": [
-                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "trellis_tags": ["pii"]}
+                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "ui_tags": ["pii"]}
                 ],
                 "relationships": [],
             },
@@ -1396,13 +1396,13 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
         after_add = yaml.safe_load(f)["models"][0]["tags"]
     assert set(after_add) == {"nightly", "pii"}
 
-    # Simulate the user removing 'pii' from trellis_tags and pushing again —
+    # Simulate the user removing 'pii' from ui_tags and pushing again —
     # additive-only means this is a documented no-op for schema.yml removal.
     with open(temp_data_model_path, "w") as f:
         yaml.dump(
             {
                 "entities": [
-                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "trellis_tags": []}
+                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "ui_tags": []}
                 ],
                 "relationships": [],
             },
@@ -1413,7 +1413,7 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
     with open(yml_path, "r") as f:
         after_second_push = yaml.safe_load(f)["models"][0]["tags"]
     assert "nightly" in after_second_push, "nightly is dbt-owned and must survive"
-    assert "pii" in after_second_push, "v1 is additive-only: pushing trellis_tags=[] never removes a tag already in schema.yml"
+    assert "pii" in after_second_push, "v1 is additive-only: pushing ui_tags=[] never removes a tag already in schema.yml"
 
 
 class TestGetModelSchema:

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -1310,6 +1310,52 @@ class TestSyncDbtTests:
         assert rel_tests[0]["relationships"]["arguments"]["to"] == "ref('cool_stuff')"
 
 
+def test_sync_relationships_preserves_dbt_only_tag_when_pushing_trellis_tag(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """A tag added directly to schema.yml (e.g. 'nightly', not via Trellis) must
+    survive a sync-dbt-tests push that adds an unrelated Trellis tag."""
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "w") as f:
+        yaml.dump(
+            {
+                "version": 2,
+                "models": [
+                    {"name": "users", "tags": ["nightly"], "columns": [{"name": "id", "data_type": "int"}]}
+                ],
+            },
+            f,
+        )
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(
+            {
+                "entities": [
+                    {
+                        "id": "users",
+                        "label": "Users",
+                        "dbt_model": "model.project.users",
+                        "trellis_tags": ["pii"],
+                    }
+                ],
+                "relationships": [],
+            },
+            f,
+        )
+
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+
+    with open(yml_path, "r") as f:
+        saved = yaml.safe_load(f)
+    tags = saved["models"][0].get("tags", [])
+    assert "nightly" in tags, f"dbt-authored tag was wiped by push; got tags: {tags}"
+    assert "pii" in tags
+
+
 class TestGetModelSchema:
     """Tests for GET /api/models/{model_name}/schema endpoint."""
 

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -1356,6 +1356,66 @@ def test_sync_relationships_preserves_dbt_only_tag_when_pushing_trellis_tag(
     assert "pii" in tags
 
 
+def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
+    test_client, temp_dir, temp_data_model_path, mock_manifest
+):
+    """End-to-end: schema.yml has 'nightly' (dbt-only). User adds 'pii' via
+    trellis_tags. Push adds 'pii' without touching 'nightly'. Push is
+    additive-only for v1: removing 'pii' from trellis_tags and pushing again
+    does NOT remove it from schema.yml (documented v1 limitation)."""
+    sql_dir = os.path.join(temp_dir, "models", "3_core")
+    os.makedirs(sql_dir, exist_ok=True)
+    with open(os.path.join(sql_dir, "users.sql"), "w") as f:
+        f.write("SELECT 1")
+    yml_path = os.path.join(sql_dir, "users.yml")
+    with open(yml_path, "w") as f:
+        yaml.dump(
+            {
+                "version": 2,
+                "models": [
+                    {"name": "users", "tags": ["nightly"], "columns": [{"name": "id", "data_type": "int"}]}
+                ],
+            },
+            f,
+        )
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(
+            {
+                "entities": [
+                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "trellis_tags": ["pii"]}
+                ],
+                "relationships": [],
+            },
+            f,
+        )
+
+    # Push: pii added, nightly must survive
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+    with open(yml_path, "r") as f:
+        after_add = yaml.safe_load(f)["models"][0]["tags"]
+    assert set(after_add) == {"nightly", "pii"}
+
+    # Simulate the user removing 'pii' from trellis_tags and pushing again —
+    # additive-only means this is a documented no-op for schema.yml removal.
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(
+            {
+                "entities": [
+                    {"id": "users", "label": "Users", "dbt_model": "model.project.users", "trellis_tags": []}
+                ],
+                "relationships": [],
+            },
+            f,
+        )
+    response = test_client.post("/api/sync-dbt-tests")
+    assert response.status_code == 200
+    with open(yml_path, "r") as f:
+        after_second_push = yaml.safe_load(f)["models"][0]["tags"]
+    assert "nightly" in after_second_push, "nightly is dbt-owned and must survive"
+    assert "pii" in after_second_push, "v1 is additive-only: pushing trellis_tags=[] never removes a tag already in schema.yml"
+
+
 class TestGetModelSchema:
     """Tests for GET /api/models/{model_name}/schema endpoint."""
 

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -55,8 +55,8 @@ class TestReconcileDbtEndpoint:
                     "id": "users",
                     "label": "Users",
                     "dbt_model": "model.project.users",
-                    "tags": ["core"],  # matches mock_manifest's model.project.users tags
-                    "trellis_tags": [],  # migration seed already ran; nothing Trellis-authored
+                    "dbt_tags": ["core"],  # matches mock_manifest's model.project.users tags
+                    "ui_tags": [],  # migration already ran; nothing Trellis-authored
                     "drafted_fields": [
                         {
                             "name": "id",

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -55,6 +55,7 @@ class TestReconcileDbtEndpoint:
                     "id": "users",
                     "label": "Users",
                     "dbt_model": "model.project.users",
+                    "tags": ["core"],  # matches mock_manifest's model.project.users tags
                     "drafted_fields": [
                         {
                             "name": "id",

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -56,6 +56,7 @@ class TestReconcileDbtEndpoint:
                     "label": "Users",
                     "dbt_model": "model.project.users",
                     "tags": ["core"],  # matches mock_manifest's model.project.users tags
+                    "trellis_tags": [],  # migration seed already ran; nothing Trellis-authored
                     "drafted_fields": [
                         {
                             "name": "id",

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -5,6 +5,7 @@ from trellis_datamodel.services.reconciliation import (
     reconcile_entity_fields,
     reconcile_entity_tags,
     reconcile_data_model,
+    compute_display_tags,
 )
 
 
@@ -334,27 +335,27 @@ class TestReconcileDataModel:
         assert users["drafted_fields"][0]["source"] == "dbt"
         assert sketch["drafted_fields"] == [{"name": "future_col", "datatype": "text"}]
 
-    def test_reconcile_data_model_refreshes_entity_tags_from_manifest(self):
+    def test_reconcile_data_model_refreshes_entity_dbt_tags_from_manifest(self):
         data_model = {
             "entities": [
-                {"id": "users", "dbt_model": "model.proj.users", "tags": ["old"]},
+                {"id": "users", "dbt_model": "model.proj.users", "dbt_tags": ["old"]},
             ]
         }
         manifest_models = [
             {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly", "core"]},
         ]
         result, changed = reconcile_data_model(data_model, manifest_models)
-        assert result["entities"][0]["tags"] == ["nightly", "core"]
+        assert result["entities"][0]["dbt_tags"] == ["nightly", "core"]
         assert changed is True
 
-    def test_reconcile_data_model_leaves_trellis_tags_untouched(self):
+    def test_reconcile_data_model_leaves_ui_tags_untouched(self):
         data_model = {
             "entities": [
                 {
                     "id": "users",
                     "dbt_model": "model.proj.users",
-                    "tags": ["old"],
-                    "trellis_tags": ["pii"],
+                    "dbt_tags": ["old"],
+                    "ui_tags": ["pii"],
                 },
             ]
         }
@@ -362,14 +363,15 @@ class TestReconcileDataModel:
             {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
         ]
         result, _ = reconcile_data_model(data_model, manifest_models)
-        assert result["entities"][0]["trellis_tags"] == ["pii"]
+        assert result["entities"][0]["ui_tags"] == ["pii"]
 
 
 class TestTagMigrationSeed:
-    def test_legacy_tags_seed_trellis_tags_once_when_trellis_tags_absent(self):
-        """An entity with a pre-existing `tags` value and no `trellis_tags` key
-        (populated by the old, pre-fix UI path) is seeded once so its tags
-        aren't lost on the first push under the new merge logic."""
+    def test_legacy_tags_seed_ui_tags_once_and_retire_legacy_key(self):
+        """An entity with a pre-existing legacy `tags` value (from before the
+        dbt_tags/ui_tags split existed) and no `ui_tags` key is seeded once so
+        its tags aren't lost, and the legacy `tags` key is retired — bound
+        entities never persist `tags` going forward."""
         data_model = {
             "entities": [
                 {"id": "users", "dbt_model": "model.proj.users", "tags": ["pii"]},
@@ -379,19 +381,22 @@ class TestTagMigrationSeed:
             {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
         ]
         result, _ = reconcile_data_model(data_model, manifest_models)
-        assert result["entities"][0]["trellis_tags"] == ["pii"]
-        assert result["entities"][0]["tags"] == ["nightly"]
+        entity = result["entities"][0]
+        assert entity["ui_tags"] == ["pii"]
+        assert entity["dbt_tags"] == ["nightly"]
+        assert "tags" not in entity
 
-    def test_seed_does_not_reapply_once_trellis_tags_exists(self):
-        """The one-time seed never runs again once trellis_tags is present,
-        even if it's empty (explicit user removal must stick)."""
+    def test_seed_does_not_reapply_once_ui_tags_exists(self):
+        """The one-time seed never runs again once ui_tags is present,
+        even if it's empty (explicit user removal must stick), but the
+        legacy tags key is still retired."""
         data_model = {
             "entities": [
                 {
                     "id": "users",
                     "dbt_model": "model.proj.users",
                     "tags": ["pii"],
-                    "trellis_tags": [],
+                    "ui_tags": [],
                 },
             ]
         }
@@ -399,19 +404,19 @@ class TestTagMigrationSeed:
             {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
         ]
         result, _ = reconcile_data_model(data_model, manifest_models)
-        assert result["entities"][0]["trellis_tags"] == []
+        entity = result["entities"][0]
+        assert entity["ui_tags"] == []
+        assert "tags" not in entity
 
-    def test_does_not_seed_already_dbt_reconciled_tags_into_trellis_tags(self):
-        """If `tags` already exactly matches what the manifest says (i.e. it was
-        already reconciled by this same logic in an earlier run, not legacy
+    def test_does_not_seed_already_dbt_reconciled_tags_into_ui_tags(self):
+        """If legacy `tags` already exactly matches what the manifest says
+        (i.e. it was already mirrored by the old pre-rename code, not legacy
         pre-fix data), a later reconcile must NOT seed the entire dbt tag list
-        into trellis_tags — that would wrongly treat dbt's own tags as
-        user-added, and defeat the read-only/removable distinction in the UI."""
+        into ui_tags — that would wrongly treat dbt's own tags as
+        user-added, and defeat the read-only/removable distinction in the UI.
+        The legacy key is still retired either way."""
         data_model = {
             "entities": [
-                # tags already equals the manifest's tags — this is what a
-                # second reconcile call sees after a first call already
-                # mirrored the manifest into `tags`.
                 {"id": "users", "dbt_model": "model.proj.users", "tags": ["sdh", "entity", "customer_360"]},
             ]
         }
@@ -419,17 +424,37 @@ class TestTagMigrationSeed:
             {"unique_id": "model.proj.users", "columns": [], "tags": ["sdh", "entity", "customer_360"]},
         ]
         result, _ = reconcile_data_model(data_model, manifest_models)
-        assert "trellis_tags" not in result["entities"][0], (
-            f"dbt-mirrored tags were wrongly seeded into trellis_tags; got: {result['entities'][0].get('trellis_tags')}"
+        entity = result["entities"][0]
+        assert "ui_tags" not in entity, (
+            f"dbt-mirrored tags were wrongly seeded into ui_tags; got: {entity.get('ui_tags')}"
         )
-        assert result["entities"][0]["tags"] == ["sdh", "entity", "customer_360"]
+        assert entity["dbt_tags"] == ["sdh", "entity", "customer_360"]
+        assert "tags" not in entity
+
+
+class TestComputeDisplayTags:
+    def test_bound_entity_unions_dbt_and_ui_tags(self):
+        entity = {"dbt_model": "model.proj.users", "dbt_tags": ["nightly"], "ui_tags": ["pii"]}
+        assert compute_display_tags(entity) == ["nightly", "pii"]
+
+    def test_bound_entity_dedupes_overlap(self):
+        entity = {"dbt_model": "model.proj.users", "dbt_tags": ["nightly", "core"], "ui_tags": ["core", "pii"]}
+        assert compute_display_tags(entity) == ["nightly", "core", "pii"]
+
+    def test_unbound_entity_uses_plain_tags(self):
+        entity = {"tags": ["draft-tag"]}
+        assert compute_display_tags(entity) == ["draft-tag"]
+
+    def test_bound_entity_with_no_tags_at_all(self):
+        entity = {"dbt_model": "model.proj.users"}
+        assert compute_display_tags(entity) == []
 
 
 class TestReconcileIdempotency:
     def test_repeated_reconcile_produces_no_further_change(self):
         data_model = {
             "entities": [
-                {"id": "users", "dbt_model": "model.proj.users", "tags": ["nightly"], "trellis_tags": ["pii"]},
+                {"id": "users", "dbt_model": "model.proj.users", "dbt_tags": ["nightly"], "ui_tags": ["pii"]},
             ]
         }
         manifest_models = [

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -401,6 +401,29 @@ class TestTagMigrationSeed:
         result, _ = reconcile_data_model(data_model, manifest_models)
         assert result["entities"][0]["trellis_tags"] == []
 
+    def test_does_not_seed_already_dbt_reconciled_tags_into_trellis_tags(self):
+        """If `tags` already exactly matches what the manifest says (i.e. it was
+        already reconciled by this same logic in an earlier run, not legacy
+        pre-fix data), a later reconcile must NOT seed the entire dbt tag list
+        into trellis_tags — that would wrongly treat dbt's own tags as
+        user-added, and defeat the read-only/removable distinction in the UI."""
+        data_model = {
+            "entities": [
+                # tags already equals the manifest's tags — this is what a
+                # second reconcile call sees after a first call already
+                # mirrored the manifest into `tags`.
+                {"id": "users", "dbt_model": "model.proj.users", "tags": ["sdh", "entity", "customer_360"]},
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["sdh", "entity", "customer_360"]},
+        ]
+        result, _ = reconcile_data_model(data_model, manifest_models)
+        assert "trellis_tags" not in result["entities"][0], (
+            f"dbt-mirrored tags were wrongly seeded into trellis_tags; got: {result['entities'][0].get('trellis_tags')}"
+        )
+        assert result["entities"][0]["tags"] == ["sdh", "entity", "customer_360"]
+
 
 class TestReconcileIdempotency:
     def test_repeated_reconcile_produces_no_further_change(self):

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -3,6 +3,7 @@
 import pytest
 from trellis_datamodel.services.reconciliation import (
     reconcile_entity_fields,
+    reconcile_entity_tags,
     reconcile_data_model,
 )
 
@@ -197,6 +198,24 @@ class TestReconcileEntityFields:
         assert "origin" not in result[0]
 
 
+class TestReconcileEntityTags:
+    def test_dbt_tags_overwrite_existing_tags_field(self):
+        """dbt is authoritative for the mirrored `tags` field — always overwritten."""
+        result = reconcile_entity_tags(existing_tags=["stale"], manifest_tags=["nightly", "core"])
+        assert result == ["nightly", "core"]
+
+    def test_absent_from_manifest_is_non_destructive(self):
+        """Model absent from manifest (partial compile) — existing tags untouched."""
+        result = reconcile_entity_tags(existing_tags=["nightly"], manifest_tags=None)
+        assert result == ["nightly"]
+
+    def test_empty_manifest_tags_clears_mirrored_tags(self):
+        """Model present in manifest with no tags — mirrored tags become empty,
+        distinct from 'absent from manifest' (None)."""
+        result = reconcile_entity_tags(existing_tags=["stale"], manifest_tags=[])
+        assert result == []
+
+
 class TestReconcileDataModel:
     """Unit tests for the reconcile_data_model function."""
 
@@ -314,3 +333,33 @@ class TestReconcileDataModel:
         sketch = next(e for e in result["entities"] if e["id"] == "sketch")
         assert users["drafted_fields"][0]["source"] == "dbt"
         assert sketch["drafted_fields"] == [{"name": "future_col", "datatype": "text"}]
+
+    def test_reconcile_data_model_refreshes_entity_tags_from_manifest(self):
+        data_model = {
+            "entities": [
+                {"id": "users", "dbt_model": "model.proj.users", "tags": ["old"]},
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly", "core"]},
+        ]
+        result, changed = reconcile_data_model(data_model, manifest_models)
+        assert result["entities"][0]["tags"] == ["nightly", "core"]
+        assert changed is True
+
+    def test_reconcile_data_model_leaves_trellis_tags_untouched(self):
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.proj.users",
+                    "tags": ["old"],
+                    "trellis_tags": ["pii"],
+                },
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
+        ]
+        result, _ = reconcile_data_model(data_model, manifest_models)
+        assert result["entities"][0]["trellis_tags"] == ["pii"]

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -363,3 +363,56 @@ class TestReconcileDataModel:
         ]
         result, _ = reconcile_data_model(data_model, manifest_models)
         assert result["entities"][0]["trellis_tags"] == ["pii"]
+
+
+class TestTagMigrationSeed:
+    def test_legacy_tags_seed_trellis_tags_once_when_trellis_tags_absent(self):
+        """An entity with a pre-existing `tags` value and no `trellis_tags` key
+        (populated by the old, pre-fix UI path) is seeded once so its tags
+        aren't lost on the first push under the new merge logic."""
+        data_model = {
+            "entities": [
+                {"id": "users", "dbt_model": "model.proj.users", "tags": ["pii"]},
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
+        ]
+        result, _ = reconcile_data_model(data_model, manifest_models)
+        assert result["entities"][0]["trellis_tags"] == ["pii"]
+        assert result["entities"][0]["tags"] == ["nightly"]
+
+    def test_seed_does_not_reapply_once_trellis_tags_exists(self):
+        """The one-time seed never runs again once trellis_tags is present,
+        even if it's empty (explicit user removal must stick)."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.proj.users",
+                    "tags": ["pii"],
+                    "trellis_tags": [],
+                },
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
+        ]
+        result, _ = reconcile_data_model(data_model, manifest_models)
+        assert result["entities"][0]["trellis_tags"] == []
+
+
+class TestReconcileIdempotency:
+    def test_repeated_reconcile_produces_no_further_change(self):
+        data_model = {
+            "entities": [
+                {"id": "users", "dbt_model": "model.proj.users", "tags": ["nightly"], "trellis_tags": ["pii"]},
+            ]
+        }
+        manifest_models = [
+            {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly"]},
+        ]
+        once, changed_once = reconcile_data_model(data_model, manifest_models)
+        twice, changed_twice = reconcile_data_model(once, manifest_models)
+        assert changed_twice is False
+        assert twice == once

--- a/trellis_datamodel/tests/test_yaml_handler.py
+++ b/trellis_datamodel/tests/test_yaml_handler.py
@@ -546,3 +546,25 @@ class TestTagHandling:
         assert (
             config_line > desc_line
         ), "Config should appear after description in version block"
+
+    def test_merge_model_tags_unions_and_preserves_dbt_only_tags(self):
+        """A tag already in schema.yml (e.g. added directly by a dbt dev) survives
+        a merge that adds a Trellis-authored tag — no full replace."""
+        handler = YamlHandler()
+        model = CommentedMap({"name": "test", "tags": ["nightly"]})
+        handler.merge_model_tags(model, ["pii"])
+        assert set(model["tags"]) == {"nightly", "pii"}
+
+    def test_merge_model_tags_removes_only_dropped_trellis_tag(self):
+        """Dropping a previously-pushed Trellis tag from trellis_tags removes only
+        that tag; a dbt-only tag already in schema.yml is untouched."""
+        handler = YamlHandler()
+        model = CommentedMap({"name": "test", "tags": ["nightly", "pii"]})
+        handler.merge_model_tags(model, [], previously_pushed=["pii"])
+        assert model["tags"] == ["nightly"]
+
+    def test_merge_model_tags_noop_when_trellis_tags_none(self):
+        handler = YamlHandler()
+        model = CommentedMap({"name": "test", "tags": ["nightly"]})
+        handler.merge_model_tags(model, None)
+        assert model["tags"] == ["nightly"]

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -268,25 +268,25 @@ class YamlHandler:
     def merge_model_tags(
         self,
         model: CommentedMap,
-        trellis_tags: Optional[List[str]],
+        ui_tags: Optional[List[str]],
         previously_pushed: Optional[List[str]] = None,
     ) -> None:
-        """Additively union `trellis_tags` into a model's existing tags, dropping only
-        tags in `previously_pushed` that are no longer present in `trellis_tags`.
+        """Additively union `ui_tags` into a model's existing tags, dropping only
+        tags in `previously_pushed` that are no longer present in `ui_tags`.
 
-        No-op when `trellis_tags is None` (Trellis has no opinion on tags this push).
+        No-op when `ui_tags is None` (Trellis has no opinion on tags this push).
         Tags outside `previously_pushed` (e.g. added directly in schema.yml by dbt) are
         never touched, since dbt owns tags it did not receive from Trellis.
         """
-        if trellis_tags is None:
+        if ui_tags is None:
             return
 
         current_tags = self.get_model_tags(model)
-        dropped = set(previously_pushed or []) - set(trellis_tags)
+        dropped = set(previously_pushed or []) - set(ui_tags)
         merged = [tag for tag in current_tags if tag not in dropped]
 
         seen = set(merged)
-        for tag in trellis_tags:
+        for tag in ui_tags:
             if tag not in seen:
                 seen.add(tag)
                 merged.append(tag)
@@ -296,25 +296,25 @@ class YamlHandler:
     def merge_version_tags(
         self,
         version: CommentedMap,
-        trellis_tags: Optional[List[str]],
+        ui_tags: Optional[List[str]],
         previously_pushed: Optional[List[str]] = None,
     ) -> None:
-        """Additively union `trellis_tags` into a version's existing tags, dropping only
-        tags in `previously_pushed` that are no longer present in `trellis_tags`.
+        """Additively union `ui_tags` into a version's existing tags, dropping only
+        tags in `previously_pushed` that are no longer present in `ui_tags`.
 
-        No-op when `trellis_tags is None` (Trellis has no opinion on tags this push).
+        No-op when `ui_tags is None` (Trellis has no opinion on tags this push).
         Tags outside `previously_pushed` (e.g. added directly in schema.yml by dbt) are
         never touched, since dbt owns tags it did not receive from Trellis.
         """
-        if trellis_tags is None:
+        if ui_tags is None:
             return
 
         current_tags = list(version.get("config", {}).get("tags", []))
-        dropped = set(previously_pushed or []) - set(trellis_tags)
+        dropped = set(previously_pushed or []) - set(ui_tags)
         merged = [tag for tag in current_tags if tag not in dropped]
 
         seen = set(merged)
-        for tag in trellis_tags:
+        for tag in ui_tags:
             if tag not in seen:
                 seen.add(tag)
                 merged.append(tag)

--- a/trellis_datamodel/utils/yaml_handler.py
+++ b/trellis_datamodel/utils/yaml_handler.py
@@ -265,6 +265,62 @@ class YamlHandler:
                 config = model["config"]
             config["tags"] = tags
 
+    def merge_model_tags(
+        self,
+        model: CommentedMap,
+        trellis_tags: Optional[List[str]],
+        previously_pushed: Optional[List[str]] = None,
+    ) -> None:
+        """Additively union `trellis_tags` into a model's existing tags, dropping only
+        tags in `previously_pushed` that are no longer present in `trellis_tags`.
+
+        No-op when `trellis_tags is None` (Trellis has no opinion on tags this push).
+        Tags outside `previously_pushed` (e.g. added directly in schema.yml by dbt) are
+        never touched, since dbt owns tags it did not receive from Trellis.
+        """
+        if trellis_tags is None:
+            return
+
+        current_tags = self.get_model_tags(model)
+        dropped = set(previously_pushed or []) - set(trellis_tags)
+        merged = [tag for tag in current_tags if tag not in dropped]
+
+        seen = set(merged)
+        for tag in trellis_tags:
+            if tag not in seen:
+                seen.add(tag)
+                merged.append(tag)
+
+        self.update_model_tags(model, merged)
+
+    def merge_version_tags(
+        self,
+        version: CommentedMap,
+        trellis_tags: Optional[List[str]],
+        previously_pushed: Optional[List[str]] = None,
+    ) -> None:
+        """Additively union `trellis_tags` into a version's existing tags, dropping only
+        tags in `previously_pushed` that are no longer present in `trellis_tags`.
+
+        No-op when `trellis_tags is None` (Trellis has no opinion on tags this push).
+        Tags outside `previously_pushed` (e.g. added directly in schema.yml by dbt) are
+        never touched, since dbt owns tags it did not receive from Trellis.
+        """
+        if trellis_tags is None:
+            return
+
+        current_tags = list(version.get("config", {}).get("tags", []))
+        dropped = set(previously_pushed or []) - set(trellis_tags)
+        merged = [tag for tag in current_tags if tag not in dropped]
+
+        seen = set(merged)
+        for tag in trellis_tags:
+            if tag not in seen:
+                seen.add(tag)
+                merged.append(tag)
+
+        self.update_version_tags(version, merged)
+
     def find_column(
         self, model: CommentedMap, column_name: str
     ) -> Optional[CommentedMap]:


### PR DESCRIPTION
# Summary

Entity tags were pushed to schema.yml as a blind full-replace, using a value that was never refreshed from the live file before writing. A tag added directly to schema.yml (e.g. nightly, added by a dbt developer) was silently deleted the next time Trellis pushed an unrelated tag change.

This applies the same "dbt is right" authority model already used for column reconciliation to tags:

- dbt_tags — dbt-owned, refreshed from schema.yml/the manifest on every reconcile, never hand-edited.
- ui_tags — only tags a user explicitly added via the Trellis UI.
- tags — no longer a persisted field on a bound entity at all. Computed at read time as the union of the two (compute_display_tags), wired into GET /api/data-model and the Bus Matrix endpoint. Unbound entities are unaffected: tags remains their single, persisted, freely-editable field.

# Scope decision: tag removal is additive-only in this release

Removing a tag from ui_tags in the UI does not remove it from schema.yml on push. Durable removal would need a second, push-time-only field distinct from the continuously-autosaved ui_tags — judged too invasive for this iteration. To remove a Trellis-added tag, edit schema.yml directly; dbt then owns it going forward. Deliberate, documented v1 limitation.

# Bugs found and fixed during real-world validation against a live dbt project

Beyond the core reconciliation fix, testing against DMB-DIA-DataPlatform/dbt/sales surfaced four more instances of the same underlying bug class — a write path sending an edit with no way for the backend to distinguish "no change" from "clear it," silently erasing reconciled tags:

1. Autosave wiped tags on any save, not just a tag edit (_split_model_and_layout had no fallback to on-disk state).
2. Migration seed copied dbt's entire tag list into the user-tags field on a second reconcile, since it couldn't tell legacy data apart from tags the manifest had already mirrored.
3. Bulk tag add/remove and the "Generate Entities" dialog's save path duplicated the original (already-buggy) persistence logic.
4. The entity detail modal's "Save Changes" button wrote the edited tag list straight to the reconcile-owned field, unconditionally.

All four are fixed to route through the dbt_tags/ui_tags split consistently. The rename itself (tags/trellis_tags → dbt_tags/ui_tags) was done specifically because the original naming caused repeated confusion about which field meant what — done now, before anything shipped beyond beta testing.

# Changes

Backend: YamlHandler.merge_model_tags/merge_version_tags (additive-union writers), reconciliation.py (reconcile_entity_tags, compute_display_tags, migration seed with legacy-vs-mirrored detection), five dbt_core.py push call sites, data_model.py split/preserve logic, bus_matrix.py.

Frontend: EntityData/Entity types, entity-tags.ts (mapEntityTagsToNodeData, computeUiTagsAfterEdit), EntityNode.svelte (tag editor, read-only chip rendering), auto-save.ts, EntityDetailModal.svelte, bulk-operations.ts, GenerateEntitiesDialog.svelte.

Docs: .cursor/project.md Design Principles, full CHANGELOG history (0.18.0, consolidating betas b1–b4).

# Testing

417 backend tests, 809 frontend tests, 0 type errors. Includes a full end-to-end round-trip proof (nightly survives a push that adds pii, survives again after pii is removed) and dedicated regression tests for each of the four write-path bugs.

# Not in this PR

- Durable tag-removal tracking.
- Applying this to additional_models (secondary bound models) — primary dbt_model only.