### PR TITLE
Feature/dbt build status indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-07-31
+
+### Added
+- **dbt build-status indicator and filter**: entities bound to a dbt model (`dbt_model` truthy) now show a build-status mark in the Entity List (a checkmark matching the sidebar's existing "Bound" filter styling) and in the Bus Matrix (a filled/hollow dot to the left of each dimension and fact label, since a dim-fact pair can have mismatched build status). Both views gained a "Built" filter (Bound/Unbound) alongside their existing filters. The Entity List also shows a small inline legend next to the filter explaining the mark.
+
 ## [0.19.0b1] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0b1] - 2026-07-30
+
+### Added
+- **dbt build-status badge and filter**: entities bound to a dbt model (`dbt_model` truthy) now show a dbt icon badge in the Entity List and in the Bus Matrix (both dimensions and facts). Both views gained a "Built" filter (Bound/Unbound) alongside their existing filters, letting you see at a glance — and filter to — what's already built in dbt versus still only modeled in Trellis.
+
 ## [0.18.0] - 2026-07-30
 
 ### Added

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -8,12 +8,14 @@
         id: string;
         label: string;
         tags?: string[];
+        dbt_model?: string;
     }
 
     interface Fact {
         id: string;
         label: string;
         tags?: string[];
+        dbt_model?: string;
     }
 
     interface Connection {
@@ -32,6 +34,7 @@
     let dimensionFilter = $state<string[]>([]);
     let factFilter = $state<string[]>([]);
     let tagFilter = $state<string[]>([]);
+    let buildStatusFilter = $state<string[]>([]);
 
     // Sort options: 'label-asc' | 'count-desc'
     let dimensionSort = $state<string>('label-asc');
@@ -45,6 +48,12 @@
         return connectionLookup.has(`${dimensionId}-${factId}`);
     }
 
+    function matchesBuildStatus(entity: Dimension | Fact): boolean {
+        if (buildStatusFilter.length === 0) return true;
+        const status = entity.dbt_model ? 'bound' : 'unbound';
+        return buildStatusFilter.includes(status);
+    }
+
     // Filtered (unsorted) collections — counts depend on these
     let filteredDimensions = $derived(
         dimensions.filter(dimension => {
@@ -53,6 +62,7 @@
                 const tags = dimension.tags || [];
                 if (!tagFilter.some(tag => tags.includes(tag))) return false;
             }
+            if (!matchesBuildStatus(dimension)) return false;
             return true;
         })
     );
@@ -64,6 +74,7 @@
                 const tags = fact.tags || [];
                 if (!tagFilter.some(tag => tags.includes(tag))) return false;
             }
+            if (!matchesBuildStatus(fact)) return false;
             return true;
         })
     );
@@ -361,13 +372,53 @@
                         {/each}
                     </div>
 
+                    <!-- Build Status Filter -->
+                    <div class="flex items-center gap-1.5 shrink-0">
+                        <label for="build-status-filter" class="text-xs text-gray-600">Built:</label>
+                        <select
+                            id="build-status-filter"
+                            class="text-xs border border-gray-300 rounded px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-primary-500 w-28"
+                            onchange={(e) => {
+                                const value = (e.target as HTMLSelectElement).value;
+                                if (value) {
+                                    if (!buildStatusFilter.includes(value)) {
+                                        buildStatusFilter = [...buildStatusFilter, value];
+                                    }
+                                    (e.target as HTMLSelectElement).value = '';
+                                }
+                            }}
+                        >
+                            <option value="">Add...</option>
+                            {#if !buildStatusFilter.includes('bound')}
+                                <option value="bound">Bound</option>
+                            {/if}
+                            {#if !buildStatusFilter.includes('unbound')}
+                                <option value="unbound">Unbound</option>
+                            {/if}
+                        </select>
+                        {#each buildStatusFilter as status}
+                            <span class="inline-flex items-center gap-1 px-2 py-1 bg-primary-100 text-primary-700 rounded text-xs shrink-0">
+                                {status === 'bound' ? 'Bound' : 'Unbound'}
+                                <button
+                                    onclick={() => {
+                                        buildStatusFilter = buildStatusFilter.filter(s => s !== status);
+                                    }}
+                                    class="hover:text-primary-900"
+                                >
+                                    <Icon icon="lucide:x" class="w-3 h-3" />
+                                </button>
+                            </span>
+                        {/each}
+                    </div>
+
                     <!-- Clear All Filters -->
-                    {#if dimensionFilter.length > 0 || factFilter.length > 0 || tagFilter.length > 0}
+                    {#if dimensionFilter.length > 0 || factFilter.length > 0 || tagFilter.length > 0 || buildStatusFilter.length > 0}
                         <button
                             onclick={() => {
                                 dimensionFilter = [];
                                 factFilter = [];
                                 tagFilter = [];
+                                buildStatusFilter = [];
                             }}
                             class="text-xs text-gray-600 hover:text-gray-800 underline shrink-0"
                         >
@@ -426,6 +477,14 @@
                                         <div class="flex items-center gap-2">
                                             <Icon icon="lucide:bar-chart-3" class="w-4 h-4 text-blue-600" />
                                             <span class="truncate">{fact.label}</span>
+                                            {#if fact.dbt_model}
+                                                <span
+                                                    class="flex-shrink-0 inline-flex items-center text-gray-400"
+                                                    title={`Built with dbt: ${fact.dbt_model.split('.').pop()}`}
+                                                >
+                                                    <Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+                                                </span>
+                                            {/if}
                                             {#if factVisibleDimensionCounts.get(fact.id) !== undefined}
                                                 <span
                                                     aria-label="{factVisibleDimensionCounts.get(fact.id)} connected dimensions"
@@ -459,6 +518,14 @@
                                             <div class="flex items-center gap-2" title={dimension.label}>
                                                 <Icon icon="lucide:list" class="w-4 h-4 text-green-600 flex-shrink-0" />
                                                 <span class="truncate">{dimension.label}</span>
+                                                {#if dimension.dbt_model}
+                                                    <span
+                                                        class="flex-shrink-0 inline-flex items-center text-gray-400"
+                                                        title={`Built with dbt: ${dimension.dbt_model.split('.').pop()}`}
+                                                    >
+                                                        <Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+                                                    </span>
+                                                {/if}
                                                 <span
                                                     aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} connected facts"
                                                     class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-green-100 text-green-700 flex-shrink-0"

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -476,15 +476,11 @@
                                     <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 min-w-[150px]">
                                         <div class="flex items-center gap-2">
                                             <Icon icon="lucide:bar-chart-3" class="w-4 h-4 text-blue-600" />
+                                            <span
+                                                class="flex-shrink-0 inline-block w-2 h-2 rounded-full {fact.dbt_model ? 'bg-primary-600' : 'border border-gray-300'}"
+                                                title={fact.dbt_model ? `Built with dbt: ${fact.dbt_model.split('.').pop()}` : 'Not yet built with dbt'}
+                                            ></span>
                                             <span class="truncate">{fact.label}</span>
-                                            {#if fact.dbt_model}
-                                                <span
-                                                    class="flex-shrink-0 inline-flex items-center text-gray-400"
-                                                    title={`Built with dbt: ${fact.dbt_model.split('.').pop()}`}
-                                                >
-                                                    <Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
-                                                </span>
-                                            {/if}
                                             {#if factVisibleDimensionCounts.get(fact.id) !== undefined}
                                                 <span
                                                     aria-label="{factVisibleDimensionCounts.get(fact.id)} connected dimensions"
@@ -517,15 +513,11 @@
                                         <td class="px-4 py-3 text-sm font-medium text-gray-900 bg-white sticky left-0 z-10 border-r border-gray-200 w-[200px] min-w-[200px]">
                                             <div class="flex items-center gap-2" title={dimension.label}>
                                                 <Icon icon="lucide:list" class="w-4 h-4 text-green-600 flex-shrink-0" />
+                                                <span
+                                                    class="flex-shrink-0 inline-block w-2 h-2 rounded-full {dimension.dbt_model ? 'bg-primary-600' : 'border border-gray-300'}"
+                                                    title={dimension.dbt_model ? `Built with dbt: ${dimension.dbt_model.split('.').pop()}` : 'Not yet built with dbt'}
+                                                ></span>
                                                 <span class="truncate">{dimension.label}</span>
-                                                {#if dimension.dbt_model}
-                                                    <span
-                                                        class="flex-shrink-0 inline-flex items-center text-gray-400"
-                                                        title={`Built with dbt: ${dimension.dbt_model.split('.').pop()}`}
-                                                    >
-                                                        <Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
-                                                    </span>
-                                                {/if}
                                                 <span
                                                     aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} connected facts"
                                                     class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-green-100 text-green-700 flex-shrink-0"

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -23,35 +23,37 @@ describe('BusMatrix — dbt build status badges', () => {
 		cleanup();
 	});
 
-	it('renders a simple-icons:dbt badge for bound dimension and bound fact, but not for unbound ones', async () => {
+	it('renders a filled build-status dot for bound dimension/fact and a hollow one for unbound', async () => {
 		render(BusMatrix);
 
 		await waitFor(() => {
 			expect(document.querySelector('table')).toBeTruthy();
 		});
 
-		const dbtBadges = Array.from(document.querySelectorAll('[title*="Built with dbt"]'));
-		expect(dbtBadges.length).toBe(2);
+		const filledDots = Array.from(document.querySelectorAll('.bg-primary-600'));
+		expect(filledDots.length).toBe(2);
 
 		const boundDimRow = Array.from(document.querySelectorAll('td')).find((td) =>
 			td.textContent?.includes('Bound Dimension')
 		) as HTMLElement;
-		expect(boundDimRow?.querySelector('[title*="Built with dbt"]')).toBeTruthy();
+		expect(boundDimRow?.querySelector('.bg-primary-600')).toBeTruthy();
 
 		const unboundDimRow = Array.from(document.querySelectorAll('td')).find((td) =>
 			td.textContent?.includes('Unbound Dimension')
 		) as HTMLElement;
-		expect(unboundDimRow?.querySelector('[title*="Built with dbt"]')).toBeFalsy();
+		expect(unboundDimRow?.querySelector('.bg-primary-600')).toBeFalsy();
+		expect(unboundDimRow?.querySelector('[title="Not yet built with dbt"]')).toBeTruthy();
 
 		const boundFactHeader = Array.from(document.querySelectorAll('th')).find((th) =>
 			th.textContent?.includes('Bound Fact')
 		) as HTMLElement;
-		expect(boundFactHeader?.querySelector('[title*="Built with dbt"]')).toBeTruthy();
+		expect(boundFactHeader?.querySelector('.bg-primary-600')).toBeTruthy();
 
 		const unboundFactHeader = Array.from(document.querySelectorAll('th')).find((th) =>
 			th.textContent?.includes('Unbound Fact')
 		) as HTMLElement;
-		expect(unboundFactHeader?.querySelector('[title*="Built with dbt"]')).toBeFalsy();
+		expect(unboundFactHeader?.querySelector('.bg-primary-600')).toBeFalsy();
+		expect(unboundFactHeader?.querySelector('[title="Not yet built with dbt"]')).toBeTruthy();
 	});
 
 	it('filtering to "Bound" only shows the bound dimension row and bound fact column', async () => {

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
+import BusMatrix from './BusMatrix.svelte';
+
+const mockBusMatrixData = vi.hoisted(() => ({
+	dimensions: [
+		{ id: 'dim_bound', label: 'Bound Dimension', tags: [], dbt_model: 'model.project.dim_bound' },
+		{ id: 'dim_unbound', label: 'Unbound Dimension', tags: [] },
+	],
+	facts: [
+		{ id: 'fct_bound', label: 'Bound Fact', tags: [], dbt_model: 'model.project.fct_bound' },
+		{ id: 'fct_unbound', label: 'Unbound Fact', tags: [] },
+	],
+	connections: [{ dimension_id: 'dim_bound', fact_id: 'fct_bound' }],
+}));
+
+vi.mock('$lib/api', () => ({
+	getBusMatrix: vi.fn().mockResolvedValue(mockBusMatrixData),
+}));
+
+describe('BusMatrix — dbt build status badges', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders a simple-icons:dbt badge for bound dimension and bound fact, but not for unbound ones', async () => {
+		render(BusMatrix);
+
+		await waitFor(() => {
+			expect(document.querySelector('table')).toBeTruthy();
+		});
+
+		const dbtBadges = Array.from(document.querySelectorAll('[title*="Built with dbt"]'));
+		expect(dbtBadges.length).toBe(2);
+
+		const boundDimRow = Array.from(document.querySelectorAll('td')).find((td) =>
+			td.textContent?.includes('Bound Dimension')
+		) as HTMLElement;
+		expect(boundDimRow?.querySelector('[title*="Built with dbt"]')).toBeTruthy();
+
+		const unboundDimRow = Array.from(document.querySelectorAll('td')).find((td) =>
+			td.textContent?.includes('Unbound Dimension')
+		) as HTMLElement;
+		expect(unboundDimRow?.querySelector('[title*="Built with dbt"]')).toBeFalsy();
+
+		const boundFactHeader = Array.from(document.querySelectorAll('th')).find((th) =>
+			th.textContent?.includes('Bound Fact')
+		) as HTMLElement;
+		expect(boundFactHeader?.querySelector('[title*="Built with dbt"]')).toBeTruthy();
+
+		const unboundFactHeader = Array.from(document.querySelectorAll('th')).find((th) =>
+			th.textContent?.includes('Unbound Fact')
+		) as HTMLElement;
+		expect(unboundFactHeader?.querySelector('[title*="Built with dbt"]')).toBeFalsy();
+	});
+
+	it('filtering to "Bound" only shows the bound dimension row and bound fact column', async () => {
+		render(BusMatrix);
+
+		await waitFor(() => {
+			expect(document.querySelector('table')).toBeTruthy();
+		});
+
+		const select = document.querySelector('#build-status-filter') as HTMLSelectElement;
+		expect(select).toBeTruthy();
+
+		await fireEvent.change(select, { target: { value: 'bound' } });
+
+		await waitFor(() => {
+			const table = document.querySelector('table') as HTMLElement;
+			expect(table.textContent).not.toContain('Unbound Dimension');
+		});
+
+		const table = document.querySelector('table') as HTMLElement;
+		expect(table.textContent).toContain('Bound Dimension');
+		expect(table.textContent).not.toContain('Unbound Fact');
+		expect(table.textContent).toContain('Bound Fact');
+
+		// only one connected fact/dimension remains visible, so counts should be 1
+		const countBadges = Array.from(table.querySelectorAll('[aria-label*="connected"]'));
+		expect(countBadges.some((el) => el.getAttribute('aria-label')?.startsWith('1 connected'))).toBe(true);
+	});
+});

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -417,7 +417,12 @@
 
 			<!-- Built Filter -->
 			<div class="flex items-center gap-2">
-				<span class="text-xs text-gray-600">Built:</span>
+				<span class="text-xs text-gray-600 inline-flex items-center gap-1">
+					Built:
+					<span class="inline-flex items-center gap-0.5 text-gray-400" title="Entities with this mark are already built with dbt">
+						(<Icon icon="lucide:check" class="w-3 h-3 text-primary-600" /> = built with dbt)
+					</span>
+				</span>
 
 				<!-- Selected build statuses as chips -->
 				{#if $entityListFilters.selectedBuildStatus.length > 0}

--- a/frontend/src/lib/components/EntityListFilters.svelte
+++ b/frontend/src/lib/components/EntityListFilters.svelte
@@ -140,6 +140,24 @@
 		}));
 	}
 
+	function toggleBuildStatus(status: 'bound' | 'unbound') {
+		entityListFilters.update((filters) => {
+			const statuses = [...filters.selectedBuildStatus];
+			if (statuses.includes(status)) {
+				return { ...filters, selectedBuildStatus: statuses.filter((s) => s !== status) };
+			} else {
+				return { ...filters, selectedBuildStatus: [...statuses, status] };
+			}
+		});
+	}
+
+	function removeBuildStatus(status: 'bound' | 'unbound') {
+		entityListFilters.update((filters) => ({
+			...filters,
+			selectedBuildStatus: filters.selectedBuildStatus.filter((s) => s !== status),
+		}));
+	}
+
 	function toggleSortDirection() {
 		entityListFilters.update((filters) => ({
 			...filters,
@@ -159,6 +177,7 @@
 			selectedDomains: [],
 			selectedTags: [],
 			selectedEntityTypes: [],
+			selectedBuildStatus: [],
 			sortDirection: filters.sortDirection,
 			groupByEntityType: filters.groupByEntityType,
 		}));
@@ -214,7 +233,7 @@
 			</button>
 
 			<!-- Clear Filters Button -->
-			{#if $entityListFilters.searchTerm || $entityListFilters.selectedDomains.length > 0 || $entityListFilters.selectedTags.length > 0 || $entityListFilters.selectedEntityTypes.length > 0}
+			{#if $entityListFilters.searchTerm || $entityListFilters.selectedDomains.length > 0 || $entityListFilters.selectedTags.length > 0 || $entityListFilters.selectedEntityTypes.length > 0 || $entityListFilters.selectedBuildStatus.length > 0}
 				<button
 					type="button"
 					onclick={clearAllFilters}
@@ -389,6 +408,57 @@
 						<option value="dimension" disabled={$entityListFilters.selectedEntityTypes.includes('dimension')}>Dimension</option>
 						<option value="fact" disabled={$entityListFilters.selectedEntityTypes.includes('fact')}>Fact</option>
 						<option value="unclassified" disabled={$entityListFilters.selectedEntityTypes.includes('unclassified')}>Unclassified</option>
+					</select>
+					<div class="absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
+						<Icon icon="lucide:chevron-down" class="w-3 h-3" />
+					</div>
+				</div>
+			</div>
+
+			<!-- Built Filter -->
+			<div class="flex items-center gap-2">
+				<span class="text-xs text-gray-600">Built:</span>
+
+				<!-- Selected build statuses as chips -->
+				{#if $entityListFilters.selectedBuildStatus.length > 0}
+					<div class="flex flex-wrap gap-1">
+						{#each $entityListFilters.selectedBuildStatus as status}
+							{@const statusLabel = status === 'bound' ? 'Bound' : 'Unbound'}
+							<span
+								class="inline-flex items-center gap-1.5 px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-medium border border-gray-300"
+							>
+								{statusLabel}
+								<button
+									onclick={() => removeBuildStatus(status)}
+									class="text-gray-600 hover:text-gray-900 transition-colors"
+									title="Remove {statusLabel}"
+								>
+									<Icon icon="lucide:x" class="w-3 h-3" />
+								</button>
+							</span>
+						{/each}
+					</div>
+				{/if}
+
+				<!-- Built dropdown -->
+				<div class="relative">
+					<select
+						value=""
+						data-testid="build-status-select"
+						onchange={(e) => {
+							const val = e.currentTarget.value as 'bound' | 'unbound';
+							if (val) {
+								toggleBuildStatus(val);
+								e.currentTarget.value = '';
+							}
+						}}
+						class="pl-2 pr-7 py-1.5 text-xs border border-gray-300 rounded bg-white focus:outline-none focus:ring-1 focus:ring-primary-600 focus:border-primary-600 appearance-none cursor-pointer"
+					>
+						<option value="" disabled selected>
+							{$entityListFilters.selectedBuildStatus.length > 0 ? 'Add status...' : 'All'}
+						</option>
+						<option value="bound" disabled={$entityListFilters.selectedBuildStatus.includes('bound')}>Bound</option>
+						<option value="unbound" disabled={$entityListFilters.selectedBuildStatus.includes('unbound')}>Unbound</option>
 					</select>
 					<div class="absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400">
 						<Icon icon="lucide:chevron-down" class="w-3 h-3" />

--- a/frontend/src/lib/components/EntityListFilters.test.ts
+++ b/frontend/src/lib/components/EntityListFilters.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { entityListFilters } from '$lib/stores';
+import EntityListFilters from './EntityListFilters.svelte';
+
+describe('EntityListFilters — Built (build status) filter', () => {
+	beforeEach(() => {
+		entityListFilters.set({
+			searchTerm: '',
+			selectedDomains: [],
+			selectedTags: [],
+			selectedEntityTypes: [],
+			selectedBuildStatus: [],
+			sortDirection: 'asc',
+			groupByEntityType: false,
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('adds "bound" to selectedBuildStatus when selecting "Bound" from the Built dropdown', async () => {
+		render(EntityListFilters, { props: { filteredCount: 0, totalCount: 0 } });
+
+		const select = document.querySelector('select[data-testid="build-status-select"]') as HTMLSelectElement;
+		expect(select).toBeTruthy();
+
+		await fireEvent.change(select, { target: { value: 'bound' } });
+
+		expect(get(entityListFilters).selectedBuildStatus).toEqual(['bound']);
+	});
+
+	it('removes "bound" from selectedBuildStatus when the chip remove button is clicked', async () => {
+		entityListFilters.update((filters) => ({ ...filters, selectedBuildStatus: ['bound'] }));
+
+		render(EntityListFilters, { props: { filteredCount: 0, totalCount: 0 } });
+
+		const removeButton = document.querySelector('[title="Remove Bound"]') as HTMLButtonElement;
+		expect(removeButton).toBeTruthy();
+
+		await fireEvent.click(removeButton);
+
+		expect(get(entityListFilters).selectedBuildStatus).toEqual([]);
+	});
+
+	it('resets selectedBuildStatus to [] along with other filters when Clear is clicked', async () => {
+		entityListFilters.update((filters) => ({
+			...filters,
+			searchTerm: 'foo',
+			selectedBuildStatus: ['bound', 'unbound'],
+			selectedEntityTypes: ['fact'],
+		}));
+
+		render(EntityListFilters, { props: { filteredCount: 0, totalCount: 0 } });
+
+		const clearButton = document.querySelector('button[title="Clear all filters"]') as HTMLButtonElement;
+		expect(clearButton).toBeTruthy();
+
+		await fireEvent.click(clearButton);
+
+		const filters = get(entityListFilters);
+		expect(filters.selectedBuildStatus).toEqual([]);
+		expect(filters.selectedEntityTypes).toEqual([]);
+		expect(filters.searchTerm).toEqual('');
+	});
+});

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -155,21 +155,21 @@
 		<Icon icon={typeIcon()} class="w-5 h-5" />
 	</div>
 
-	<!-- dbt build status badge (only when entity is bound to a dbt model) -->
-	{#if entity.dbt_model}
-		<span
-			class="flex-shrink-0 inline-flex items-center text-gray-400"
-			title={`Built with dbt: ${entity.dbt_model.split('.').pop()}`}
-		>
-			<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
-		</span>
-	{/if}
-
 	<!-- Entity Info (name, type, domain, tags) - Horizontal Layout -->
 	<div class="flex-1 min-w-0 flex items-center gap-3">
 		<!-- Entity name -->
 		<span class="text-sm font-semibold text-slate-800 truncate min-w-[200px]">
 			{entity.label}
+		</span>
+
+		<!-- dbt build status badge — reserved slot so later badges stay aligned whether or not the entity is bound -->
+		<span
+			class="flex-shrink-0 inline-flex items-center justify-center w-4 text-gray-400"
+			title={entity.dbt_model ? `Built with dbt: ${entity.dbt_model.split('.').pop()}` : undefined}
+		>
+			{#if entity.dbt_model}
+				<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+			{/if}
 		</span>
 
 		<!-- Type badge (only visible in dimensional modeling) -->

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -155,6 +155,16 @@
 		<Icon icon={typeIcon()} class="w-5 h-5" />
 	</div>
 
+	<!-- dbt build status badge (only when entity is bound to a dbt model) -->
+	{#if entity.dbt_model}
+		<span
+			class="flex-shrink-0 inline-flex items-center text-gray-400"
+			title={`Built with dbt: ${entity.dbt_model.split('.').pop()}`}
+		>
+			<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+		</span>
+	{/if}
+
 	<!-- Entity Info (name, type, domain, tags) - Horizontal Layout -->
 	<div class="flex-1 min-w-0 flex items-center gap-3">
 		<!-- Entity name -->

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -162,13 +162,13 @@
 			{entity.label}
 		</span>
 
-		<!-- dbt build status badge — reserved slot so later badges stay aligned whether or not the entity is bound -->
+		<!-- dbt build status badge — reserved slot so later badges stay aligned whether or not the entity is bound. Uses the same check icon/color as the "Bound" filter in the sidebar for consistency. -->
 		<span
-			class="flex-shrink-0 inline-flex items-center justify-center w-4 text-gray-400"
+			class="flex-shrink-0 inline-flex items-center justify-center w-4 text-primary-600"
 			title={entity.dbt_model ? `Built with dbt: ${entity.dbt_model.split('.').pop()}` : undefined}
 		>
 			{#if entity.dbt_model}
-				<Icon icon="simple-icons:dbt" class="h-3.5 w-3.5 opacity-70" aria-hidden="true" />
+				<Icon icon="lucide:check" class="h-3.5 w-3.5" aria-hidden="true" />
 			{/if}
 		</span>
 

--- a/frontend/src/lib/components/EntityRow.test.ts
+++ b/frontend/src/lib/components/EntityRow.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import EntityRow from './EntityRow.svelte';
+import type { Entity } from '$lib/types';
+
+const baseEntity: Entity = {
+	id: 'booking',
+	label: 'Booking',
+	position: { x: 0, y: 0 },
+};
+
+describe('EntityRow — dbt build status badge', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders a dbt badge with tooltip showing the resolved model name for a bound entity', () => {
+		const entity: Entity = {
+			...baseEntity,
+			dbt_model: 'model.project.dim_customer',
+		};
+
+		render(EntityRow, { props: { entity } });
+
+		// The badge is the title-bearing wrapper around the Icon component (mirrors the
+		// existing "Materialized in dbt model" convention in EntityDetailModal.svelte, where
+		// assertions target the wrapper's title/aria-label rather than the Icon's internal
+		// (async-loaded) SVG markup).
+		const badge = document.querySelector('[title*="Built with dbt"]');
+		expect(badge).toBeTruthy();
+		expect(badge?.getAttribute('title')).toContain('Built with dbt: dim_customer');
+	});
+
+	it('does not render a dbt badge for an unbound entity (no dbt_model)', () => {
+		const entity: Entity = {
+			...baseEntity,
+			dbt_model: undefined,
+		};
+
+		render(EntityRow, { props: { entity } });
+
+		const badge = document.querySelector('[title*="Built with dbt"]');
+		expect(badge).toBeFalsy();
+	});
+});

--- a/frontend/src/lib/stores.test.ts
+++ b/frontend/src/lib/stores.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { get } from 'svelte/store';
-import { nodes, edges, canUndo, canRedo, pushHistory, initHistory, undo, redo } from './stores';
+import { nodes, edges, canUndo, canRedo, pushHistory, initHistory, undo, redo, entityListFilters } from './stores';
 
 describe('Undo/Redo History', () => {
     beforeEach(() => {
@@ -154,6 +154,12 @@ describe('Undo/Redo History', () => {
         // Undo should go back to initial empty state, not intermediate states
         undo();
         expect(get(nodes)).toEqual([]);
+    });
+});
+
+describe('entityListFilters', () => {
+    it('initializes with selectedBuildStatus as an empty array', () => {
+        expect(get(entityListFilters).selectedBuildStatus).toEqual([]);
     });
 });
 

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -58,6 +58,7 @@ export const entityListFilters = writable<EntityListFilters>({
 	selectedDomains: [],
 	selectedTags: [],
 	selectedEntityTypes: [],
+	selectedBuildStatus: [],
 	sortDirection: 'asc',
 	groupByEntityType: false,
 });

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -472,6 +472,7 @@ export interface EntityListFilters {
     selectedDomains: string[];
     selectedTags: string[];
     selectedEntityTypes: Array<'dimension' | 'fact' | 'unclassified'>;
+    selectedBuildStatus: Array<'bound' | 'unbound'>;
     sortDirection: 'asc' | 'desc';
     groupByEntityType: boolean;
 }

--- a/frontend/src/lib/utils/entity-filtering.test.ts
+++ b/frontend/src/lib/utils/entity-filtering.test.ts
@@ -10,7 +10,8 @@ describe('entity-filtering', () => {
 		domain?: string,
 		tags?: string[],
 		domains?: string[],
-		entity_type?: 'dimension' | 'fact' | 'unclassified'
+		entity_type?: 'dimension' | 'fact' | 'unclassified',
+		dbt_model?: string
 	): Entity => ({
 		id,
 		label,
@@ -20,6 +21,7 @@ describe('entity-filtering', () => {
 		description: '',
 		entity_type: entity_type ?? 'dimension',
 		attributes: [],
+		dbt_model,
 	});
 
 	describe('filterEntities', () => {
@@ -641,6 +643,109 @@ describe('entity-filtering', () => {
 
 			expect(result).toHaveLength(1);
 			expect(result[0].label).toBe('Customer Master');
+		});
+	});
+
+	describe('Build status filtering', () => {
+		it('should return all entities when selectedBuildStatus is empty array', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedBuildStatus: [],
+			});
+
+			expect(result).toHaveLength(2);
+		});
+
+		it('should return all entities when selectedBuildStatus is undefined', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+			});
+
+			expect(result).toHaveLength(2);
+		});
+
+		it('should filter to only bound entities when selectedBuildStatus is ["bound"]', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Product', 'Inventory', [], [], 'dimension', ''),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedBuildStatus: ['bound'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Customer');
+		});
+
+		it('should filter to only unbound entities when selectedBuildStatus is ["unbound"]', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Product', 'Inventory', [], [], 'dimension', ''),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedBuildStatus: ['unbound'],
+			});
+
+			expect(result).toHaveLength(2);
+			expect(result.map((e) => e.label)).toEqual(['Order', 'Product']);
+		});
+
+		it('should return all entities when both bound and unbound are selected', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Order', 'Sales', [], [], 'fact'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: '',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedBuildStatus: ['bound', 'unbound'],
+			});
+
+			expect(result).toHaveLength(2);
+		});
+
+		it('should combine correctly with search term filter', () => {
+			const entities = [
+				createEntity('1', 'Customer', 'Sales', [], [], 'dimension', 'dim_customer'),
+				createEntity('2', 'Customer Order', 'Sales', [], [], 'fact'),
+				createEntity('3', 'Product', 'Inventory', [], [], 'dimension'),
+			];
+
+			const result = filterEntities(entities, {
+				searchTerm: 'customer',
+				selectedDomains: [],
+				selectedTags: [],
+				selectedBuildStatus: ['unbound'],
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].label).toBe('Customer Order');
 		});
 	});
 });

--- a/frontend/src/lib/utils/entity-filtering.ts
+++ b/frontend/src/lib/utils/entity-filtering.ts
@@ -29,6 +29,7 @@ export function filterEntities(
 		selectedDomains: string[];
 		selectedTags: string[];
 		selectedEntityTypes?: Array<'dimension' | 'fact' | 'unclassified'>;
+		selectedBuildStatus?: Array<'bound' | 'unbound'>;
 	}
 ): Entity[] {
 	return entities.filter((entity) => {
@@ -42,6 +43,14 @@ export function filterEntities(
 			const effectiveType: 'dimension' | 'fact' | 'unclassified' =
 				entity.entity_type ?? 'unclassified';
 			if (!filters.selectedEntityTypes.includes(effectiveType)) {
+				return false;
+			}
+		}
+
+		// Filter by build status (OR logic: if empty/undefined, show all)
+		if (filters.selectedBuildStatus && filters.selectedBuildStatus.length > 0) {
+			const isBound = !!entity.dbt_model;
+			if (!filters.selectedBuildStatus.includes(isBound ? 'bound' : 'unbound')) {
 				return false;
 			}
 		}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.19.0b1"
+version = "0.19.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.18.0"
+version = "0.19.0b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "trellis-datamodel"
-version = "0.17.1"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Show a dbt build-status badge (dbt icon) on bound entities in the Entity List, plus a new "Built" filter (Bound/Unbound) alongside the existing Domain/Tag/Type filters
- Show the same badge and filter on dimensions and facts in the Bus Matrix, applying to both axes via a single filter control
- No backend changes: dbt_model was already returned by both APIs, this is purely frontend typing, filtering logic, and rendering

## Test plan

- [x] npx vitest run — 41 test files, 823 tests passing (up from 818 baseline)
- [x] npm run check — 0 type errors (46 pre-existing warnings, unchanged)
- [x] New unit/component tests added: entity-filtering.test.ts, stores.test.ts, EntityListFilters.test.ts, EntityRow.test.ts, BusMatrix.test.ts
- [x] Manual check: Entity List's new "Built" filter renders and behaves correctly (screenshotted)
- [ ] Manual check: Bus Matrix badge/filter in a live browser (dev session was interrupted before this could be captured — component test coverage exists, but no manual screenshot)