### PR TITLE
Fix/entity list loading indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-07-31
+
+### Fixed
+- **Entity List showed "No entities yet" while still loading**: on projects with lots of entities, the list rendered its empty state for a few seconds during the initial data model fetch, indistinguishable from an actually-empty project. Entity List now shows a loading spinner until the fetch completes, matching the pattern already used on Canvas.
+- **Inconsistent loading spinners across views**: Bus Matrix, Exposures, and Business Events each used their own spinner markup (icon-based, different border style/size/color) instead of the shared pattern, and the Bus Matrix/Exposures/Business Events page wrappers showed a blank screen during their initial config-check before rendering. All loading spinners are now visually identical and none of the views have a blank-screen gap.
+- **Entity List loading spinner positioned near the top instead of centered**: the wrapper div around the Entity List component had no height set, so the component's own full-height centering never had space to work with. Fixed by propagating height down through the wrapper.
+
 ## [0.19.0] - 2026-07-31
 
 ### Added

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -213,7 +213,7 @@
     {#if loading}
         <div class="flex items-center justify-center h-full">
             <div class="text-center">
-                <div class="w-8 h-8 animate-spin border-4 border-primary-600 border-t-transparent rounded-full mx-auto mb-2"></div>
+                <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
                 <p class="text-sm text-gray-600">Loading Bus Matrix...</p>
             </div>
         </div>

--- a/frontend/src/lib/components/BusinessEvents.svelte
+++ b/frontend/src/lib/components/BusinessEvents.svelte
@@ -817,7 +817,7 @@ let dropIndicatorPosition = $state<'before' | 'after' | null>(null);
     {#if loading}
         <div class="flex items-center justify-center h-full">
             <div class="text-center">
-                <div class="w-8 h-8 animate-spin border-4 border-primary-600 border-t-transparent rounded-full mx-auto mb-2"></div>
+                <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
                 <p class="text-sm text-gray-600">Loading business events...</p>
             </div>
         </div>

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -211,9 +211,11 @@
 		<!-- Hierarchical Entity List -->
 		{#if loading}
 			<!-- Loading state: still fetching data model -->
-			<div class="flex flex-col items-center justify-center py-16 px-4 text-center">
-				<div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
-				<p class="text-sm text-gray-600">Loading entities...</p>
+			<div class="h-full flex items-center justify-center px-4 text-center">
+				<div>
+					<div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
+					<p class="text-sm text-gray-600">Loading entities...</p>
+				</div>
 			</div>
 		{:else if entities.length === 0}
 			<!-- Empty state: No entities exist -->

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { getContext } from 'svelte';
+	import { readable, type Readable } from 'svelte/store';
 	import {
 		nodes,
 		entityListFilters,
@@ -14,6 +16,10 @@
 	import EntityRow from './EntityRow.svelte';
 	import CollapseChevron from './CollapseChevron.svelte';
 	import Icon from '@iconify/svelte';
+
+	const loadingStore =
+		getContext<Readable<boolean>>('loading') ?? readable(false);
+	const loading = $derived($loadingStore);
 
 	// Convert nodes to entities for filtering and grouping
 	const entities = $derived.by(() => {
@@ -203,7 +209,13 @@
 		{/if}
 
 		<!-- Hierarchical Entity List -->
-		{#if entities.length === 0}
+		{#if loading}
+			<!-- Loading state: still fetching data model -->
+			<div class="flex flex-col items-center justify-center py-16 px-4 text-center">
+				<div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
+				<p class="text-sm text-gray-600">Loading entities...</p>
+			</div>
+		{:else if entities.length === 0}
 			<!-- Empty state: No entities exist -->
 			<div class="flex flex-col items-center justify-center py-16 px-4 text-center">
 				<div class="text-gray-400 mb-4">

--- a/frontend/src/lib/components/ExposuresTable.svelte
+++ b/frontend/src/lib/components/ExposuresTable.svelte
@@ -254,7 +254,7 @@ $effect(() => {
     {#if loading}
         <div class="flex items-center justify-center h-full">
             <div class="text-center">
-                <Icon icon="lucide:loader-2" class="w-8 h-8 animate-spin text-primary-600 mx-auto mb-2" />
+                <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
                 <p class="text-sm text-gray-600">Loading exposures...</p>
             </div>
         </div>

--- a/frontend/src/routes/(app)/bus-matrix/+page.svelte
+++ b/frontend/src/routes/(app)/bus-matrix/+page.svelte
@@ -35,9 +35,16 @@
     <meta name="description" content="Bus matrix view - understand data flow across your data models" />
 </svelte:head>
 
-{#if !loading && busMatrixEnabled}
+{#if loading}
+    <div class="flex-1 h-full relative w-full flex items-center justify-center">
+        <div class="text-center">
+            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
+            <p class="text-sm text-gray-600">Loading bus matrix...</p>
+        </div>
+    </div>
+{:else if busMatrixEnabled}
     <BusMatrix />
-{:else if !loading}
+{:else}
     <div class="flex items-center justify-center h-full text-gray-500">
         <p>Bus matrix view is not available.</p>
     </div>

--- a/frontend/src/routes/(app)/business-events/+page.svelte
+++ b/frontend/src/routes/(app)/business-events/+page.svelte
@@ -43,9 +43,9 @@
 </svelte:head>
 
 {#if loading}
-    <div class="flex items-center justify-center h-full">
-        <div class="flex flex-col items-center gap-3">
-            <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+    <div class="flex-1 h-full relative w-full flex items-center justify-center">
+        <div class="text-center">
+            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
             <p class="text-sm text-gray-600">Loading business events...</p>
         </div>
     </div>

--- a/frontend/src/routes/(app)/entity-list/+page.svelte
+++ b/frontend/src/routes/(app)/entity-list/+page.svelte
@@ -74,7 +74,7 @@
 
 		<!-- List Section -->
 		<div class="flex-1 overflow-auto w-full">
-			<div class="max-w-7xl mx-auto">
+			<div class="max-w-7xl mx-auto h-full">
 				<EntityList />
 			</div>
 		</div>

--- a/frontend/src/routes/(app)/exposures/+page.svelte
+++ b/frontend/src/routes/(app)/exposures/+page.svelte
@@ -43,9 +43,16 @@
     <meta name="description" content="Exposures view - visualize your dbt exposures and downstream data products" />
 </svelte:head>
 
-{#if !loading && exposuresEnabled && hasExposuresData}
+{#if loading}
+    <div class="flex-1 h-full relative w-full flex items-center justify-center">
+        <div class="text-center">
+            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mb-4"></div>
+            <p class="text-sm text-gray-600">Loading exposures...</p>
+        </div>
+    </div>
+{:else if exposuresEnabled && hasExposuresData}
     <ExposuresTable {exposuresEnabled} {exposuresDefaultLayout} />
-{:else if !loading}
+{:else}
     <div class="flex items-center justify-center h-full text-gray-500">
         <p>Exposures view is not available.</p>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.19.0"
+version = "0.19.1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Fix inconsistent loading states across Entity List, Bus Matrix, Exposures, and Business Events.

Entity List showed "No entities yet" for a few seconds while the data model was still loading on large projects, indistinguishable from an actually-empty project. Added a loading spinner gated on the same loading context canvas already uses.

While checking that, found three more inconsistencies and fixed them too: Bus Matrix, Exposures, and Business Events each had their own different spinner markup (icon vs CSS ring, different sizes/colors) instead of a shared pattern, and the Bus Matrix/Exposures/Business Events page wrappers showed a blank screen during their initial config-check before rendering anything. Unified all of them to the same spinner markup and removed the blank-screen gaps.

Also fixed the Entity List spinner sitting nad of centered — the wrapper div around thecomponent had no height set so the component's own centering had no space to work with.

Bumped version to 0.19.1 and updated CHANGELOG.

Tests: 417 backend tests pass, npm run check clean, no functional behavior changed outside the loading states themselves.