### PR TITLE
Refactor/generalize transformation adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.0b1] - 2026-08-03
+## [0.20.0b2] - 2026-08-03
 
-> **Prerelease.** This is a large structural refactor that changes how entities are stored in
-> `data_model.yml`. It is behavior-preserving by design and fully covered by tests, but the on-disk
-> change is worth exercising against a real project before a stable release.
+> **Prerelease.** Supersedes 0.20.0b1 — same refactor, one field renamed. See b1 below for the full
+> set of changes in this release line.
+
+### Changed since b1
+
+- **`native_data_type` renamed to `physical_datatype`.** "Native" left the reader asking native to
+  what, and implied an untouched value the field does not hold (catalog spellings are canonicalized
+  on the way in). It also read badly beside its sibling: `datatype: text` next to
+  `native_data_type: TEXT` differs only by case. `physical_datatype` names the real distinction —
+  `datatype` is Trellis's logical bucket (closed set: text/int/float/bool/date/timestamp/unknown),
+  `physical_datatype` is the concrete type the framework's catalog reports (varchar, timestamp,
+  numeric(38,0)) — and matching `datatype`'s spelling keeps the pair symmetric.
+
+  **If you saved a `data_model.yml` while running b1**, it contains `native_data_type` keys. b2 does
+  not read that name (it reads `physical_datatype`, falling back to the legacy `dbt_data_type`), so
+  those precise types will read as absent. **Run a reconcile** — it repopulates the field from the
+  framework catalog, so nothing is permanently lost. `native_data_type` is deliberately not kept as a
+  legacy read key: it existed only in b1 and carrying it forever would mean three spellings of one
+  field.
 
 ### ⚠️ Upgrade is one-way
 
@@ -23,12 +39,17 @@ That means **rolling back to 0.19.x after saving is not supported**. Older versi
 not appear on the canvas. Commit or back up `data_model.yml` before upgrading if you want a clean way
 back.
 
+## [0.20.0b1] - 2026-08-03
+
+> **Superseded by 0.20.0b2**, which renames this release's `native_data_type` field to
+> `physical_datatype`. Everything below still describes the release line.
+
 ### Added
 - **Framework-neutral endpoint paths**: `/api/reconcile`, `/api/schema`, and `/api/sync-tests` are now the primary API surface. The legacy `/api/reconcile-dbt`, `/api/dbt-schema`, `/api/sync-dbt-tests` paths have been retired now that the frontend is fully migrated.
 - **Framework-driven Sidebar icon/label**: the sidebar's model icon and label are now driven by the configured `framework` rather than assuming dbt. A framework Trellis has no adapter for falls back to neutral branding instead of silently rendering dbt's icon and label.
 
 ### Changed
-- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `physical_datatype`. Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
+- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `native_data_type` (renamed again to `physical_datatype` in b2). Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
 - **Reconciliation "wins" semantics reworded as framework-neutral**: `services/reconciliation.py`'s dbt-wins rule is now described as "the active framework's materialized model wins over a drafted concept." The underlying algorithm (one-way, idempotent, absence-is-never-deletion) is unchanged.
 - **Adapter protocol closed up**: `save_schema_file`, `infer_entity_types`, `get_model_dirs`, and `reset_inference_cache` are now declared on `TransformationAdapter` instead of being called on `DbtCoreAdapter` without a protocol contract. No module outside `adapters/` imports `DbtCoreAdapter` directly anymore. A new `FakeAdapter` test double proves reconciliation and schema services work against a non-dbt adapter.
 - **Internal dbt-named functions renamed**: `reconcile_dbt()` → `reconcile_framework()`, `sync_dbt_tests()` → `sync_framework_tests()`, `_map_dbt_type()` → `_map_column_type()`, `save_dbt_schema()` → `save_model_schema_from_request()`/`save_schema_file()`. Purely internal — no API impact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-08-03
+
+Structural refactor that decouples Trellis from dbt-specific naming, so a second transformation
+framework becomes an adapter you write rather than `if framework == ...` branches threaded through
+every service. No functional change for dbt-core users. Validated through the 0.20.0b1/b2
+prereleases against a real project: `data_model.yml` migrates cleanly on first save, and push
+produces the expected `schema.yml` output.
+
+### ⚠️ Upgrade is one-way
+
+Entity fields are renamed on disk (`dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`,
+`dbt_data_type` → `physical_datatype`). Reading the old names is permanent, so **upgrading is
+transparent and needs no migration**. Writing is not: the first save after upgrading rewrites your
+`data_model.yml` with the new names only.
+
+That means **rolling back to 0.19.x after saving is not supported**. Older versions only look for
+`dbt_model`, so every entity would load as unbound — model bindings and framework-mirrored tags would
+not appear on the canvas. Commit or back up `data_model.yml` before upgrading if you want a clean way
+back.
+
+### Added
+- **Framework-neutral endpoint paths**: `/api/reconcile`, `/api/schema`, and `/api/sync-tests` are now the primary API surface, replacing `/api/reconcile-dbt`, `/api/dbt-schema`, and `/api/sync-dbt-tests`.
+- **Framework-driven Sidebar icon/label**: the sidebar's model icon and label are driven by the configured `framework` rather than assuming dbt. A framework Trellis has no adapter for falls back to neutral branding instead of silently rendering dbt's.
+
+### Changed
+- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `physical_datatype`. Old names load transparently and permanently; only the new names are written back. `physical_datatype` pairs with a column's `datatype`: `datatype` is the coarse logical bucket, `physical_datatype` the concrete type the framework's catalog reports, kept so a push doesn't downgrade a precise type.
+- **Reconciliation "wins" semantics reworded as framework-neutral**: described as "the active framework's materialized model wins over a drafted concept". The algorithm (one-way, idempotent, absence-is-never-deletion) is unchanged.
+- **Adapter protocol closed up**: `save_schema_file`, `infer_entity_types`, `get_model_dirs`, and `reset_inference_cache` are now declared on `TransformationAdapter` instead of being called on `DbtCoreAdapter` without a contract. No module outside `adapters/` imports `DbtCoreAdapter`. A `FakeAdapter` test double proves reconciliation and schema services work against a non-dbt adapter.
+- **Internal dbt-named functions renamed**: `reconcile_dbt()` → `reconcile_framework()`, `sync_dbt_tests()` → `sync_framework_tests()`, `_map_dbt_type()` → `_map_column_type()`, `save_dbt_schema()` → `save_model_schema_from_request()`/`save_schema_file()`. Internal only.
+
+### Notes
+- Behavior-preserving by design: dbt-core projects see no functional change beyond the transparently read-compatible field renames.
+- Some subsystems (`services/lineage.py`, `services/exposures.py`, `services/manifest.py`, and related routes) still read dbt artifacts directly rather than through the adapter protocol. Deferred to the BruinAdapter work and pinned by strict-xfail contract tests so it can't be silently forgotten.
+- No second framework ships here. `FrameworkEnum` lists only `dbt-core`, so a framework becomes selectable in `trellis.yml` at the same time as its working adapter, never before.
+
 ## [0.20.0b2] - 2026-08-03
 
 > **Prerelease.** Supersedes 0.20.0b1 — same refactor, one field renamed. See b1 below for the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-07-31
+
+### Added
+- **`FrameworkEnum.BRUIN` and Bruin config scaffolding**: `trellis.yml` accepts `framework: bruin` with `bruin_pipeline_path`/`bruin_asset_paths`, resolved the same way as the existing dbt config fields. Setting `framework: bruin` today raises a clear "Bruin adapter not yet implemented" error from the adapter factory instead of silently running dbt behavior. Building the actual `BruinAdapter` is left to a follow-up.
+- **Framework-neutral endpoint paths**: `/api/reconcile`, `/api/schema`, and `/api/sync-tests` are now the primary API surface. The legacy `/api/reconcile-dbt`, `/api/dbt-schema`, `/api/sync-dbt-tests` paths have been retired now that the frontend is fully migrated.
+- **Framework-driven Sidebar icon/label**: the sidebar's model icon and label now switch on the configured `framework` (dbt-core vs. bruin) instead of assuming dbt. A placeholder Bruin icon is bundled ahead of the adapter itself.
+
+### Changed
+- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `native_data_type`. Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
+- **Reconciliation "wins" semantics reworded as framework-neutral**: `services/reconciliation.py`'s dbt-wins rule is now described as "the active framework's materialized model wins over a drafted concept." The underlying algorithm (one-way, idempotent, absence-is-never-deletion) is unchanged.
+- **Adapter protocol closed up**: `save_schema_file`, `infer_entity_types`, `get_model_dirs`, and `reset_inference_cache` are now declared on `TransformationAdapter` instead of being called on `DbtCoreAdapter` without a protocol contract. No module outside `adapters/` imports `DbtCoreAdapter` directly anymore. A new `FakeAdapter` test double proves reconciliation and schema services work against a non-dbt adapter.
+- **Internal dbt-named functions renamed**: `reconcile_dbt()` → `reconcile_framework()`, `sync_dbt_tests()` → `sync_framework_tests()`, `_map_dbt_type()` → `_map_column_type()`, `save_dbt_schema()` → `save_model_schema_from_request()`/`save_schema_file()`. Purely internal — no API impact.
+
+### Notes
+- This is a behavior-preserving structural refactor: existing dbt-core projects see no functional change beyond internal field renames, which are transparently read-compatible.
+- Some subsystems (`services/lineage.py`, `services/exposures.py`, `services/manifest.py`, and related routes) still read dbt artifacts directly instead of going through the adapter protocol. This is deliberately deferred to the upcoming BruinAdapter work and pinned by strict-xfail contract tests so it can't be silently forgotten.
+
 ## [0.19.1] - 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.20.0] - 2026-07-31
 
 ### Added
-- **`FrameworkEnum.BRUIN` and Bruin config scaffolding**: `trellis.yml` accepts `framework: bruin` with `bruin_pipeline_path`/`bruin_asset_paths`, resolved the same way as the existing dbt config fields. Setting `framework: bruin` today raises a clear "Bruin adapter not yet implemented" error from the adapter factory instead of silently running dbt behavior. Building the actual `BruinAdapter` is left to a follow-up.
 - **Framework-neutral endpoint paths**: `/api/reconcile`, `/api/schema`, and `/api/sync-tests` are now the primary API surface. The legacy `/api/reconcile-dbt`, `/api/dbt-schema`, `/api/sync-dbt-tests` paths have been retired now that the frontend is fully migrated.
-- **Framework-driven Sidebar icon/label**: the sidebar's model icon and label now switch on the configured `framework` (dbt-core vs. bruin) instead of assuming dbt. A placeholder Bruin icon is bundled ahead of the adapter itself.
+- **Framework-driven Sidebar icon/label**: the sidebar's model icon and label are now driven by the configured `framework` rather than assuming dbt. A framework Trellis has no adapter for falls back to neutral branding instead of silently rendering dbt's icon and label.
 
 ### Changed
 - **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `native_data_type`. Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - This is a behavior-preserving structural refactor: existing dbt-core projects see no functional change beyond internal field renames, which are transparently read-compatible.
 - Some subsystems (`services/lineage.py`, `services/exposures.py`, `services/manifest.py`, and related routes) still read dbt artifacts directly instead of going through the adapter protocol. This is deliberately deferred to the upcoming BruinAdapter work and pinned by strict-xfail contract tests so it can't be silently forgotten.
+- No second framework ships here. This release is the groundwork that makes adding one an adapter-shaped job; `FrameworkEnum` still lists only `dbt-core`, so a framework becomes selectable in `trellis.yml` at the same time as its working adapter, never before.
 
 ## [0.19.1] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.0] - 2026-07-31
+## [0.20.0b1] - 2026-08-03
+
+> **Prerelease.** This is a large structural refactor that changes how entities are stored in
+> `data_model.yml`. It is behavior-preserving by design and fully covered by tests, but the on-disk
+> change is worth exercising against a real project before a stable release.
+
+### ⚠️ Upgrade is one-way
+
+Entity fields are renamed on disk (`dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`,
+`dbt_data_type` → `native_data_type`). Reading the old names is permanent, so **upgrading is
+transparent and needs no migration**. Writing is not: the first save after upgrading rewrites your
+`data_model.yml` with the new names only.
+
+That means **rolling back to 0.19.x after saving is not supported**. Older versions only look for
+`dbt_model`, so every entity would load as unbound — model bindings and framework-mirrored tags would
+not appear on the canvas. Commit or back up `data_model.yml` before upgrading if you want a clean way
+back.
 
 ### Added
 - **Framework-neutral endpoint paths**: `/api/reconcile`, `/api/schema`, and `/api/sync-tests` are now the primary API surface. The legacy `/api/reconcile-dbt`, `/api/dbt-schema`, `/api/sync-dbt-tests` paths have been retired now that the frontend is fully migrated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚠️ Upgrade is one-way
 
 Entity fields are renamed on disk (`dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`,
-`dbt_data_type` → `native_data_type`). Reading the old names is permanent, so **upgrading is
+`dbt_data_type` → `physical_datatype`). Reading the old names is permanent, so **upgrading is
 transparent and needs no migration**. Writing is not: the first save after upgrading rewrites your
 `data_model.yml` with the new names only.
 
@@ -28,7 +28,7 @@ back.
 - **Framework-driven Sidebar icon/label**: the sidebar's model icon and label are now driven by the configured `framework` rather than assuming dbt. A framework Trellis has no adapter for falls back to neutral branding instead of silently rendering dbt's icon and label.
 
 ### Changed
-- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `native_data_type`. Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
+- **`data_model.yml` entity fields generalized**: `dbt_model` → `model_ref`, `dbt_tags` → `framework_tags`, `dbt_data_type` → `physical_datatype`. Existing files using the old field names continue to load transparently (read-compat is permanent); only the new names are written back on save. No manual migration needed.
 - **Reconciliation "wins" semantics reworded as framework-neutral**: `services/reconciliation.py`'s dbt-wins rule is now described as "the active framework's materialized model wins over a drafted concept." The underlying algorithm (one-way, idempotent, absence-is-never-deletion) is unchanged.
 - **Adapter protocol closed up**: `save_schema_file`, `infer_entity_types`, `get_model_dirs`, and `reset_inference_cache` are now declared on `TransformationAdapter` instead of being called on `DbtCoreAdapter` without a protocol contract. No module outside `adapters/` imports `DbtCoreAdapter` directly anymore. A new `FakeAdapter` test double proves reconciliation and schema services work against a non-dbt adapter.
 - **Internal dbt-named functions renamed**: `reconcile_dbt()` → `reconcile_framework()`, `sync_dbt_tests()` → `sync_framework_tests()`, `_map_dbt_type()` → `_map_column_type()`, `save_dbt_schema()` → `save_model_schema_from_request()`/`save_schema_file()`. Purely internal — no API impact.

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { inferRelationships, addSevenWsEntry, removeSevenWsEntry, updateSevenWsEntry, getDimensions, createBusinessEvent, updateBusinessEvent, getBusinessEventProcesses, createBusinessEventProcess, updateBusinessEventProcess, resolveBusinessEventProcess, attachEventsToProcess, detachEventsFromProcess, generateEntitiesFromProcess } from './api';
+import { inferRelationships, addSevenWsEntry, removeSevenWsEntry, updateSevenWsEntry, getDimensions, createBusinessEvent, updateBusinessEvent, getBusinessEventProcesses, createBusinessEventProcess, updateBusinessEventProcess, resolveBusinessEventProcess, attachEventsToProcess, detachEventsFromProcess, generateEntitiesFromProcess, syncDbtTests, reconcileDbt } from './api';
 import type { BusinessEventType, BusinessEventSevenWs, CreateProcessRequest, UpdateProcessRequest, AttachEventsRequest, DetachEventsRequest } from '$lib/types';
 
 describe('API Functions - 7 Ws', () => {
@@ -27,6 +27,51 @@ describe('API Functions - 7 Ws', () => {
         const result = await inferRelationships();
         expect(result).toHaveLength(1);
         expect(result[0]).toMatchObject(rel);
+    });
+});
+
+describe('framework-neutral endpoint paths', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('syncDbtTests calls /api/sync-tests, not the legacy /api/sync-dbt-tests path', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockResolvedValue({ message: 'ok' }),
+            }),
+        );
+
+        await syncDbtTests();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            'http://localhost:8089/api/sync-tests',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const calledUrl = (global.fetch as any).mock.calls[0][0];
+        expect(calledUrl).not.toContain('/sync-dbt-tests');
+    });
+
+    it('reconcileDbt calls /api/reconcile, not the legacy /api/reconcile-dbt path', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockResolvedValue({ status: 'success', changed: false, data_model: {} }),
+            }),
+        );
+
+        await reconcileDbt();
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            'http://localhost:8089/api/reconcile',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const calledUrl = (global.fetch as any).mock.calls[0][0];
+        expect(calledUrl).not.toContain('/reconcile-dbt');
     });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type {
-    DbtModel,
+    ModelInfo,
     DataModel,
     DraftedField,
     ConfigStatus,
@@ -81,7 +81,7 @@ export function getApiBase(): string {
 
 const API_BASE = getApiBase();
 
-export async function getManifest(): Promise<DbtModel[]> {
+export async function getManifest(): Promise<ModelInfo[]> {
     try {
         // Short-circuit in test/smoke environments to avoid console 500s when backend is absent
         const isSmokeMode =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -212,7 +212,7 @@ export async function inferRelationships(): Promise<Relationship[]> {
 
 export async function syncDbtTests(): Promise<{ message: string }> {
     try {
-        const res = await fetch(`${API_BASE}/sync-dbt-tests`, {
+        const res = await fetch(`${API_BASE}/sync-tests`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({}),
@@ -1135,7 +1135,7 @@ export async function detachEventsFromProcess(
 
 export async function reconcileDbt(): Promise<{ status: string; changed: boolean; data_model: DataModel }> {
     try {
-        const res = await fetch(`${API_BASE}/reconcile-dbt`, { method: 'POST' });
+        const res = await fetch(`${API_BASE}/reconcile`, { method: 'POST' });
         if (!res.ok) {
             if (res.status === 404) return { status: 'success', changed: false, data_model: {} as DataModel };
             throw new Error(`Failed to reconcile dbt: ${res.status}`);

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -3,11 +3,13 @@
     import { onMount } from 'svelte';
     import Icon from '@iconify/svelte';
     import * as XLSX from 'xlsx';
+    import { readModelRef } from '$lib/utils/entity-compat';
 
     interface Dimension {
         id: string;
         label: string;
         tags?: string[];
+        model_ref?: string;
         dbt_model?: string;
     }
 
@@ -15,6 +17,7 @@
         id: string;
         label: string;
         tags?: string[];
+        model_ref?: string;
         dbt_model?: string;
     }
 
@@ -50,7 +53,7 @@
 
     function matchesBuildStatus(entity: Dimension | Fact): boolean {
         if (buildStatusFilter.length === 0) return true;
-        const status = entity.dbt_model ? 'bound' : 'unbound';
+        const status = readModelRef(entity) ? 'bound' : 'unbound';
         return buildStatusFilter.includes(status);
     }
 
@@ -477,8 +480,8 @@
                                         <div class="flex items-center gap-2">
                                             <Icon icon="lucide:bar-chart-3" class="w-4 h-4 text-blue-600" />
                                             <span
-                                                class="flex-shrink-0 inline-block w-2 h-2 rounded-full {fact.dbt_model ? 'bg-primary-600' : 'border border-gray-300'}"
-                                                title={fact.dbt_model ? `Built with dbt: ${fact.dbt_model.split('.').pop()}` : 'Not yet built with dbt'}
+                                                class="flex-shrink-0 inline-block w-2 h-2 rounded-full {readModelRef(fact) ? 'bg-primary-600' : 'border border-gray-300'}"
+                                                title={readModelRef(fact) ? `Built with dbt: ${readModelRef(fact)!.split('.').pop()}` : 'Not yet built with dbt'}
                                             ></span>
                                             <span class="truncate">{fact.label}</span>
                                             {#if factVisibleDimensionCounts.get(fact.id) !== undefined}
@@ -514,8 +517,8 @@
                                             <div class="flex items-center gap-2" title={dimension.label}>
                                                 <Icon icon="lucide:list" class="w-4 h-4 text-green-600 flex-shrink-0" />
                                                 <span
-                                                    class="flex-shrink-0 inline-block w-2 h-2 rounded-full {dimension.dbt_model ? 'bg-primary-600' : 'border border-gray-300'}"
-                                                    title={dimension.dbt_model ? `Built with dbt: ${dimension.dbt_model.split('.').pop()}` : 'Not yet built with dbt'}
+                                                    class="flex-shrink-0 inline-block w-2 h-2 rounded-full {readModelRef(dimension) ? 'bg-primary-600' : 'border border-gray-300'}"
+                                                    title={readModelRef(dimension) ? `Built with dbt: ${readModelRef(dimension)!.split('.').pop()}` : 'Not yet built with dbt'}
                                                 ></span>
                                                 <span class="truncate">{dimension.label}</span>
                                                 <span

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -4,11 +4,11 @@ import BusMatrix from './BusMatrix.svelte';
 
 const mockBusMatrixData = vi.hoisted(() => ({
 	dimensions: [
-		{ id: 'dim_bound', label: 'Bound Dimension', tags: [], dbt_model: 'model.project.dim_bound' },
+		{ id: 'dim_bound', label: 'Bound Dimension', tags: [], model_ref: 'model.project.dim_bound' },
 		{ id: 'dim_unbound', label: 'Unbound Dimension', tags: [] },
 	],
 	facts: [
-		{ id: 'fct_bound', label: 'Bound Fact', tags: [], dbt_model: 'model.project.fct_bound' },
+		{ id: 'fct_bound', label: 'Bound Fact', tags: [], model_ref: 'model.project.fct_bound' },
 		{ id: 'fct_unbound', label: 'Unbound Fact', tags: [] },
 	],
 	connections: [{ dimension_id: 'dim_bound', fact_id: 'fct_bound' }],

--- a/frontend/src/lib/components/CustomEdge.svelte
+++ b/frontend/src/lib/components/CustomEdge.svelte
@@ -24,6 +24,7 @@
     MARKER_PADDING,
     type EdgeCalculationContext
   } from '$lib/utils/edge-calculations';
+  import { readModelRef } from '$lib/utils/entity-compat';
 
   let { 
     id,
@@ -144,8 +145,8 @@
       };
     }
     // Next: primary bound model
-    if (nodeData?.dbt_model) {
-      const byPrimary = $dbtModels.find((m) => m.unique_id === nodeData.dbt_model);
+    if (readModelRef(nodeData ?? {})) {
+      const byPrimary = $dbtModels.find((m) => m.unique_id === readModelRef(nodeData));
       if (byPrimary) return byPrimary;
     }
     // Next: first additional model

--- a/frontend/src/lib/components/CustomEdge.svelte
+++ b/frontend/src/lib/components/CustomEdge.svelte
@@ -5,7 +5,7 @@
     type EdgeProps,
     useSvelteFlow
   } from '@xyflow/svelte';
-  import { edges, nodes, viewMode, dbtModels } from '$lib/stores';
+  import { edges, nodes, viewMode, frameworkModels } from '$lib/stores';
   import Icon from '@iconify/svelte';
   import {
     getNodeDimensions,
@@ -134,7 +134,7 @@
   const resolveActiveModel = (nodeData: any) => {
     // Prefer explicit active model id if present
     if (nodeData?._activeModelId) {
-      const byId = $dbtModels.find((m) => m.unique_id === nodeData._activeModelId);
+      const byId = $frameworkModels.find((m) => m.unique_id === nodeData._activeModelId);
       if (byId) return byId;
     }
     // Next: ephemeral active model name/version
@@ -146,13 +146,13 @@
     }
     // Next: primary bound model
     if (readModelRef(nodeData ?? {})) {
-      const byPrimary = $dbtModels.find((m) => m.unique_id === readModelRef(nodeData));
+      const byPrimary = $frameworkModels.find((m) => m.unique_id === readModelRef(nodeData));
       if (byPrimary) return byPrimary;
     }
     // Next: first additional model
     const firstAdditional = (nodeData?.additional_models as string[] | undefined)?.[0] || null;
     if (firstAdditional) {
-      const byAdditional = $dbtModels.find((m) => m.unique_id === firstAdditional);
+      const byAdditional = $frameworkModels.find((m) => m.unique_id === firstAdditional);
       if (byAdditional) return byAdditional;
     }
     return null;

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -6,6 +6,7 @@
 	import { mergeFields } from '$lib/utils/merged-fields';
 	import type { MergedField } from '$lib/utils/merged-fields';
 	import { computeUiTagsAfterEdit } from '$lib/utils/entity-tags';
+	import { readModelRef, readFrameworkTags } from '$lib/utils/entity-compat';
 	import type { Node } from '@xyflow/svelte';
 	import { getContext } from 'svelte';
 	import type { AutoSaveService } from '$lib/services/auto-save';
@@ -142,13 +143,13 @@
 	let isBoundEntity = $derived.by(() => {
 		if (!currentEntity) return false;
 		const data = currentEntity.data as unknown as EntityData;
-		return !!data?.dbt_model;
+		return !!readModelRef(data ?? {});
 	});
 
 	// Look up the bound dbt model
 	let boundModel = $derived(
 		currentEntity
-			? $dbtModels.find((m) => m.unique_id === (currentEntity?.data as unknown as EntityData)?.dbt_model) ?? null
+			? $dbtModels.find((m) => m.unique_id === readModelRef((currentEntity?.data as unknown as EntityData) ?? {})) ?? null
 			: null,
 	);
 
@@ -257,8 +258,9 @@
 		const data = currentEntity.data as unknown as EntityData;
 		const models: string[] = [];
 
-		if (data?.dbt_model) {
-			models.push(data.dbt_model);
+		const modelRef = readModelRef(data ?? {});
+		if (modelRef) {
+			models.push(modelRef);
 		}
 
 		if (data?.additional_models) {
@@ -654,13 +656,13 @@
 		nodes.update((n) => {
 			return n.map((node) => {
 				if (node.id === currentEntity.id) {
-					const isBound = Boolean(node.data?.dbt_model);
+					const isBound = Boolean(readModelRef((node.data ?? {}) as any));
 					// Bound entities: `tags` is a computed display union and reconcile-owned
 					// `dbt_tags` is read-only — an edit here only ever changes `ui_tags`.
 					// Unbound entities: `tags` remains the single freely-editable field.
 					const tagFields = isBound
 						? { ui_tags: (() => {
-								const uiTags = computeUiTagsAfterEdit((node.data as any)?.dbt_tags, entityTags);
+								const uiTags = computeUiTagsAfterEdit(readFrameworkTags((node.data ?? {}) as any), entityTags);
 								return uiTags.length > 0 ? uiTags : undefined;
 							})() }
 						: { tags: entityTags.length > 0 ? entityTags : undefined };

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Icon from '@iconify/svelte';
-	import { nodes, edges, entityDetailModal, pushHistory, dbtModels, modelingStyle } from '$lib/stores';
+	import { nodes, edges, entityDetailModal, pushHistory, frameworkModels, modelingStyle } from '$lib/stores';
 	import { getSourceSystemSuggestions, getBusinessEventProcesses, updateModelSchema, getManifest, getModelSchema } from '$lib/api';
 	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn, OriginEntry } from '$lib/types';
 	import { mergeFields } from '$lib/utils/merged-fields';
@@ -149,7 +149,7 @@
 	// Look up the bound dbt model
 	let boundModel = $derived(
 		currentEntity
-			? $dbtModels.find((m) => m.unique_id === readModelRef((currentEntity?.data as unknown as EntityData) ?? {})) ?? null
+			? $frameworkModels.find((m) => m.unique_id === readModelRef((currentEntity?.data as unknown as EntityData) ?? {})) ?? null
 			: null,
 	);
 
@@ -756,7 +756,7 @@
 			editableDraftedFields = editableDraftedFields.filter((_, i) => i !== draftIndex);
 			// Refresh manifest so auto-promotion runs
 			const models = await getManifest();
-			dbtModels.set(models);
+			frameworkModels.set(models);
 		} catch (e: unknown) {
 			materializeError = e instanceof Error ? e.message : 'Failed to materialize field';
 		}

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -32,7 +32,7 @@ function setupBoundEntityWithDraft() {
     position: { x: 0, y: 0 },
     data: {
       label: 'Entity X',
-      dbt_model: 'model.proj.entity_x',
+      model_ref: 'model.proj.entity_x',
       drafted_fields: [{ name: 'pending_col', datatype: 'text' }],
     } as any,
   }] as any);
@@ -71,7 +71,7 @@ function setupBoundEntityWithDraftOrigin() {
     position: { x: 0, y: 0 },
     data: {
       label: 'Mixed Entity',
-      dbt_model: 'model.proj.entity_x',
+      model_ref: 'model.proj.entity_x',
       drafted_fields: [{
         name: 'extra_col',
         datatype: 'text',
@@ -232,9 +232,9 @@ describe('EntityDetailModal — tag save behavior', () => {
       position: { x: 0, y: 0 },
       data: {
         label: 'Entity X',
-        dbt_model: 'model.proj.entity_x',
+        model_ref: 'model.proj.entity_x',
         tags: ['nightly'],
-        dbt_tags: ['nightly'],
+        framework_tags: ['nightly'],
         ui_tags: [],
       } as any,
     }] as any);
@@ -257,7 +257,7 @@ describe('EntityDetailModal — tag save behavior', () => {
 
     const savedNode = get(nodes).find((n) => n.id === 'node-1');
     expect((savedNode?.data as any).ui_tags).toEqual(['pii']);
-    expect((savedNode?.data as any).dbt_tags).toEqual(['nightly']);
+    expect((savedNode?.data as any).framework_tags).toEqual(['nightly']);
     // `tags` is a display-only union refreshed by the next reconcile/reload —
     // handleSave doesn't need to touch it. What matters is that autosave never
     // sends it for bound entities regardless of its (possibly stale) local

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte';
-import { nodes, edges, dbtModels, entityDetailModal } from '$lib/stores';
+import { nodes, edges, frameworkModels, entityDetailModal } from '$lib/stores';
 import type { DbtModel } from '$lib/types';
 import { updateModelSchema } from '$lib/api';
 
@@ -36,7 +36,7 @@ function setupBoundEntityWithDraft() {
       drafted_fields: [{ name: 'pending_col', datatype: 'text' }],
     } as any,
   }] as any);
-  dbtModels.set([mockDbtModel]);
+  frameworkModels.set([mockDbtModel]);
   entityDetailModal.set({ open: true, entityId: 'node-1' });
 }
 
@@ -59,7 +59,7 @@ function setupUnboundEntityWithDraftOrigin() {
       }],
     } as any,
   }] as any);
-  dbtModels.set([]);
+  frameworkModels.set([]);
   entityDetailModal.set({ open: true, entityId: 'node-1' });
 }
 
@@ -80,7 +80,7 @@ function setupBoundEntityWithDraftOrigin() {
       }],
     } as any,
   }] as any);
-  dbtModels.set([mockDbtModel]);
+  frameworkModels.set([mockDbtModel]);
   entityDetailModal.set({ open: true, entityId: 'node-1' });
 }
 
@@ -101,7 +101,7 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
     nodes.set([]);
-    dbtModels.set([]);
+    frameworkModels.set([]);
     entityDetailModal.set({ open: false, entityId: null });
   });
 
@@ -216,7 +216,7 @@ describe('EntityDetailModal — tag save behavior', () => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     nodes.set([]);
-    dbtModels.set([]);
+    frameworkModels.set([]);
     entityDetailModal.set({ open: false, entityId: null });
   });
 
@@ -238,7 +238,7 @@ describe('EntityDetailModal — tag save behavior', () => {
         ui_tags: [],
       } as any,
     }] as any);
-    dbtModels.set([mockDbtModel]);
+    frameworkModels.set([mockDbtModel]);
     entityDetailModal.set({ open: true, entityId: 'node-1' });
   }
 
@@ -271,7 +271,7 @@ describe('EntityDetailModal — tag save behavior', () => {
       position: { x: 0, y: 0 },
       data: { label: 'Draft Entity', tags: ['draft-tag'] } as any,
     }] as any);
-    dbtModels.set([]);
+    frameworkModels.set([]);
     entityDetailModal.set({ open: true, entityId: 'node-1' });
     await renderModal();
 
@@ -294,7 +294,7 @@ describe('EntityDetailModal — Relationships section', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     nodes.set([]);
     edges.set([]);
-    dbtModels.set([]);
+    frameworkModels.set([]);
     entityDetailModal.set({ open: false, entityId: null });
   });
 

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -13,6 +13,7 @@
 	import type { Entity, EntityData } from '$lib/types';
 	import { filterEntities } from '$lib/utils/entity-filtering';
 	import { groupEntitiesByDomain } from '$lib/utils/entity-grouping';
+	import { readModelRef } from '$lib/utils/entity-compat';
 	import EntityRow from './EntityRow.svelte';
 	import CollapseChevron from './CollapseChevron.svelte';
 	import Icon from '@iconify/svelte';
@@ -31,7 +32,7 @@
 					id: node.id,
 					label: data.label,
 					description: data.description,
-					dbt_model: data.dbt_model,
+					dbt_model: readModelRef(data),
 					additional_models: data.additional_models,
 					drafted_fields: data.drafted_fields,
 					position: node.position,

--- a/frontend/src/lib/components/EntityList.svelte
+++ b/frontend/src/lib/components/EntityList.svelte
@@ -32,7 +32,7 @@
 					id: node.id,
 					label: data.label,
 					description: data.description,
-					dbt_model: readModelRef(data),
+					model_ref: readModelRef(data),
 					additional_models: data.additional_models,
 					drafted_fields: data.drafted_fields,
 					position: node.position,

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -7,7 +7,7 @@
     } from "@xyflow/svelte";
     import {
         viewMode,
-        dbtModels,
+        frameworkModels,
         nodes,
         edges,
         draggingField,
@@ -115,7 +115,7 @@
 
     // Find model details by unique_id (e.g. "model.elmo.entity_booking")
     let modelDetails = $derived(
-        activeModelId ? $dbtModels.find((m) => m.unique_id === activeModelId) : null,
+        activeModelId ? $frameworkModels.find((m) => m.unique_id === activeModelId) : null,
     );
 
     // Reset active index when models change
@@ -849,11 +849,11 @@
                 };
             }
             if (readModelRef(sourceNodeData ?? {})) {
-                return $dbtModels.find(m => m.unique_id === readModelRef(sourceNodeData)) || null;
+                return $frameworkModels.find(m => m.unique_id === readModelRef(sourceNodeData)) || null;
             }
             const firstAdditional = (sourceNodeData?.additional_models as string[] | undefined)?.[0] || null;
             if (firstAdditional) {
-                return $dbtModels.find(m => m.unique_id === firstAdditional) || null;
+                return $frameworkModels.find(m => m.unique_id === firstAdditional) || null;
             }
             return null;
         })();
@@ -866,11 +866,11 @@
                 };
             }
             if (readModelRef(targetNodeData ?? {})) {
-                return $dbtModels.find(m => m.unique_id === readModelRef(targetNodeData)) || null;
+                return $frameworkModels.find(m => m.unique_id === readModelRef(targetNodeData)) || null;
             }
             const firstAdditional = (targetNodeData?.additional_models as string[] | undefined)?.[0] || null;
             if (firstAdditional) {
-                return $dbtModels.find(m => m.unique_id === firstAdditional) || null;
+                return $frameworkModels.find(m => m.unique_id === firstAdditional) || null;
             }
             return null;
         })();

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -309,7 +309,7 @@
         event.stopImmediatePropagation();
         isDragOver = false;
 
-        const json = event.dataTransfer?.getData("application/dbt-model");
+        const json = event.dataTransfer?.getData("application/model-ref");
         if (!json) return;
         const model: DbtModel = JSON.parse(json);
 

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -42,6 +42,7 @@
     import { mergeFields } from "$lib/utils/merged-fields";
     import type { MergedField } from "$lib/utils/merged-fields";
     import { computeUiTagsAfterEdit } from "$lib/utils/entity-tags";
+    import { readModelRef, readFrameworkTags } from "$lib/utils/entity-compat";
     import { getContext } from "svelte";
     import { goto } from "$app/navigation";
     import TagEditor from "./TagEditor.svelte";
@@ -94,7 +95,7 @@
     let hasExposuresData = $derived($hasExposuresDataStore);
 
     // Reactive binding check
-    let boundModelName = $derived(data.dbt_model as string | undefined);
+    let boundModelName = $derived(readModelRef(data));
     let additionalModels = $derived((data.additional_models as string[]) || []);
     let allBoundModels = $derived(
         boundModelName ? [boundModelName, ...additionalModels] : []
@@ -423,7 +424,7 @@
                     }
                 } else {
                     // Other nodes: get all bound models
-                    const primary = node.data?.dbt_model as string | undefined;
+                    const primary = readModelRef((node.data ?? {}) as any);
                     const additional = (node.data?.additional_models as string[]) || [];
                     if (primary) {
                         boundModels = [primary, ...additional];
@@ -636,14 +637,14 @@
     // schema.yml to mirror, so `tags` remains the single freely-editable field.
     let entityTags = $derived(
         isBound
-            ? normalizeTags([...(data.dbt_tags || []), ...((data.ui_tags || []) as string[])])
+            ? normalizeTags([...readFrameworkTags(data), ...((data.ui_tags || []) as string[])])
             : normalizeTags(data.tags),
     );
 
     // dbt_tags are always dbt-owned: they render read-only in the tag editor
     // (no remove affordance) because a Trellis push never removes a tag it
     // doesn't own. Only meaningful for bound entities.
-    let readOnlyTags = $derived(isBound ? normalizeTags(data.dbt_tags) : []);
+    let readOnlyTags = $derived(isBound ? normalizeTags(readFrameworkTags(data)) : []);
 
     // Roles display (for dimensions)
     // EntityRole is an object with { role, label, source } — extract the role string
@@ -665,7 +666,7 @@
 
         allSelectedIds.forEach((nodeId) => {
             const node = $nodes.find((n) => n.id === nodeId);
-            const nodeIsBound = !!node?.data?.dbt_model;
+            const nodeIsBound = !!readModelRef((node?.data ?? {}) as any);
 
             if (nodeIsBound) {
                 // `dbt_tags` is a dbt-mirrored, reconcile-owned field for bound
@@ -673,7 +674,7 @@
                 // An edit in the tag editor only ever changes `ui_tags`; a
                 // dbt-mirrored tag missing from `newTags` (e.g. the user tried to
                 // remove a read-only chip) is not treated as a removal, since dbt wins.
-                const uiTags = computeUiTagsAfterEdit(node?.data?.dbt_tags, newTags);
+                const uiTags = computeUiTagsAfterEdit(readFrameworkTags((node?.data ?? {}) as any), newTags);
                 updateNodeData(nodeId, { ui_tags: uiTags });
             } else {
                 // Unbound entities have no schema.yml to mirror; `tags` is the
@@ -847,8 +848,8 @@
                     version: sourceNodeData._activeModelVersion as number | null | undefined,
                 };
             }
-            if (sourceNodeData?.dbt_model) {
-                return $dbtModels.find(m => m.unique_id === sourceNodeData.dbt_model) || null;
+            if (readModelRef(sourceNodeData ?? {})) {
+                return $dbtModels.find(m => m.unique_id === readModelRef(sourceNodeData)) || null;
             }
             const firstAdditional = (sourceNodeData?.additional_models as string[] | undefined)?.[0] || null;
             if (firstAdditional) {
@@ -864,8 +865,8 @@
                     version: targetNodeData._activeModelVersion as number | null | undefined,
                 };
             }
-            if (targetNodeData?.dbt_model) {
-                return $dbtModels.find(m => m.unique_id === targetNodeData.dbt_model) || null;
+            if (readModelRef(targetNodeData ?? {})) {
+                return $dbtModels.find(m => m.unique_id === readModelRef(targetNodeData)) || null;
             }
             const firstAdditional = (targetNodeData?.additional_models as string[] | undefined)?.[0] || null;
             if (firstAdditional) {

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -22,7 +22,7 @@
         openDeleteConfirmModal,
         closeDeleteConfirmModal,
     } from "$lib/stores";
-    import type { DbtModel, DraftedField, EntityData, EntityRole } from "$lib/types";
+    import type { ModelInfo, DraftedField, EntityData, EntityRole } from "$lib/types";
     import {
         inferRelationships,
         getLineage,
@@ -311,7 +311,7 @@
 
         const json = event.dataTransfer?.getData("application/model-ref");
         if (!json) return;
-        const model: DbtModel = JSON.parse(json);
+        const model: ModelInfo = JSON.parse(json);
 
         // Track the final ID (may change during auto-naming)
         let finalId = id;

--- a/frontend/src/lib/components/EntityNode.svelte
+++ b/frontend/src/lib/components/EntityNode.svelte
@@ -326,7 +326,7 @@
             activeModelIndex = currentAdditional.length + 1;
         } else {
             // Store the full unique_id (e.g. "model.elmo.entity_booking")
-            const updates: Record<string, unknown> = { dbt_model: model.unique_id };
+            const updates: Record<string, unknown> = { model_ref: model.unique_id };
             const hasDescription = (data.description || "").trim().length > 0;
             if (!hasDescription && (model.description || "").trim().length > 0) {
                 updates.description = model.description;
@@ -367,13 +367,13 @@
                             return updatedEdge;
                         });
                         
-                        // Update the node itself with new ID - include ALL updates (dbt_model, description, label)
+                        // Update the node itself with new ID - include ALL updates (model_ref, description, label)
                         $nodes = $nodes.map((node) => {
                             if (node.id === id) {
-                                const updatedData = { 
-                                    ...node.data, 
+                                const updatedData = {
+                                    ...node.data,
                                     label: formattedLabel,
-                                    ...updates // Include dbt_model and description from updates
+                                    ...updates // Include model_ref and description from updates
                                 };
                                 return {
                                     ...node,
@@ -550,7 +550,7 @@
     }
 
     function unbind() {
-        updateNodeData(id, { dbt_model: null });
+        updateNodeData(id, { model_ref: null });
 
         // Clear field mappings on edges connected to this entity
         edges.update((list) =>

--- a/frontend/src/lib/components/EntityNode.test.ts
+++ b/frontend/src/lib/components/EntityNode.test.ts
@@ -48,7 +48,7 @@ const mockProps = {
   id: 'booking',
   data: {
     label: 'Booking',
-    dbt_model: 'model.project.booking',
+    model_ref: 'model.project.booking',
     drafted_fields: [{ name: 'new_col', datatype: 'text', description: '' }],
     width: 280,
     panelHeight: 200,

--- a/frontend/src/lib/components/EntityNode.test.ts
+++ b/frontend/src/lib/components/EntityNode.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
-import { dbtModels, viewMode } from '$lib/stores';
+import { frameworkModels, viewMode } from '$lib/stores';
 import EntityNode from './EntityNode.svelte';
 import type { EntityData } from '$lib/types';
 import { computeUiTagsAfterEdit } from '$lib/utils/entity-tags';
@@ -74,7 +74,7 @@ const svelteFlowContext = new Map<string, unknown>([
 
 describe('EntityNode — merged field rendering', () => {
   beforeEach(() => {
-    dbtModels.set([mockDbtModel] as any);
+    frameworkModels.set([mockDbtModel] as any);
     viewMode.set('logical');
     vi.clearAllMocks();
   });

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -3,6 +3,7 @@
 	import type { Entity } from "$lib/types";
 	import { entityDetailModal, entitySelection, modelingStyle } from "$lib/stores";
 	import DomainBadge from "./DomainBadge.svelte";
+	import { readModelRef } from "$lib/utils/entity-compat";
 
 	type Props = {
 		entity: Entity;
@@ -125,6 +126,9 @@
 		if (entity.entity_type !== 'dimension') return [];
 		return (entity as any).roles || [];
 	});
+
+	// Bound model reference (prefers new `model_ref`, falls back to legacy `dbt_model`)
+	const boundModelRef = $derived(readModelRef(entity));
 </script>
 
 <div
@@ -165,9 +169,9 @@
 		<!-- dbt build status badge — reserved slot so later badges stay aligned whether or not the entity is bound. Uses the same check icon/color as the "Bound" filter in the sidebar for consistency. -->
 		<span
 			class="flex-shrink-0 inline-flex items-center justify-center w-4 text-primary-600"
-			title={entity.dbt_model ? `Built with dbt: ${entity.dbt_model.split('.').pop()}` : undefined}
+			title={boundModelRef ? `Built with dbt: ${boundModelRef.split('.').pop()}` : undefined}
 		>
-			{#if entity.dbt_model}
+			{#if boundModelRef}
 				<Icon icon="lucide:check" class="h-3.5 w-3.5" aria-hidden="true" />
 			{/if}
 		</span>

--- a/frontend/src/lib/components/EntityRow.test.ts
+++ b/frontend/src/lib/components/EntityRow.test.ts
@@ -17,7 +17,7 @@ describe('EntityRow — dbt build status badge', () => {
 	it('renders a dbt badge with tooltip showing the resolved model name for a bound entity', () => {
 		const entity: Entity = {
 			...baseEntity,
-			dbt_model: 'model.project.dim_customer',
+			model_ref: 'model.project.dim_customer',
 		};
 
 		render(EntityRow, { props: { entity } });
@@ -34,7 +34,7 @@ describe('EntityRow — dbt build status badge', () => {
 	it('does not render a dbt badge for an unbound entity (no dbt_model)', () => {
 		const entity: Entity = {
 			...baseEntity,
-			dbt_model: undefined,
+			model_ref: undefined,
 		};
 
 		render(EntityRow, { props: { entity } });

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -9,6 +9,7 @@
     import { nodes, edges, modelingStyle, sourceColors, dimensionPrefixes, factPrefixes } from '$lib/stores';
     import { formatModelNameForLabel, generateEntityId, generateSlug, mergeRelationshipIntoEdges, normalizeTags, shouldAutoSyncGeneratedEntityLabel } from '$lib/utils';
     import { DimensionalModelPositioner } from '$lib/services/position-calculator';
+    import { readModelRef } from '$lib/utils/entity-compat';
     import CustomEntitySelect from './CustomEntitySelect.svelte';
     import type { Node, Edge } from '@xyflow/svelte';
     import Icon from '@iconify/svelte';
@@ -966,7 +967,7 @@
                 .map((n) => {
                     const displayTags = normalizeTags(n.data?.tags);
                     const uiTags = normalizeTags((n.data as any)?.ui_tags);
-                    const isBound = Boolean(n.data?.dbt_model);
+                    const isBound = Boolean(readModelRef((n.data ?? {}) as any));
 
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;
                     const domain = ((n.data as any)?.domain) as string | undefined;
@@ -978,7 +979,7 @@
                         id: n.id,
                         label: ((n.data.label as string) || '').trim() || 'Entity',
                         description: n.data.description as string | undefined,
-                        dbt_model: n.data.dbt_model as string | undefined,
+                        dbt_model: readModelRef((n.data ?? {}) as any),
                         additional_models: n.data?.additional_models as string[] | undefined,
                         drafted_fields: n.data?.drafted_fields as any[] | undefined,
                         position: n.position,

--- a/frontend/src/lib/components/GenerateEntitiesDialog.svelte
+++ b/frontend/src/lib/components/GenerateEntitiesDialog.svelte
@@ -979,14 +979,14 @@
                         id: n.id,
                         label: ((n.data.label as string) || '').trim() || 'Entity',
                         description: n.data.description as string | undefined,
-                        dbt_model: readModelRef((n.data ?? {}) as any),
+                        model_ref: readModelRef((n.data ?? {}) as any),
                         additional_models: n.data?.additional_models as string[] | undefined,
                         drafted_fields: n.data?.drafted_fields as any[] | undefined,
                         position: n.position,
                         width: n.data?.width as number | undefined,
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
-                        // Bound entities: `dbt_tags`/`tags` mirror schema.yml and are
+                        // Bound entities: `framework_tags`/`tags` mirror schema.yml and are
                         // reconcile-owned; never hand-written here, only `ui_tags`.
                         // Unbound entities: `tags` remains the single freely-editable field.
                         ...(isBound

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -16,6 +16,7 @@
     import type { ModelInfo, TreeNode, EntityData } from "$lib/types";
     import { getModelFolder, normalizeTags, classifyModelTypeFromPrefixes } from "$lib/utils";
     import { readModelRef } from "$lib/utils/entity-compat";
+    import { getFrameworkDisplay } from "$lib/utils/framework-display";
     import SidebarGroup from "./SidebarGroup.svelte";
     import Icon from "@iconify/svelte";
 
@@ -141,14 +142,7 @@
 
     let treeNodes = $derived(buildTree(filteredModels));
 
-    const frameworkDisplay: Record<string, { icon: string; label: string }> = {
-        "dbt-core": { icon: "https://www.getdbt.com/favicon.ico", label: "dbt Models" },
-        bruin: { icon: "/icons/bruin.svg", label: "Bruin Assets" },
-    };
-
-    let currentFrameworkDisplay = $derived(
-        frameworkDisplay[$activeFramework] ?? frameworkDisplay["dbt-core"],
-    );
+    let currentFrameworkDisplay = $derived(getFrameworkDisplay($activeFramework));
 
     function toggleFolder(folder: string) {
         if ($folderFilter.includes(folder)) {
@@ -539,7 +533,7 @@
         <div class="mb-2 flex items-center gap-2" title="These models are read from manifest/catalog artifacts of the configured framework">
             <img
                 src={currentFrameworkDisplay.icon}
-                alt={$activeFramework === "dbt-core" ? "dbt icon" : "Bruin icon"}
+                alt={currentFrameworkDisplay.alt}
                 class="w-4 h-4 flex-shrink-0"
             />
             <span class="text-xs font-semibold text-gray-600">{currentFrameworkDisplay.label}</span>

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -11,6 +11,7 @@
         entityTypeFilter,
         modelBoundFilter,
         sidebarSearchTerm,
+        activeFramework,
     } from "$lib/stores";
     import type { DbtModel, TreeNode, EntityData } from "$lib/types";
     import { getModelFolder, normalizeTags, classifyModelTypeFromPrefixes } from "$lib/utils";
@@ -139,6 +140,15 @@
 
     let treeNodes = $derived(buildTree(filteredModels));
 
+    const frameworkDisplay: Record<string, { icon: string; label: string }> = {
+        "dbt-core": { icon: "https://www.getdbt.com/favicon.ico", label: "dbt Models" },
+        bruin: { icon: "/icons/bruin.svg", label: "Bruin Assets" },
+    };
+
+    let currentFrameworkDisplay = $derived(
+        frameworkDisplay[$activeFramework] ?? frameworkDisplay["dbt-core"],
+    );
+
     function toggleFolder(folder: string) {
         if ($folderFilter.includes(folder)) {
             $folderFilter = $folderFilter.filter((f) => f !== folder);
@@ -229,7 +239,7 @@
         if (!event.dataTransfer) return;
         // Set data to identify the drag source and payload
         event.dataTransfer.setData(
-            "application/dbt-model",
+            "application/model-ref",
             JSON.stringify(model),
         );
         event.dataTransfer.effectAllowed = "all";
@@ -524,14 +534,14 @@
             <!-- Separator -->
         <div class="border-t border-gray-200 mb-3"></div>
 
-        <!-- dbt Models Header -->
-        <div class="mb-2 flex items-center gap-2" title="These models are read from manifest/catalog artifacts of dbt">
+        <!-- Framework Models Header -->
+        <div class="mb-2 flex items-center gap-2" title="These models are read from manifest/catalog artifacts of the configured framework">
             <img
-                src="https://www.getdbt.com/favicon.ico"
-                alt="dbt icon"
+                src={currentFrameworkDisplay.icon}
+                alt={$activeFramework === "dbt-core" ? "dbt icon" : "Bruin icon"}
                 class="w-4 h-4 flex-shrink-0"
             />
-            <span class="text-xs font-semibold text-gray-600">dbt Models</span>
+            <span class="text-xs font-semibold text-gray-600">{currentFrameworkDisplay.label}</span>
         </div>
 
         <div class="flex-1 overflow-y-auto pr-1 space-y-0.5">

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -13,8 +13,9 @@
         sidebarSearchTerm,
         activeFramework,
     } from "$lib/stores";
-    import type { DbtModel, TreeNode, EntityData } from "$lib/types";
+    import type { ModelInfo, TreeNode, EntityData } from "$lib/types";
     import { getModelFolder, normalizeTags, classifyModelTypeFromPrefixes } from "$lib/utils";
+    import { readModelRef } from "$lib/utils/entity-compat";
     import SidebarGroup from "./SidebarGroup.svelte";
     import Icon from "@iconify/svelte";
 
@@ -28,7 +29,7 @@
 
     $effect(() => { sidebarSearchTerm.set(searchTerm); });
 
-    function inferModelVersion(model: DbtModel): number | null {
+    function inferModelVersion(model: ModelInfo): number | null {
         if (model.version !== undefined && model.version !== null) {
             return model.version;
         }
@@ -45,7 +46,7 @@
         return null;
     }
 
-    function getModelLabel(model: DbtModel): string {
+    function getModelLabel(model: ModelInfo): string {
         const version = inferModelVersion(model);
         return version ? `${model.name}.v${version}` : model.name;
     }
@@ -121,7 +122,7 @@
                 const isBound = currentNodes.some((n) => {
                     if (n.type !== 'entity') return false;
                     const data = n.data as unknown as EntityData;
-                    const primaryMatch = data.dbt_model === m.unique_id;
+                    const primaryMatch = readModelRef(data) === m.unique_id;
                     const additionalMatch = (data.additional_models || []).includes(m.unique_id);
                     return primaryMatch || additionalMatch;
                 });
@@ -180,7 +181,7 @@
         $modelBoundFilter = null;
     }
 
-    function buildTree(models: DbtModel[]): TreeNode[] {
+    function buildTree(models: ModelInfo[]): TreeNode[] {
         const rootObj: any = { _files: [], _folders: {} };
 
         for (const model of models) {
@@ -205,7 +206,7 @@
             const folderNodes = Object.keys(obj._folders).map((key) =>
                 convert(obj._folders[key], key, path ? `${path}/${key}` : key),
             );
-            const fileNodes = obj._files.map((m: DbtModel) => {
+            const fileNodes = obj._files.map((m: ModelInfo) => {
                 const label = getModelLabel(m);
                 const filePath = path ? `${path}/${label}` : label;
                 return {
@@ -235,7 +236,7 @@
         return convert(rootObj, "root", "").children;
     }
 
-    function onDragStart(event: DragEvent, model: DbtModel) {
+    function onDragStart(event: DragEvent, model: ModelInfo) {
         if (!event.dataTransfer) return;
         // Set data to identify the drag source and payload
         event.dataTransfer.setData(

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import {
-        dbtModels,
+        frameworkModels,
         configStatus,
         folderFilter,
         tagFilter,
@@ -53,7 +53,7 @@
     let allFolders = $derived(
         Array.from(
             new Set(
-                $dbtModels
+                $frameworkModels
                     .map((m) => getModelFolder(m))
                     .filter((f): f is string => f !== null),
             ),
@@ -65,7 +65,7 @@
         Array.from(
             new Set([
                 // Tags from dbt models (manifest.json)
-                ...$dbtModels.flatMap((m) => normalizeTags(m.tags)),
+                ...$frameworkModels.flatMap((m) => normalizeTags(m.tags)),
                 // Tags from entity nodes on canvas (user-added tags)
                 ...$nodes
                     .filter((n) => n.type === "entity")
@@ -76,7 +76,7 @@
 
     // Apply search and filters
     let filteredModels = $derived(
-        $dbtModels.filter((m) => {
+        $frameworkModels.filter((m) => {
             // Search filter
             const label = getModelLabel(m);
             if (!label.toLowerCase().includes(searchTerm.toLowerCase())) {
@@ -548,7 +548,7 @@
                             Loading...
                         </div>
                     </div>
-                {:else if $dbtModels.length === 0}
+                {:else if $frameworkModels.length === 0}
                     <div class="text-center mt-10 px-2">
                         <div class="text-gray-500 text-sm mb-4">
                             No models found

--- a/frontend/src/lib/components/Sidebar.test.ts
+++ b/frontend/src/lib/components/Sidebar.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-import { frameworkModels, folderFilter, tagFilter, nodes } from '$lib/stores';
+import { frameworkModels, folderFilter, tagFilter, nodes, activeFramework } from '$lib/stores';
 import { getModelFolder } from '$lib/utils';
+import Sidebar from './Sidebar.svelte';
 
 // Mock DbtModel data
 const mockModels = [
@@ -160,5 +162,36 @@ describe('Filter Helper Functions', () => {
 
         const noMatch = ['staging'].some(tag => modelTags.includes(tag));
         expect(noMatch).toBe(false);
+    });
+});
+
+describe('Sidebar — framework-driven header', () => {
+    beforeEach(() => {
+        frameworkModels.set([]);
+        folderFilter.set([]);
+        tagFilter.set([]);
+        nodes.set([]);
+    });
+
+    it('renders the Bruin icon and label when framework is "bruin"', () => {
+        activeFramework.set('bruin');
+        render(Sidebar, { props: {} });
+
+        expect(document.body.textContent).not.toContain('dbt Models');
+
+        const icon = document.querySelector('img[alt="dbt icon"], img[alt="Bruin icon"]') as HTMLImageElement | null;
+        expect(icon).toBeTruthy();
+        expect(icon?.getAttribute('src')).toContain('/icons/bruin.svg');
+    });
+
+    it('renders the dbt icon and "dbt Models" label unchanged when framework is "dbt-core"', () => {
+        activeFramework.set('dbt-core');
+        render(Sidebar, { props: {} });
+
+        expect(document.body.textContent).toContain('dbt Models');
+
+        const icon = document.querySelector('img[alt="dbt icon"]') as HTMLImageElement | null;
+        expect(icon).toBeTruthy();
+        expect(icon?.getAttribute('src')).toBe('https://www.getdbt.com/favicon.ico');
     });
 });

--- a/frontend/src/lib/components/Sidebar.test.ts
+++ b/frontend/src/lib/components/Sidebar.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { frameworkModels, folderFilter, tagFilter, nodes, activeFramework } from '$lib/stores';
+import { FRAMEWORK_DISPLAY_KEYS } from '$lib/utils/framework-display';
 import { getModelFolder } from '$lib/utils';
 import Sidebar from './Sidebar.svelte';
 
@@ -173,15 +174,18 @@ describe('Sidebar — framework-driven header', () => {
         nodes.set([]);
     });
 
-    it('renders the Bruin icon and label when framework is "bruin"', () => {
-        activeFramework.set('bruin');
+    it('falls back to neutral branding for a framework with no branding of its own', () => {
+        // Proves the header is genuinely framework-driven rather than dbt-assumed:
+        // an unrecognised framework must not silently render dbt's icon and label.
+        activeFramework.set('some-other-framework');
         render(Sidebar, { props: {} });
 
         expect(document.body.textContent).not.toContain('dbt Models');
 
-        const icon = document.querySelector('img[alt="dbt icon"], img[alt="Bruin icon"]') as HTMLImageElement | null;
+        const icon = document.querySelector('img[alt="framework icon"]') as HTMLImageElement | null;
         expect(icon).toBeTruthy();
-        expect(icon?.getAttribute('src')).toContain('/icons/bruin.svg');
+        expect(icon?.getAttribute('src')).toContain('/icons/framework.svg');
+        expect(icon?.getAttribute('src')).not.toContain('getdbt.com');
     });
 
     it('renders the dbt icon and "dbt Models" label unchanged when framework is "dbt-core"', () => {
@@ -193,5 +197,12 @@ describe('Sidebar — framework-driven header', () => {
         const icon = document.querySelector('img[alt="dbt icon"]') as HTMLImageElement | null;
         expect(icon).toBeTruthy();
         expect(icon?.getAttribute('src')).toBe('https://www.getdbt.com/favicon.ico');
+    });
+
+    it('does not hardcode any framework beyond the one Trellis implements', () => {
+        // The display map is scaffolding for future adapters; entries may only be
+        // added alongside a working adapter, so it cannot drift into advertising
+        // frameworks that raise "unknown framework" at runtime.
+        expect(FRAMEWORK_DISPLAY_KEYS).toEqual(['dbt-core']);
     });
 });

--- a/frontend/src/lib/components/Sidebar.test.ts
+++ b/frontend/src/lib/components/Sidebar.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { dbtModels, folderFilter, tagFilter, nodes } from '$lib/stores';
+import { frameworkModels, folderFilter, tagFilter, nodes } from '$lib/stores';
 import { getModelFolder } from '$lib/utils';
 
 // Mock DbtModel data
@@ -78,14 +78,14 @@ const mockNodes = [
 
 describe('Sidebar Filtering Logic', () => {
     beforeEach(() => {
-        dbtModels.set(mockModels);
+        frameworkModels.set(mockModels);
         folderFilter.set([]);
         tagFilter.set([]);
         nodes.set(mockNodes);
     });
 
     it('initializes with correct mock data', () => {
-        expect(get(dbtModels)).toHaveLength(3);
+        expect(get(frameworkModels)).toHaveLength(3);
         expect(get(nodes)).toHaveLength(4);
         expect(get(folderFilter)).toEqual([]);
         expect(get(tagFilter)).toEqual([]);

--- a/frontend/src/lib/components/SidebarGroup.svelte
+++ b/frontend/src/lib/components/SidebarGroup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { DbtModel, TreeNode, EntityData } from "$lib/types";
+    import type { ModelInfo, TreeNode, EntityData } from "$lib/types";
     import SidebarGroup from "./SidebarGroup.svelte";
     import Icon from "@iconify/svelte";
     import { folderFilter, nodes, modelingStyle, dimensionPrefixes, factPrefixes } from "$lib/stores";
@@ -9,7 +9,7 @@
 
     let { node, onDragStart, mainFolderPrefix = "" } = $props<{
         node: TreeNode;
-        onDragStart: (event: DragEvent, model: DbtModel) => void;
+        onDragStart: (event: DragEvent, model: ModelInfo) => void;
         mainFolderPrefix?: string;
     }>();
     

--- a/frontend/src/lib/components/SidebarGroup.svelte
+++ b/frontend/src/lib/components/SidebarGroup.svelte
@@ -5,6 +5,7 @@
     import { folderFilter, nodes, modelingStyle, dimensionPrefixes, factPrefixes } from "$lib/stores";
     import { extractRelativePath, toggleFolderFilter } from "$lib/utils/folder-utils";
     import { classifyModelTypeFromPrefixes } from "$lib/utils";
+    import { readModelRef } from "$lib/utils/entity-compat";
 
     let { node, onDragStart, mainFolderPrefix = "" } = $props<{
         node: TreeNode;
@@ -24,7 +25,7 @@
             isModelBound = currentNodes.some((n) => {
                 if (n.type !== 'entity') return false;
                 const data = n.data as unknown as EntityData;
-                const primaryMatch = data.dbt_model === node.model!.unique_id;
+                const primaryMatch = readModelRef(data) === node.model!.unique_id;
                 const additionalMatch = (data.additional_models || []).includes(node.model!.unique_id);
                 return primaryMatch || additionalMatch;
             });

--- a/frontend/src/lib/services/auto-save.test.ts
+++ b/frontend/src/lib/services/auto-save.test.ts
@@ -495,6 +495,41 @@ describe('AutoSaveService', () => {
             expect(entity.dbt_tags).toBeUndefined();
         });
 
+        it('sends model_ref (not dbt_model) for a bound entity, keeping tag-omission asymmetry intact', () => {
+            const nodes: Node[] = [
+                {
+                    id: 'entity1',
+                    type: 'entity',
+                    position: { x: 0, y: 0 },
+                    data: {
+                        label: 'Entity 1',
+                        dbt_model: 'model1',
+                        tags: ['nightly', 'pii'],
+                        dbt_tags: ['nightly'],
+                        ui_tags: ['pii'],
+                    },
+                },
+            ];
+            const edges: Edge[] = [];
+
+            service.save(nodes, edges);
+            vi.advanceTimersByTime(400);
+
+            const dataModelArg = vi.mocked(apiSaveDataModel).mock.calls[0][0];
+            const entity = dataModelArg.entities[0] as any;
+
+            // The payload must carry the new key spelling, not the legacy one.
+            expect(entity.model_ref).toBe('model1');
+            expect(entity.dbt_model).toBeUndefined();
+
+            // Untouched from Sprint 0's characterization: bound entities still
+            // omit the mirrored tags fields and only send ui_tags.
+            expect(entity.ui_tags).toEqual(['pii']);
+            expect(entity.tags).toBeUndefined();
+            expect(entity.dbt_tags).toBeUndefined();
+            expect(entity.framework_tags).toBeUndefined();
+        });
+
         it('unbound entity still persists tags as the single freely-editable field', () => {
             const nodes: Node[] = [
                 {

--- a/frontend/src/lib/services/auto-save.ts
+++ b/frontend/src/lib/services/auto-save.ts
@@ -257,14 +257,14 @@ export class AutoSaveService {
                         id: n.id,
                         label: ((n.data.label as string) || '').trim() || 'Entity',
                         description: n.data.description as string | undefined,
-                        dbt_model: n.data.dbt_model as string | undefined,
+                        model_ref: readModelRef(n.data as any),
                         additional_models: n.data?.additional_models as string[] | undefined,
                         drafted_fields: n.data?.drafted_fields as any[] | undefined,
                         position: n.position,
                         width: n.data?.width as number | undefined,
                         panel_height: n.data?.panelHeight as number | undefined,
                         collapsed: (n.data?.collapsed as boolean) ?? false,
-                        // Bound entities: `dbt_tags`/`tags` mirror schema.yml and are
+                        // Bound entities: `framework_tags`/`tags` mirror schema.yml and are
                         // reconcile-owned; autosave must never write them, only
                         // `ui_tags` (user-added). Unbound entities: `tags` remains
                         // the single freely-editable field.

--- a/frontend/src/lib/services/auto-save.ts
+++ b/frontend/src/lib/services/auto-save.ts
@@ -2,6 +2,7 @@ import type { Node, Edge } from '@xyflow/svelte';
 import type { DataModel, EntityRole } from '$lib/types';
 import { getApiBase, saveDataModel as apiSaveDataModel } from '$lib/api';
 import { normalizeTags } from '$lib/utils';
+import { readModelRef } from '$lib/utils/entity-compat';
 import { get } from 'svelte/store';
 import { sourceColors as sourceColorsStore, modelingStyle as modelingStyleStore } from '$lib/stores';
 
@@ -243,7 +244,7 @@ export class AutoSaveService {
                 .filter((n) => n.type === 'entity')
                 .map((n) => {
                     const displayTags = normalizeTags(n.data?.tags);
-                    const isBound = Boolean(n.data?.dbt_model);
+                    const isBound = Boolean(readModelRef(n.data as any));
                     const uiTags = normalizeTags((n.data as any)?.ui_tags);
 
                     const source_system = ((n.data as any)?.source_system) as string[] | undefined;

--- a/frontend/src/lib/services/position-calculator.test.ts
+++ b/frontend/src/lib/services/position-calculator.test.ts
@@ -563,7 +563,7 @@ describe("position-calculator", () => {
                         id: "entity1",
                         type: "entity",
                         position: { x: 20, y: 20 },
-                        data: { label: "Entity 1", width: 280, panelHeight: 200, collapsed: false, dbt_model: { name: "model1" } },
+                        data: { label: "Entity 1", width: 280, panelHeight: 200, collapsed: false, model_ref: { name: "model1" } },
                         parentId: "group1",
                     },
                 ];

--- a/frontend/src/lib/services/position-calculator.ts
+++ b/frontend/src/lib/services/position-calculator.ts
@@ -1,5 +1,6 @@
 import type { Node } from "@xyflow/svelte";
 import type { Position } from "$lib/utils/position-utils";
+import { readModelRef } from "$lib/utils/entity-compat";
 
 /**
  * Configuration for dimensional model positioning
@@ -281,7 +282,7 @@ export class GroupSizeCalculator {
             }
 
             // Add extra height for logical view metadata if bound
-            if (viewMode === "logical" && child.data?.dbt_model) {
+            if (viewMode === "logical" && readModelRef(child.data as any)) {
                 estimatedHeight += this.config.logicalViewAdditionalHeight;
             }
 

--- a/frontend/src/lib/services/schema-manager.ts
+++ b/frontend/src/lib/services/schema-manager.ts
@@ -1,4 +1,4 @@
-import type { DbtModel, ModelSchema, ModelSchemaColumn } from '$lib/types';
+import type { ModelInfo, ModelSchema, ModelSchemaColumn } from '$lib/types';
 import { getModelSchema, updateModelSchema } from '$lib/api';
 import { normalizeTags } from '$lib/utils';
 
@@ -133,7 +133,7 @@ export class SchemaManager {
         modelName: string,
         version: number | null | undefined,
         manifestTags: string[] = [],
-        fallbackColumns?: DbtModel['columns'],
+        fallbackColumns?: ModelInfo['columns'],
     ): Promise<void> {
         this.modelName = modelName;
         this.version = version ?? null;

--- a/frontend/src/lib/stores.test.ts
+++ b/frontend/src/lib/stores.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { Writable } from 'svelte/store';
 import { get } from 'svelte/store';
-import { nodes, edges, canUndo, canRedo, pushHistory, initHistory, undo, redo, entityListFilters } from './stores';
+import { nodes, edges, canUndo, canRedo, pushHistory, initHistory, undo, redo, entityListFilters, frameworkModels } from './stores';
+import type { ModelInfo } from './types';
 
 describe('Undo/Redo History', () => {
     beforeEach(() => {
@@ -160,6 +162,32 @@ describe('Undo/Redo History', () => {
 describe('entityListFilters', () => {
     it('initializes with selectedBuildStatus as an empty array', () => {
         expect(get(entityListFilters).selectedBuildStatus).toEqual([]);
+    });
+});
+
+describe('frameworkModels', () => {
+    it('is exported as a writable store of ModelInfo[]', () => {
+        // Type-level assertion: frameworkModels must be Writable<ModelInfo[]>
+        const typed: Writable<ModelInfo[]> = frameworkModels;
+        expect(typed).toBe(frameworkModels);
+
+        // Runtime behavior: default value is an empty array, and it's settable
+        expect(get(frameworkModels)).toEqual([]);
+
+        const sample: ModelInfo[] = [
+            {
+                unique_id: 'model.elmo.stg_customers',
+                name: 'stg_customers',
+                schema: 'main',
+                table: 'stg_customers',
+                columns: [],
+            },
+        ];
+        frameworkModels.set(sample);
+        expect(get(frameworkModels)).toEqual(sample);
+
+        // Reset for other tests
+        frameworkModels.set([]);
     });
 });
 

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -21,7 +21,7 @@ export const frameworkModels = writable<ModelInfo[]>([]);
 export const viewMode = writable<'conceptual' | 'logical' | 'exposures' | 'bus_matrix' | 'business_events'>('conceptual');
 export const modelingStyle = writable<'dimensional_model' | 'entity_model'>('dimensional_model');
 export const configStatus = writable<any>(null);
-// Active transformation framework (e.g. 'dbt-core', 'bruin') — drives framework-specific UI (icons, labels, MIME types).
+// Active transformation framework (currently only 'dbt-core') — drives framework-specific UI (icons, labels, MIME types).
 export const activeFramework = writable<string>('dbt-core');
 export const labelPrefixes = writable<string[]>([]);
 export const dimensionPrefixes = writable<string[]>([]);

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,6 +1,6 @@
 import { writable, get } from 'svelte/store';
 import type { Node, Edge } from '@xyflow/svelte';
-import type { DbtModel, EntityListFilters, FieldDragState } from './types';
+import type { ModelInfo, EntityListFilters, FieldDragState } from './types';
 
 /**
  * Deep clone that handles Svelte 5 Proxy objects (which structuredClone cannot clone).
@@ -17,7 +17,7 @@ function deepClone<T>(obj: T): T {
 
 export const nodes = writable<Node[]>([]);
 export const edges = writable<Edge[]>([]);
-export const dbtModels = writable<DbtModel[]>([]);
+export const frameworkModels = writable<ModelInfo[]>([]);
 export const viewMode = writable<'conceptual' | 'logical' | 'exposures' | 'bus_matrix' | 'business_events'>('conceptual');
 export const modelingStyle = writable<'dimensional_model' | 'entity_model'>('dimensional_model');
 export const configStatus = writable<any>(null);

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -21,6 +21,8 @@ export const frameworkModels = writable<ModelInfo[]>([]);
 export const viewMode = writable<'conceptual' | 'logical' | 'exposures' | 'bus_matrix' | 'business_events'>('conceptual');
 export const modelingStyle = writable<'dimensional_model' | 'entity_model'>('dimensional_model');
 export const configStatus = writable<any>(null);
+// Active transformation framework (e.g. 'dbt-core', 'bruin') — drives framework-specific UI (icons, labels, MIME types).
+export const activeFramework = writable<string>('dbt-core');
 export const labelPrefixes = writable<string[]>([]);
 export const dimensionPrefixes = writable<string[]>([]);
 export const factPrefixes = writable<string[]>([]);

--- a/frontend/src/lib/types.test.ts
+++ b/frontend/src/lib/types.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expectTypeOf } from 'vitest';
-import type { OriginEntry, DbtColumn, DraftedField } from './types';
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { OriginEntry, DbtColumn, DraftedField, Entity } from './types';
+import { readModelRef, readFrameworkTags } from './utils/entity-compat';
 
 describe('origin types', () => {
 	it('OriginEntry is a single-key record', () => {
@@ -17,5 +18,20 @@ describe('origin types', () => {
 			origin: [{ DH1: 'CORE.A' }],
 		};
 		expectTypeOf(field.origin).toEqualTypeOf<OriginEntry[] | undefined>();
+	});
+});
+
+describe('Entity model_ref/framework_tags round-trip', () => {
+	it('reads model_ref and framework_tags via the compat helpers', () => {
+		const entity: Entity = {
+			id: 'entity_booking',
+			label: 'Booking',
+			position: { x: 0, y: 0 },
+			model_ref: 'model.elmo.entity_booking',
+			framework_tags: ['pii', 'core'],
+		};
+
+		expect(readModelRef(entity)).toBe('model.elmo.entity_booking');
+		expect(readFrameworkTags(entity)).toEqual(['pii', 'core']);
 	});
 });

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -7,7 +7,7 @@ export interface DbtColumn {
     origin?: OriginEntry[];
 }
 
-export interface DbtModel {
+export interface ModelInfo {
     unique_id: string; // e.g. "model.elmo.entity_booking"
     name: string;
     version?: number | null;
@@ -20,12 +20,15 @@ export interface DbtModel {
     tags?: string[];
 }
 
+/** @deprecated Use `ModelInfo` instead. Kept as a transitional alias. */
+export type DbtModel = ModelInfo;
+
 export interface TreeNode {
     name: string;
     path: string;
     type: 'folder' | 'file';
-    children: TreeNode[]; 
-    model?: DbtModel; 
+    children: TreeNode[];
+    model?: ModelInfo;
 }
 
 export interface ColumnLink {
@@ -52,18 +55,22 @@ export interface DraftedField {
 export interface EntityData {
     label: string;
     description?: string;
-    dbt_model?: string; // unique_id of the bound model (e.g. "model.elmo.entity_booking")
-    additional_models?: string[]; // additional dbt models bound to this entity
-    drafted_fields?: DraftedField[]; // User-defined fields when no dbt model is bound
+    model_ref?: string; // unique_id of the bound model (e.g. "model.elmo.entity_booking")
+    /** @deprecated Use `model_ref` instead. */
+    dbt_model?: string;
+    additional_models?: string[]; // additional models bound to this entity
+    drafted_fields?: DraftedField[]; // User-defined fields when no model is bound
     width?: number;
     panelHeight?: number;
     collapsed?: boolean;
     folder?: string; // relative folder path (excluding main path)
-    // For a bound entity, `tags` is a computed display union (dbt_tags + ui_tags)
+    // For a bound entity, `tags` is a computed display union (framework_tags + ui_tags)
     // sent by the backend — never persisted, never hand-edited. Unbound entities
     // persist `tags` directly as their single, freely-editable field.
     tags?: string[];
-    dbt_tags?: string[]; // Bound entities only: dbt-mirrored, reconcile-owned, read-only
+    framework_tags?: string[]; // Bound entities only: framework-mirrored, reconcile-owned, read-only
+    /** @deprecated Use `framework_tags` instead. */
+    dbt_tags?: string[];
     ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified"; // Entity type for dimensional modeling
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)
@@ -80,6 +87,8 @@ export interface Entity {
     id: string;
     label: string;
     description?: string;
+    model_ref?: string;
+    /** @deprecated Use `model_ref` instead. */
     dbt_model?: string;
     additional_models?: string[];
     drafted_fields?: DraftedField[];
@@ -88,7 +97,9 @@ export interface Entity {
     panel_height?: number;
     collapsed?: boolean;
     tags?: string[]; // Unbound entities only: single, freely-editable field
-    dbt_tags?: string[]; // Bound entities only: dbt-mirrored, reconcile-owned
+    framework_tags?: string[]; // Bound entities only: framework-mirrored, reconcile-owned
+    /** @deprecated Use `framework_tags` instead. */
+    dbt_tags?: string[];
     ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified";
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -20,9 +20,6 @@ export interface ModelInfo {
     tags?: string[];
 }
 
-/** @deprecated Use `ModelInfo` instead. Kept as a transitional alias. */
-export type DbtModel = ModelInfo;
-
 export interface TreeNode {
     name: string;
     path: string;
@@ -56,8 +53,6 @@ export interface EntityData {
     label: string;
     description?: string;
     model_ref?: string; // unique_id of the bound model (e.g. "model.elmo.entity_booking")
-    /** @deprecated Use `model_ref` instead. */
-    dbt_model?: string;
     additional_models?: string[]; // additional models bound to this entity
     drafted_fields?: DraftedField[]; // User-defined fields when no model is bound
     width?: number;
@@ -69,8 +64,6 @@ export interface EntityData {
     // persist `tags` directly as their single, freely-editable field.
     tags?: string[];
     framework_tags?: string[]; // Bound entities only: framework-mirrored, reconcile-owned, read-only
-    /** @deprecated Use `framework_tags` instead. */
-    dbt_tags?: string[];
     ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified"; // Entity type for dimensional modeling
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)
@@ -88,8 +81,6 @@ export interface Entity {
     label: string;
     description?: string;
     model_ref?: string;
-    /** @deprecated Use `model_ref` instead. */
-    dbt_model?: string;
     additional_models?: string[];
     drafted_fields?: DraftedField[];
     position: { x: number; y: number };
@@ -98,8 +89,6 @@ export interface Entity {
     collapsed?: boolean;
     tags?: string[]; // Unbound entities only: single, freely-editable field
     framework_tags?: string[]; // Bound entities only: framework-mirrored, reconcile-owned
-    /** @deprecated Use `framework_tags` instead. */
-    dbt_tags?: string[];
     ui_tags?: string[]; // Bound entities only: tags explicitly added via the Trellis tag editor
     entity_type?: "fact" | "dimension" | "unclassified";
     annotation_type?: AnnotationType; // For dimensions: which 7W category (who/what/when/where/how/why)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,7 +46,7 @@ export interface DraftedField {
     description?: string;
     origin?: OriginEntry[];
     source?: 'dbt' | 'draft';
-    dbt_data_type?: string; // exact warehouse type, preserved so push doesn't downgrade to the `datatype` bucket
+    physical_datatype?: string; // exact type from the framework's catalog, preserved so push doesn't downgrade to the `datatype` bucket
 }
 
 export interface EntityData {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type {
     ConfigInfo,
-    DbtModel,
+    ModelInfo,
     Relationship,
     ModelSchema,
     ModelSchemaColumn,
@@ -277,7 +277,7 @@ export function extractModelNameFromUniqueId(uniqueId: string): string {
  * Skips "models/" prefix and the first directory level (e.g., "3_core").
  * Returns null if no subfolder exists.
  */
-export function getModelFolder(model: DbtModel): string | null {
+export function getModelFolder(model: ModelInfo): string | null {
     if (!model.file_path) return null;
     let p = model.file_path.replace(/\\/g, '/');
     const lastSlash = p.lastIndexOf('/');

--- a/frontend/src/lib/utils/auto-promote-nodes.test.ts
+++ b/frontend/src/lib/utils/auto-promote-nodes.test.ts
@@ -10,7 +10,7 @@ function makeEntityNode(id: string, dbtModel: string | undefined, draftedFields:
     position: { x: 0, y: 0 },
     data: {
       label: id,
-      dbt_model: dbtModel,
+      model_ref: dbtModel,
       drafted_fields: draftedFields.length > 0 ? draftedFields : undefined,
     } as unknown as EntityData,
   } as Node;

--- a/frontend/src/lib/utils/auto-promote-nodes.test.ts
+++ b/frontend/src/lib/utils/auto-promote-nodes.test.ts
@@ -34,8 +34,8 @@ describe('autoPromoteAllNodes', () => {
         { name: 'new_field', datatype: 'text' },
       ]),
     ];
-    const dbtModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
-    const { nodes: result, changed } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
+    const { nodes: result, changed } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(changed).toBe(true);
     const entityData = result[0].data as unknown as EntityData;
     expect(entityData.drafted_fields).toEqual([{ name: 'new_field', datatype: 'text' }]);
@@ -47,24 +47,24 @@ describe('autoPromoteAllNodes', () => {
         { name: 'custom_field', datatype: 'text' },
       ]),
     ];
-    const dbtModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
-    const { nodes: result, changed } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
+    const { nodes: result, changed } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(changed).toBe(false);
     expect(result[0]).toBe(nodes[0]); // Same reference
   });
 
   it('leaves unbound nodes untouched', () => {
     const nodes = [makeEntityNode('unbound', undefined, [{ name: 'x', datatype: 'text' }])];
-    const dbtModels: DbtModel[] = [makeDbtModel('model.a.something', ['x'])];
-    const { nodes: result, changed } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [makeDbtModel('model.a.something', ['x'])];
+    const { nodes: result, changed } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(changed).toBe(false);
     expect(result[0]).toBe(nodes[0]);
   });
 
   it('handles node with no drafted_fields', () => {
     const nodes = [makeEntityNode('booking', 'model.a.booking', [])];
-    const dbtModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
-    const { nodes: result, changed } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [makeDbtModel('model.a.booking', ['id'])];
+    const { nodes: result, changed } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(changed).toBe(false);
     expect(result[0]).toBe(nodes[0]);
   });
@@ -73,8 +73,8 @@ describe('autoPromoteAllNodes', () => {
     const nodes = [
       makeEntityNode('booking', 'model.a.booking', [{ name: 'X', datatype: 'text' }]),
     ];
-    const dbtModels: DbtModel[] = [makeDbtModel('model.a.booking', ['x'])];
-    const { nodes: result, changed } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [makeDbtModel('model.a.booking', ['x'])];
+    const { nodes: result, changed } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(changed).toBe(false);
     const entityData = result[0].data as unknown as EntityData;
     expect(entityData.drafted_fields).toHaveLength(1);
@@ -82,8 +82,8 @@ describe('autoPromoteAllNodes', () => {
 
   it('returns original nodes array reference when nothing changed', () => {
     const nodes = [makeEntityNode('booking', 'model.a.booking', [])];
-    const dbtModels: DbtModel[] = [];
-    const { nodes: result } = autoPromoteAllNodes(nodes, dbtModels);
+    const frameworkModels: DbtModel[] = [];
+    const { nodes: result } = autoPromoteAllNodes(nodes, frameworkModels);
     expect(result).toBe(nodes); // Same array reference
   });
 });

--- a/frontend/src/lib/utils/auto-promote-nodes.ts
+++ b/frontend/src/lib/utils/auto-promote-nodes.ts
@@ -5,10 +5,10 @@ import { readModelRef } from './entity-compat';
 
 export function autoPromoteAllNodes(
 	nodes: Node[],
-	dbtModels: DbtModel[],
+	frameworkModels: DbtModel[],
 ): { nodes: Node[]; changed: boolean } {
 	let changed = false;
-	const byUniqueId = new Map(dbtModels.map((m) => [m.unique_id, m]));
+	const byUniqueId = new Map(frameworkModels.map((m) => [m.unique_id, m]));
 	const next = nodes.map((node) => {
 		if (node.type !== 'entity') return node;
 		const data = node.data as unknown as EntityData;

--- a/frontend/src/lib/utils/auto-promote-nodes.ts
+++ b/frontend/src/lib/utils/auto-promote-nodes.ts
@@ -1,11 +1,11 @@
 import type { Node } from '@xyflow/svelte';
-import type { DbtModel, EntityData } from '$lib/types';
+import type { ModelInfo, EntityData } from '$lib/types';
 import { promoteDraftsAgainstModel } from './field-promotion';
 import { readModelRef } from './entity-compat';
 
 export function autoPromoteAllNodes(
 	nodes: Node[],
-	frameworkModels: DbtModel[],
+	frameworkModels: ModelInfo[],
 ): { nodes: Node[]; changed: boolean } {
 	let changed = false;
 	const byUniqueId = new Map(frameworkModels.map((m) => [m.unique_id, m]));

--- a/frontend/src/lib/utils/auto-promote-nodes.ts
+++ b/frontend/src/lib/utils/auto-promote-nodes.ts
@@ -1,6 +1,7 @@
 import type { Node } from '@xyflow/svelte';
 import type { DbtModel, EntityData } from '$lib/types';
 import { promoteDraftsAgainstModel } from './field-promotion';
+import { readModelRef } from './entity-compat';
 
 export function autoPromoteAllNodes(
 	nodes: Node[],
@@ -11,8 +12,9 @@ export function autoPromoteAllNodes(
 	const next = nodes.map((node) => {
 		if (node.type !== 'entity') return node;
 		const data = node.data as unknown as EntityData;
-		if (!data?.dbt_model) return node;
-		const model = byUniqueId.get(data.dbt_model);
+		const modelRef = data ? readModelRef(data) : undefined;
+		if (!modelRef) return node;
+		const model = byUniqueId.get(modelRef);
 		const promoted = promoteDraftsAgainstModel(data.drafted_fields, model);
 		if (promoted === data.drafted_fields) return node;
 		changed = true;

--- a/frontend/src/lib/utils/bulk-operations.test.ts
+++ b/frontend/src/lib/utils/bulk-operations.test.ts
@@ -299,9 +299,9 @@ describe('bulk-operations', () => {
 					...createEntityNode('1', 'Customer'),
 					data: {
 						label: 'Customer',
-						dbt_model: 'model.proj.customer',
+						model_ref: 'model.proj.customer',
 						tags: ['nightly'],
-						dbt_tags: ['nightly'],
+						framework_tags: ['nightly'],
 						ui_tags: [],
 					},
 				},
@@ -313,7 +313,7 @@ describe('bulk-operations', () => {
 			const updatedNodes = get(nodesStore);
 			expect(updatedNodes[0].data.ui_tags).toEqual(['pii']);
 			expect(updatedNodes[0].data.tags).toEqual(['nightly']);
-			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
+			expect((updatedNodes[0].data as any).framework_tags).toEqual(['nightly']);
 		});
 
 		it('adding a tag already owned by dbt is a no-op on ui_tags for a bound entity', () => {
@@ -322,8 +322,8 @@ describe('bulk-operations', () => {
 					...createEntityNode('1', 'Customer'),
 					data: {
 						label: 'Customer',
-						dbt_model: 'model.proj.customer',
-						dbt_tags: ['nightly'],
+						model_ref: 'model.proj.customer',
+						framework_tags: ['nightly'],
 						ui_tags: [],
 					},
 				},
@@ -480,9 +480,9 @@ describe('bulk-operations', () => {
 					...createEntityNode('1', 'Customer'),
 					data: {
 						label: 'Customer',
-						dbt_model: 'model.proj.customer',
+						model_ref: 'model.proj.customer',
 						tags: ['nightly', 'pii'],
-						dbt_tags: ['nightly'],
+						framework_tags: ['nightly'],
 						ui_tags: ['pii'],
 					},
 				},
@@ -493,7 +493,7 @@ describe('bulk-operations', () => {
 
 			const updatedNodes = get(nodesStore);
 			expect(updatedNodes[0].data.ui_tags).toBeUndefined();
-			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
+			expect((updatedNodes[0].data as any).framework_tags).toEqual(['nightly']);
 			expect(updatedNodes[0].data.tags).toEqual(['nightly', 'pii']);
 		});
 
@@ -503,8 +503,8 @@ describe('bulk-operations', () => {
 					...createEntityNode('1', 'Customer'),
 					data: {
 						label: 'Customer',
-						dbt_model: 'model.proj.customer',
-						dbt_tags: ['nightly'],
+						model_ref: 'model.proj.customer',
+						framework_tags: ['nightly'],
 						ui_tags: ['pii'],
 					},
 				},
@@ -515,7 +515,7 @@ describe('bulk-operations', () => {
 
 			const updatedNodes = get(nodesStore);
 			expect(updatedNodes[0].data.ui_tags).toEqual(['pii']);
-			expect((updatedNodes[0].data as any).dbt_tags).toEqual(['nightly']);
+			expect((updatedNodes[0].data as any).framework_tags).toEqual(['nightly']);
 		});
 	});
 

--- a/frontend/src/lib/utils/bulk-operations.ts
+++ b/frontend/src/lib/utils/bulk-operations.ts
@@ -1,6 +1,7 @@
 import type { Node, Edge } from '@xyflow/svelte';
 import { nodes as nodesStore, edges as edgesStore, entitySelection, pushHistory } from '$lib/stores';
 import { get } from 'svelte/store';
+import { readModelRef, readFrameworkTags } from './entity-compat';
 
 /**
  * Bulk add domain to multiple entities
@@ -63,9 +64,9 @@ export function bulkAddTags(entityIds: string[], tagsToAdd: string[]): void {
 
 	const updatedNodes = currentNodes.map((node) => {
 		if (entityIds.includes(node.id) && node.type === 'entity') {
-			const isBound = Boolean(node.data?.dbt_model);
+			const isBound = Boolean(node.data && readModelRef(node.data as any));
 			const tagField = isBound ? 'ui_tags' : 'tags';
-			const dbtTags: string[] = isBound ? ((node.data as any)?.dbt_tags || []) : [];
+			const dbtTags: string[] = isBound ? readFrameworkTags((node.data as any) || {}) : [];
 			const currentTags = (node.data as any)?.[tagField] || [];
 			const newTags = Array.isArray(currentTags) ? [...currentTags] : [];
 
@@ -114,7 +115,7 @@ export function bulkRemoveTags(entityIds: string[], tagsToRemove: string[]): voi
 
 	const updatedNodes = currentNodes.map((node) => {
 		if (entityIds.includes(node.id) && node.type === 'entity') {
-			const isBound = Boolean(node.data?.dbt_model);
+			const isBound = Boolean(node.data && readModelRef(node.data as any));
 			const tagField = isBound ? 'ui_tags' : 'tags';
 			const currentTags = (node.data as any)?.[tagField];
 			if (!Array.isArray(currentTags)) return node;

--- a/frontend/src/lib/utils/entity-compat.test.ts
+++ b/frontend/src/lib/utils/entity-compat.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readModelRef, readFrameworkTags } from './entity-compat';
+
+describe('readModelRef', () => {
+    it('reads the new model_ref key', () => {
+        expect(readModelRef({ model_ref: 'model.proj.users' })).toBe('model.proj.users');
+    });
+
+    it('falls back to the legacy dbt_model key', () => {
+        expect(readModelRef({ dbt_model: 'model.proj.legacy_users' })).toBe('model.proj.legacy_users');
+    });
+
+    it('prefers model_ref when both are present', () => {
+        expect(readModelRef({ model_ref: 'model.proj.new_users', dbt_model: 'model.proj.legacy_users' })).toBe(
+            'model.proj.new_users'
+        );
+    });
+
+    it('returns undefined when neither key is present', () => {
+        expect(readModelRef({})).toBeUndefined();
+    });
+});
+
+describe('readFrameworkTags', () => {
+    it('reads the new framework_tags key', () => {
+        expect(readFrameworkTags({ framework_tags: ['nightly'] })).toEqual(['nightly']);
+    });
+
+    it('falls back to the legacy dbt_tags key', () => {
+        expect(readFrameworkTags({ dbt_tags: ['nightly'] })).toEqual(['nightly']);
+    });
+
+    it('prefers framework_tags when both are present', () => {
+        expect(readFrameworkTags({ framework_tags: ['pii'], dbt_tags: ['nightly'] })).toEqual(['pii']);
+    });
+
+    it('returns [] when neither key is present', () => {
+        expect(readFrameworkTags({})).toEqual([]);
+    });
+});

--- a/frontend/src/lib/utils/entity-compat.ts
+++ b/frontend/src/lib/utils/entity-compat.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration-compat helpers for reading entity fields that are being renamed
+ * from their legacy dbt-specific names to framework-agnostic ones:
+ *   - `dbt_model` -> `model_ref`
+ *   - `dbt_tags` -> `framework_tags`
+ *
+ * These helpers prefer the new key when present and fall back to the legacy
+ * key otherwise, so callers can be migrated incrementally without any change
+ * in observed behavior. Once all data is migrated and all call sites read
+ * through these helpers, the legacy keys can be dropped in one place.
+ */
+
+interface EntityWithModelRef {
+    model_ref?: string;
+    dbt_model?: string;
+}
+
+interface EntityWithFrameworkTags {
+    framework_tags?: string[];
+    dbt_tags?: string[];
+}
+
+/**
+ * Returns the entity's model reference, preferring the new `model_ref` key
+ * and falling back to the legacy `dbt_model` key.
+ */
+export function readModelRef(e: EntityWithModelRef): string | undefined {
+    return e.model_ref ?? e.dbt_model;
+}
+
+/**
+ * Returns the entity's framework tags, preferring the new `framework_tags`
+ * key and falling back to the legacy `dbt_tags` key. Returns an empty array
+ * when neither is present.
+ */
+export function readFrameworkTags(e: EntityWithFrameworkTags): string[] {
+    return e.framework_tags ?? e.dbt_tags ?? [];
+}

--- a/frontend/src/lib/utils/entity-filtering.test.ts
+++ b/frontend/src/lib/utils/entity-filtering.test.ts
@@ -11,7 +11,7 @@ describe('entity-filtering', () => {
 		tags?: string[],
 		domains?: string[],
 		entity_type?: 'dimension' | 'fact' | 'unclassified',
-		dbt_model?: string
+		model_ref?: string
 	): Entity => ({
 		id,
 		label,
@@ -21,7 +21,7 @@ describe('entity-filtering', () => {
 		description: '',
 		entity_type: entity_type ?? 'dimension',
 		attributes: [],
-		dbt_model,
+		model_ref,
 	});
 
 	describe('filterEntities', () => {

--- a/frontend/src/lib/utils/entity-filtering.ts
+++ b/frontend/src/lib/utils/entity-filtering.ts
@@ -1,4 +1,5 @@
 import type { Entity } from '$lib/types';
+import { readModelRef } from './entity-compat';
 
 /**
  * Simple fuzzy/substring match for search term
@@ -49,7 +50,7 @@ export function filterEntities(
 
 		// Filter by build status (OR logic: if empty/undefined, show all)
 		if (filters.selectedBuildStatus && filters.selectedBuildStatus.length > 0) {
-			const isBound = !!entity.dbt_model;
+			const isBound = !!readModelRef(entity);
 			if (!filters.selectedBuildStatus.includes(isBound ? 'bound' : 'unbound')) {
 				return false;
 			}

--- a/frontend/src/lib/utils/entity-tags.test.ts
+++ b/frontend/src/lib/utils/entity-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mapEntityTagsToNodeData, computeUiTagsAfterEdit } from './entity-tags';
+import { readFrameworkTags } from './entity-compat';
 
 describe('mapEntityTagsToNodeData', () => {
     it('splits dbt_tags and ui_tags for a bound entity, plus the display tags union', () => {
@@ -23,6 +24,25 @@ describe('mapEntityTagsToNodeData', () => {
         expect(result.tags).toEqual(['draft-tag']);
         expect(result.dbt_tags).toEqual([]);
         expect(result.ui_tags).toEqual([]);
+    });
+
+    it('returns empty mirrored/ui tags for an unbound entity', () => {
+        const entity = { tags: ['draft-tag'] };
+        const result = mapEntityTagsToNodeData(entity);
+        expect(result.dbt_tags).toEqual(readFrameworkTags({}));
+        expect(result.ui_tags).toEqual(readFrameworkTags({}));
+    });
+
+    it('returns mirrored+ui split for a bound entity', () => {
+        const entity = {
+            dbt_model: 'model.proj.users',
+            tags: ['nightly', 'pii'],
+            dbt_tags: ['nightly'],
+            ui_tags: ['pii']
+        };
+        const result = mapEntityTagsToNodeData(entity);
+        expect(result.dbt_tags).toEqual(readFrameworkTags({ dbt_tags: entity.dbt_tags }));
+        expect(result.ui_tags).toEqual(readFrameworkTags({ dbt_tags: entity.ui_tags }));
     });
 });
 

--- a/frontend/src/lib/utils/entity-tags.test.ts
+++ b/frontend/src/lib/utils/entity-tags.test.ts
@@ -3,55 +3,55 @@ import { mapEntityTagsToNodeData, computeUiTagsAfterEdit } from './entity-tags';
 import { readFrameworkTags } from './entity-compat';
 
 describe('mapEntityTagsToNodeData', () => {
-    it('splits dbt_tags and ui_tags for a bound entity, plus the display tags union', () => {
-        const entity = { dbt_model: 'model.proj.users', tags: ['nightly', 'pii'], dbt_tags: ['nightly'], ui_tags: ['pii'] };
+    it('splits framework_tags and ui_tags for a bound entity, plus the display tags union', () => {
+        const entity = { model_ref: 'model.proj.users', tags: ['nightly', 'pii'], framework_tags: ['nightly'], ui_tags: ['pii'] };
         const result = mapEntityTagsToNodeData(entity);
         expect(result.tags).toEqual(['nightly', 'pii']);
-        expect(result.dbt_tags).toEqual(['nightly']);
+        expect(result.framework_tags).toEqual(['nightly']);
         expect(result.ui_tags).toEqual(['pii']);
     });
 
-    it('defaults dbt_tags/ui_tags to [] only when genuinely absent', () => {
-        const entity = { dbt_model: 'model.proj.users', tags: ['nightly'] };
+    it('defaults framework_tags/ui_tags to [] only when genuinely absent', () => {
+        const entity = { model_ref: 'model.proj.users', tags: ['nightly'] };
         const result = mapEntityTagsToNodeData(entity);
-        expect(result.dbt_tags).toEqual([]);
+        expect(result.framework_tags).toEqual([]);
         expect(result.ui_tags).toEqual([]);
     });
 
-    it('unbound entity treats tags as the single freely-editable field, dbt_tags/ui_tags unused', () => {
+    it('unbound entity treats tags as the single freely-editable field, framework_tags/ui_tags unused', () => {
         const entity = { tags: ['draft-tag'] };
         const result = mapEntityTagsToNodeData(entity);
         expect(result.tags).toEqual(['draft-tag']);
-        expect(result.dbt_tags).toEqual([]);
+        expect(result.framework_tags).toEqual([]);
         expect(result.ui_tags).toEqual([]);
     });
 
     it('returns empty mirrored/ui tags for an unbound entity', () => {
         const entity = { tags: ['draft-tag'] };
         const result = mapEntityTagsToNodeData(entity);
-        expect(result.dbt_tags).toEqual(readFrameworkTags({}));
+        expect(result.framework_tags).toEqual(readFrameworkTags({}));
         expect(result.ui_tags).toEqual(readFrameworkTags({}));
     });
 
     it('returns mirrored+ui split for a bound entity', () => {
         const entity = {
-            dbt_model: 'model.proj.users',
+            model_ref: 'model.proj.users',
             tags: ['nightly', 'pii'],
-            dbt_tags: ['nightly'],
+            framework_tags: ['nightly'],
             ui_tags: ['pii']
         };
         const result = mapEntityTagsToNodeData(entity);
-        expect(result.dbt_tags).toEqual(readFrameworkTags({ dbt_tags: entity.dbt_tags }));
-        expect(result.ui_tags).toEqual(readFrameworkTags({ dbt_tags: entity.ui_tags }));
+        expect(result.framework_tags).toEqual(readFrameworkTags({ framework_tags: entity.framework_tags }));
+        expect(result.ui_tags).toEqual(readFrameworkTags({ framework_tags: entity.ui_tags }));
     });
 });
 
 describe('computeUiTagsAfterEdit', () => {
-    it('appends only the delta not already dbt-mirrored', () => {
+    it('appends only the delta not already framework-mirrored', () => {
         expect(computeUiTagsAfterEdit(['nightly'], ['nightly', 'pii'])).toEqual(['pii']);
     });
 
-    it('removing a dbt-mirrored tag from the widget is a no-op — it is not tracked as a removal', () => {
+    it('removing a framework-mirrored tag from the widget is a no-op — it is not tracked as a removal', () => {
         expect(computeUiTagsAfterEdit(['nightly'], ['pii'])).toEqual(['pii']);
     });
 

--- a/frontend/src/lib/utils/entity-tags.ts
+++ b/frontend/src/lib/utils/entity-tags.ts
@@ -1,4 +1,5 @@
 import { normalizeTags } from '$lib/utils';
+import { readModelRef, readFrameworkTags } from './entity-compat';
 
 /**
  * Split an entity's tag fields into node data. `tags` is the backend-computed
@@ -7,16 +8,16 @@ import { normalizeTags } from '$lib/utils';
  * unbound entities have no schema.yml to mirror and use plain `tags` as their
  * single, freely-editable field instead.
  */
-export function mapEntityTagsToNodeData(entity: { dbt_model?: string; tags?: unknown; dbt_tags?: unknown; ui_tags?: unknown }): {
+export function mapEntityTagsToNodeData(entity: { model_ref?: string; dbt_model?: string; tags?: unknown; framework_tags?: string[]; dbt_tags?: string[]; ui_tags?: unknown }): {
     tags: string[];
     dbt_tags: string[];
     ui_tags: string[];
 } {
     const tags = normalizeTags(entity.tags);
-    if (!entity.dbt_model) {
+    if (!readModelRef(entity)) {
         return { tags, dbt_tags: [], ui_tags: [] };
     }
-    return { tags, dbt_tags: normalizeTags(entity.dbt_tags), ui_tags: normalizeTags(entity.ui_tags) };
+    return { tags, dbt_tags: normalizeTags(readFrameworkTags(entity)), ui_tags: normalizeTags(entity.ui_tags) };
 }
 
 /**

--- a/frontend/src/lib/utils/entity-tags.ts
+++ b/frontend/src/lib/utils/entity-tags.ts
@@ -3,35 +3,35 @@ import { readModelRef, readFrameworkTags } from './entity-compat';
 
 /**
  * Split an entity's tag fields into node data. `tags` is the backend-computed
- * display union (dbt_tags + ui_tags) for bound entities — read-only, never
- * hand-edited. `dbt_tags`/`ui_tags` are only meaningful for bound entities;
+ * display union (framework_tags + ui_tags) for bound entities — read-only, never
+ * hand-edited. `framework_tags`/`ui_tags` are only meaningful for bound entities;
  * unbound entities have no schema.yml to mirror and use plain `tags` as their
  * single, freely-editable field instead.
  */
 export function mapEntityTagsToNodeData(entity: { model_ref?: string; dbt_model?: string; tags?: unknown; framework_tags?: string[]; dbt_tags?: string[]; ui_tags?: unknown }): {
     tags: string[];
-    dbt_tags: string[];
+    framework_tags: string[];
     ui_tags: string[];
 } {
     const tags = normalizeTags(entity.tags);
     if (!readModelRef(entity)) {
-        return { tags, dbt_tags: [], ui_tags: [] };
+        return { tags, framework_tags: [], ui_tags: [] };
     }
-    return { tags, dbt_tags: normalizeTags(readFrameworkTags(entity)), ui_tags: normalizeTags(entity.ui_tags) };
+    return { tags, framework_tags: normalizeTags(readFrameworkTags(entity)), ui_tags: normalizeTags(entity.ui_tags) };
 }
 
 /**
- * Given a bound entity's dbt-mirrored tags and the full tag list a user's edit
+ * Given a bound entity's framework-mirrored tags and the full tag list a user's edit
  * in the tag-editor widget implies (`newTags` — the widget's post-edit state),
  * compute the resulting `ui_tags`.
  *
- * Only tags not already dbt-mirrored are Trellis's to track: a dbt-mirrored tag is
- * never removable via this path (dbt wins), so its absence from `newTags` — e.g. a
- * user trying to drop a read-only chip — is not treated as a removal. Anything the
- * user actually removed from `ui_tags` (tags absent from `newTags` that aren't
- * dbt-mirrored either) is dropped, since the diff is keyed off `newTags` alone.
+ * Only tags not already framework-mirrored are Trellis's to track: a framework-mirrored
+ * tag is never removable via this path (the framework's model wins), so its absence from
+ * `newTags` — e.g. a user trying to drop a read-only chip — is not treated as a removal.
+ * Anything the user actually removed from `ui_tags` (tags absent from `newTags` that
+ * aren't framework-mirrored either) is dropped, since the diff is keyed off `newTags` alone.
  */
-export function computeUiTagsAfterEdit(dbtTags: unknown, newTags: unknown): string[] {
-    const dbtMirrored = new Set(normalizeTags(dbtTags));
-    return normalizeTags(newTags).filter((t) => !dbtMirrored.has(t));
+export function computeUiTagsAfterEdit(frameworkTags: unknown, newTags: unknown): string[] {
+    const frameworkMirrored = new Set(normalizeTags(frameworkTags));
+    return normalizeTags(newTags).filter((t) => !frameworkMirrored.has(t));
 }

--- a/frontend/src/lib/utils/excel-export.integration.test.ts
+++ b/frontend/src/lib/utils/excel-export.integration.test.ts
@@ -29,7 +29,7 @@ describe('excel-export integration tests', () => {
         tags: ['core', 'master-data'],
         source_system: ['SAP', 'Salesforce'],
         description: 'Customer master data from various sources',
-        dbt_model: 'dim_customer',
+        model_ref: 'dim_customer',
         additional_models: ['stg_customer', 'int_customer']
       };
 

--- a/frontend/src/lib/utils/excel-export.test.ts
+++ b/frontend/src/lib/utils/excel-export.test.ts
@@ -179,7 +179,7 @@ describe('Sheet Generators', () => {
         tags: ['pii', 'core'],
         source_system: ['CRM', 'ERP'],
         description: 'Customer entity',
-        dbt_model: 'model.project.customer',
+        model_ref: 'model.project.customer',
         additional_models: ['model.project.customer_history']
       };
 

--- a/frontend/src/lib/utils/excel-export.ts
+++ b/frontend/src/lib/utils/excel-export.ts
@@ -2,6 +2,7 @@ import * as XLSX from 'xlsx';
 import type { Node } from '@xyflow/svelte';
 import type { AnnotationType, EntityData, OriginEntry } from '$lib/types';
 import { stringifyOrigin } from './origin';
+import { readModelRef } from '$lib/utils/entity-compat';
 
 type ExportAttribute = {
 	name: string;
@@ -181,7 +182,7 @@ export function generateOverviewSheet(entity: EntityData, isDimensional: boolean
 		['Tags', entity.tags?.join(', ') || '-'],
 		['Source Systems', entity.source_system?.join(', ') || '-'],
 		['Description', entity.description || '-'],
-		['dbt Model', entity.dbt_model || '-'],
+		['dbt Model', readModelRef(entity) || '-'],
 		['Additional Models', entity.additional_models?.join(', ') || '-']
 	];
 

--- a/frontend/src/lib/utils/field-promotion.ts
+++ b/frontend/src/lib/utils/field-promotion.ts
@@ -1,8 +1,8 @@
-import type { DbtModel, DraftedField } from '$lib/types';
+import type { ModelInfo, DraftedField } from '$lib/types';
 
 export function promoteDraftsAgainstModel(
 	drafted: DraftedField[] | undefined,
-	model: DbtModel | undefined,
+	model: ModelInfo | undefined,
 ): DraftedField[] | undefined {
 	if (drafted === undefined) return undefined;
 	if (!model || !model.columns || model.columns.length === 0) return drafted;

--- a/frontend/src/lib/utils/framework-display.ts
+++ b/frontend/src/lib/utils/framework-display.ts
@@ -1,0 +1,40 @@
+/**
+ * Framework-driven branding for the model sidebar.
+ *
+ * Trellis is framework-agnostic by design: the transformation framework is a
+ * config value, not an assumption baked into the UI. This map holds branding
+ * only for frameworks Trellis actually implements an adapter for. Anything else
+ * gets neutral branding rather than silently inheriting dbt's, which would make
+ * the header lie about what the models came from.
+ *
+ * Add an entry here when its adapter lands, not before.
+ */
+
+export interface FrameworkDisplay {
+    icon: string;
+    label: string;
+    alt: string;
+}
+
+const FRAMEWORK_DISPLAY: Record<string, FrameworkDisplay> = {
+    "dbt-core": {
+        icon: "https://www.getdbt.com/favicon.ico",
+        label: "dbt Models",
+        alt: "dbt icon",
+    },
+};
+
+/** Neutral branding for a configured framework Trellis has no adapter for yet. */
+export const DEFAULT_FRAMEWORK_DISPLAY: FrameworkDisplay = {
+    icon: "/icons/framework.svg",
+    label: "Models",
+    alt: "framework icon",
+};
+
+/** Frameworks with dedicated branding. Exported so tests can assert it stays honest. */
+export const FRAMEWORK_DISPLAY_KEYS = Object.keys(FRAMEWORK_DISPLAY);
+
+export function getFrameworkDisplay(framework: string | undefined | null): FrameworkDisplay {
+    if (!framework) return DEFAULT_FRAMEWORK_DISPLAY;
+    return FRAMEWORK_DISPLAY[framework] ?? DEFAULT_FRAMEWORK_DISPLAY;
+}

--- a/frontend/src/lib/utils/markdown-export.test.ts
+++ b/frontend/src/lib/utils/markdown-export.test.ts
@@ -18,7 +18,7 @@ describe('markdown-export utilities', () => {
 			tags: ['pii', 'core'],
 			source_system: ['CRM', 'ERP'],
 			description: 'Main customer entity',
-			dbt_model: 'model.project.customer',
+			model_ref: 'model.project.customer',
 			additional_models: ['model.project.customer_history']
 		};
 

--- a/frontend/src/lib/utils/markdown-export.ts
+++ b/frontend/src/lib/utils/markdown-export.ts
@@ -2,6 +2,7 @@ import type { Node } from '@xyflow/svelte';
 import type { EntityData, OriginEntry } from '$lib/types';
 import { formatEntityType, formatAnnotationType, formatRelationshipType, formatRelationshipKeys } from './excel-export';
 import { stringifyOrigin } from './origin';
+import { readModelRef } from '$lib/utils/entity-compat';
 
 /**
  * Prepares a value for a GFM pipe table cell: single-line text and no raw `|` characters.
@@ -49,7 +50,7 @@ export function formatEntityAsMarkdown(
 	lines.push(`**Tags:** ${entity.tags?.join(', ') || '-'}`);
 	lines.push(`**Source Systems:** ${entity.source_system?.join(', ') || '-'}`);
 	lines.push(`**Description:** ${entity.description || '-'}`);
-	lines.push(`**dbt Model:** ${entity.dbt_model || '-'}`);
+	lines.push(`**dbt Model:** ${readModelRef(entity) || '-'}`);
 	lines.push(`**Additional Models:** ${entity.additional_models?.join(', ') || '-'}`);
 	lines.push('');
 

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -24,6 +24,7 @@
         dimensionPrefixes,
         factPrefixes,
         sourceColors,
+        activeFramework,
     } from "$lib/stores";
     import {
         getApiBase,
@@ -541,6 +542,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                 busMatrixEnabled = info?.bus_matrix_enabled ?? false;
                 businessEventsEnabled = info?.business_events_enabled ?? false;
                 $modelingStyle = info?.modeling_style ?? 'entity_model';
+                $activeFramework = info?.framework ?? 'dbt-core';
                 $labelPrefixes = getLabelPrefixesFromConfig(info ?? null);
                 dimensionPrefixes.set(info?.dimension_prefix ?? []);
                 factPrefixes.set(info?.fact_prefix ?? []);

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -46,6 +46,7 @@ import {
     getLabelPrefixesFromConfig,
 } from "$lib/utils";
 import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
+import { readModelRef } from "$lib/utils/entity-compat";
     import { applyDagreLayout } from "$lib/layout";
     import Sidebar from "$lib/components/Sidebar.svelte";
     import ConfigInfoModal from "$lib/components/ConfigInfoModal.svelte";
@@ -589,10 +590,10 @@ import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
 
                 // Helper to get folder and tags from dbt model
                 function getEntityMetadata(entity: any) {
-                    if (!entity.dbt_model) return { folder: null, model: null };
+                    if (!readModelRef(entity)) return { folder: null, model: null };
 
                     const model = models.find(
-                        (m: any) => m.unique_id === entity.dbt_model,
+                        (m: any) => m.unique_id === readModelRef(entity),
                     );
                     if (!model) return { folder: null, model: null };
 
@@ -612,7 +613,7 @@ import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
                         data: {
                             label: e.label?.trim() || formatModelNameForLabel(modelName.trim(), $labelPrefixes),
                             description: e.description,
-                            dbt_model: e.dbt_model,
+                            dbt_model: readModelRef(e),
                             additional_models: e.additional_models,
                             drafted_fields: e.drafted_fields,
                             width: e.width ?? 280,
@@ -797,7 +798,7 @@ import { mapEntityTagsToNodeData } from "$lib/utils/entity-tags";
                 return node;
             }
 
-            const primaryModel = models.find((m) => m.unique_id === node.data.dbt_model);
+            const primaryModel = models.find((m) => m.unique_id === readModelRef(node.data as any));
             const additionalModelIds = (node.data?.additional_models as string[]) || [];
             const additionalModels = additionalModelIds.map((id) => models.find((m) => m.unique_id === id)).filter((m): m is DbtModel => m !== undefined);
             const allBoundModels = primaryModel ? [primaryModel, ...additionalModels] : additionalModels;

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -603,7 +603,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                 // Map data model to Svelte Flow format with metadata
                 const entityNodes = (dataModel.entities || []).map((e: any) => {
                     const metadata = getEntityMetadata(e);
-                    const { tags, dbt_tags, ui_tags } = mapEntityTagsToNodeData(e);
+                    const { tags, framework_tags, ui_tags } = mapEntityTagsToNodeData(e);
                     const modelName = metadata.model ? metadata.model.name : e.id;
                     return {
                         id: e.id,
@@ -621,7 +621,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                             collapsed: e.collapsed ?? false,
                             folder: metadata.folder,
                             tags,
-                            dbt_tags,
+                            framework_tags,
                             ui_tags,
                             entity_type: e.entity_type,
                             source_system: e.source_system,

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -58,7 +58,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
     import DeleteConfirmModal from "$lib/components/DeleteConfirmModal.svelte";
     import EntityDetailModal from "$lib/components/EntityDetailModal.svelte";
     import { type Node, type Edge } from "@xyflow/svelte";
-    import type { ConfigInfo, DbtModel, GuidanceConfig } from "$lib/types";
+    import type { ConfigInfo, ModelInfo, GuidanceConfig } from "$lib/types";
     import Icon from "$lib/components/Icon.svelte";
     import { lineageModal, closeLineageModal, sourceEditorModal, closeSourceEditorModal, deleteConfirmModal, closeDeleteConfirmModal } from "$lib/stores";
     import { AutoSaveService } from "$lib/services/auto-save";
@@ -802,7 +802,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
 
             const primaryModel = models.find((m) => m.unique_id === readModelRef(node.data as any));
             const additionalModelIds = (node.data?.additional_models as string[]) || [];
-            const additionalModels = additionalModelIds.map((id) => models.find((m) => m.unique_id === id)).filter((m): m is DbtModel => m !== undefined);
+            const additionalModels = additionalModelIds.map((id) => models.find((m) => m.unique_id === id)).filter((m): m is ModelInfo => m !== undefined);
             const allBoundModels = primaryModel ? [primaryModel, ...additionalModels] : additionalModels;
 
             let visible = true;

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -8,7 +8,7 @@
     import {
     nodes,
     edges,
-    dbtModels,
+    frameworkModels,
     viewMode,
     configStatus,
     initHistory,
@@ -308,7 +308,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                     if (existingEntityIds.has(id)) return;
 
                     const model =
-                        $dbtModels.find(
+                        $frameworkModels.find(
                             (m) => m.unique_id === id || m.name === id,
                         ) ?? null;
                     const folder = model ? getModelFolder(model) : null;
@@ -558,7 +558,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
 
                 // Load Manifest
                 const models = await getManifest();
-                $dbtModels = models;
+                $frameworkModels = models;
 
                 // Reconcile manifest columns into data_model.yml (provenance-aware, non-destructive).
                 // This writes source='dbt' fields into each bound entity before we load the data model,
@@ -788,7 +788,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
 
         const activeFolder = $folderFilter;
         const activeTags = $tagFilter;
-        const models = $dbtModels;
+        const models = $frameworkModels;
 
         const currentNodes = untrack(() => $nodes);
         const currentEdges = untrack(() => $edges);

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -322,7 +322,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                         data: {
                             label: formatModelNameForLabel((model?.name ?? id).trim(), $labelPrefixes),
                             description: model?.description ?? "",
-                            dbt_model: model?.unique_id ?? null,
+                            model_ref: model?.unique_id ?? null,
                             additional_models: [],
                             drafted_fields: [],
                             width: 280,
@@ -615,7 +615,7 @@ import { readModelRef } from "$lib/utils/entity-compat";
                         data: {
                             label: e.label?.trim() || formatModelNameForLabel(modelName.trim(), $labelPrefixes),
                             description: e.description,
-                            dbt_model: readModelRef(e),
+                            model_ref: readModelRef(e),
                             additional_models: e.additional_models,
                             drafted_fields: e.drafted_fields,
                             width: e.width ?? 280,

--- a/frontend/src/routes/(app)/entity-list/+page.svelte
+++ b/frontend/src/routes/(app)/entity-list/+page.svelte
@@ -2,6 +2,7 @@
 	import { nodes, entityListFilters, bulkEditModal } from '$lib/stores';
 	import type { EntityData } from '$lib/types';
 	import { filterEntities } from '$lib/utils/entity-filtering';
+	import { readModelRef } from '$lib/utils/entity-compat';
 	import EntityList from '$lib/components/EntityList.svelte';
 	import EntityListFilters from '$lib/components/EntityListFilters.svelte';
 	import BulkEditModal from '$lib/components/BulkEditModal.svelte';
@@ -17,7 +18,7 @@
 					id: node.id,
 					label: data.label,
 					description: data.description,
-					dbt_model: data.dbt_model,
+					dbt_model: readModelRef(data),
 					additional_models: data.additional_models,
 					drafted_fields: data.drafted_fields,
 					position: node.position,

--- a/frontend/src/routes/(app)/entity-list/+page.svelte
+++ b/frontend/src/routes/(app)/entity-list/+page.svelte
@@ -18,7 +18,7 @@
 					id: node.id,
 					label: data.label,
 					description: data.description,
-					dbt_model: readModelRef(data),
+					model_ref: readModelRef(data),
 					additional_models: data.additional_models,
 					drafted_fields: data.drafted_fields,
 					position: node.position,

--- a/frontend/static/icons/bruin.svg
+++ b/frontend/static/icons/bruin.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Bruin">
+  <title>Bruin</title>
+  <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="2.5" y="3.5" width="7" height="6" rx="1.2"/>
+    <rect x="14.5" y="3.5" width="7" height="6" rx="1.2"/>
+    <rect x="8.5" y="14.5" width="7" height="6" rx="1.2"/>
+    <path d="M6 9.5v3a2 2 0 0 0 2 2h.5"/>
+    <path d="M18 9.5v3a2 2 0 0 1-2 2h-.5"/>
+  </g>
+</svg>

--- a/frontend/static/icons/framework.svg
+++ b/frontend/static/icons/framework.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Bruin">
-  <title>Bruin</title>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Transformation framework">
+  <title>Transformation framework</title>
   <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <rect x="2.5" y="3.5" width="7" height="6" rx="1.2"/>
     <rect x="14.5" y="3.5" width="7" height="6" rx="1.2"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.20.0"
+version = "0.20.0b1"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.20.0b1"
+version = "0.20.0b2"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.19.1"
+version = "0.20.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.20.0b2"
+version = "0.20.0"
 description = "Visual data model editor for dbt projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/adapters/__init__.py
+++ b/trellis_datamodel/adapters/__init__.py
@@ -19,7 +19,9 @@ def get_adapter() -> Union[DbtCoreAdapter, TransformationAdapter]:
         An adapter instance implementing TransformationAdapter.
 
     Raises:
-        ValueError: If the configured framework is not supported.
+        ValueError: If the configured framework is not recognized.
+        NotImplementedError: If the configured framework is recognized but not
+            yet implemented (currently: bruin).
     """
     # Always read from the live config module (cfg) to respect load_config()
     if cfg.FRAMEWORK == "dbt-core":
@@ -31,9 +33,15 @@ def get_adapter() -> Union[DbtCoreAdapter, TransformationAdapter]:
             model_paths=cfg.DBT_MODEL_PATHS,
         )
 
+    if cfg.FRAMEWORK == "bruin":
+        raise NotImplementedError(
+            "Bruin adapter not yet implemented — see follow-up spec"
+        )
+
     raise ValueError(
         f"Unknown framework: {cfg.FRAMEWORK}. "
-        f"Supported frameworks: dbt-core"
+        f"Supported frameworks: dbt-core. "
+        f"Planned (not yet implemented): bruin."
     )
 
 

--- a/trellis_datamodel/adapters/__init__.py
+++ b/trellis_datamodel/adapters/__init__.py
@@ -19,9 +19,7 @@ def get_adapter() -> Union[DbtCoreAdapter, TransformationAdapter]:
         An adapter instance implementing TransformationAdapter.
 
     Raises:
-        ValueError: If the configured framework is not recognized.
-        NotImplementedError: If the configured framework is recognized but not
-            yet implemented (currently: bruin).
+        ValueError: If the configured framework is not supported.
     """
     # Always read from the live config module (cfg) to respect load_config()
     if cfg.FRAMEWORK == "dbt-core":
@@ -33,15 +31,9 @@ def get_adapter() -> Union[DbtCoreAdapter, TransformationAdapter]:
             model_paths=cfg.DBT_MODEL_PATHS,
         )
 
-    if cfg.FRAMEWORK == "bruin":
-        raise NotImplementedError(
-            "Bruin adapter not yet implemented — see follow-up spec"
-        )
-
     raise ValueError(
         f"Unknown framework: {cfg.FRAMEWORK}. "
-        f"Supported frameworks: dbt-core. "
-        f"Planned (not yet implemented): bruin."
+        f"Supported frameworks: dbt-core"
     )
 
 

--- a/trellis_datamodel/adapters/base.py
+++ b/trellis_datamodel/adapters/base.py
@@ -165,3 +165,57 @@ class TransformationAdapter(Protocol):
         """
         ...
 
+    def save_schema_file(
+        self,
+        entity_id: str,
+        model_name: str,
+        fields: list[dict[str, str]],
+        description: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+    ) -> Path:
+        """
+        Generate and save a framework schema definition file for drafted fields.
+
+        This is used for creating new schema files from the data model editor.
+
+        Args:
+            entity_id: Entity ID from the data model.
+            model_name: Name of the framework model backing the entity.
+            fields: List of field definitions.
+            description: Optional model description.
+            tags: Optional list of tags to additively union onto whatever is
+                already present in the schema file.
+
+        Returns:
+            Path to the saved schema file.
+        """
+        ...
+
+    def infer_entity_types(self) -> dict[str, str]:
+        """
+        Infer entity types from framework model naming patterns.
+
+        Returns:
+            dict[entity_id, entity_type]: Mapping from entity ID to inferred
+            type ("fact", "dimension", or "unclassified").
+        """
+        ...
+
+    def get_model_dirs(self) -> list[str]:
+        """
+        Return the directories where the active framework's models live.
+
+        Returns:
+            List of absolute directory paths.
+        """
+        ...
+
+    def reset_inference_cache(self) -> None:
+        """
+        Reset any cached entity type inference results.
+
+        Should be called when configuration changes that affect inference
+        (e.g., dimensional modeling config, manifest path changes).
+        """
+        ...
+

--- a/trellis_datamodel/adapters/base.py
+++ b/trellis_datamodel/adapters/base.py
@@ -59,7 +59,7 @@ class Entity(TypedDict, total=False):
     id: str
     label: str
     description: Optional[str]
-    dbt_model: Optional[str]
+    model_ref: Optional[str]
     additional_models: Optional[list[str]]
     drafted_fields: Optional[list[dict[str, Any]]]
     tags: Optional[list[str]]
@@ -139,7 +139,7 @@ class TransformationAdapter(Protocol):
 
         Args:
             include_unbound: When True, also include relationships for entities
-                that exist in the data model but are not yet bound to a dbt
+                that exist in the data model but are not yet bound to a framework
                 model. Useful for frontends that want immediate inference right
                 after a bind action, before the data model file is persisted.
 

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from trellis_datamodel import config as cfg
+from trellis_datamodel.models.entity_keys import get_model_ref
 from trellis_datamodel.utils.yaml_handler import YamlHandler
 from trellis_datamodel.utils.origin import parse_origin
 from .base import (
@@ -156,7 +157,7 @@ class DbtCoreAdapter:
         Prefers the bound dbt_model (strips project prefix), otherwise applies
         inference patterns to generate an appropriate model name with prefix.
         """
-        dbt_model = entity.get("dbt_model")
+        dbt_model = get_model_ref(entity)
         if dbt_model:
             # Respect existing bound dbt_model values (don't re-prefix bound entities)
             # dbt unique_id for versioned models looks like model.<project>.<name>.v2
@@ -257,7 +258,7 @@ class DbtCoreAdapter:
 
         for entity in entities:
             entity_id = entity.get("id")
-            dbt_model = entity.get("dbt_model")
+            dbt_model = get_model_ref(entity)
             if dbt_model:
                 parts = dbt_model.split(".")
                 version_part = None
@@ -452,7 +453,7 @@ class DbtCoreAdapter:
         for entity in data_model.get("entities", []):
             if entity.get("id") != entity_id:
                 continue
-            dbt_model = entity.get("dbt_model") or ""
+            dbt_model = get_model_ref(entity) or ""
             # Check last token after split to support fully-qualified model IDs
             last_token = dbt_model.split(".")[-1] if dbt_model else ""
             version = self._extract_version_from_string(last_token)
@@ -784,7 +785,7 @@ class DbtCoreAdapter:
             bound_entities = {
                 e.get("id")
                 for e in data_model.get("entities", [])
-                if e.get("id") and (e.get("dbt_model") or e.get("additional_models"))
+                if e.get("id") and (get_model_ref(e) or e.get("additional_models"))
             }
         relationships: list[Relationship] = []
         yml_found = False
@@ -1060,7 +1061,7 @@ class DbtCoreAdapter:
             # For bound entities, use the correct path from manifest
             # For unbound entities, use model_name (with prefix applied) for yml file
             yml_path = None
-            if entity.get("dbt_model"):
+            if get_model_ref(entity):
                 yml_path = self._get_model_yml_path(model_name)
             if not yml_path:
                 yml_path = os.path.join(models_dir, f"{model_name}.yml")
@@ -1198,7 +1199,7 @@ class DbtCoreAdapter:
         )
         if entity:
             # If entity is bound, use the bound model name from _entity_to_model_name
-            if entity.get("dbt_model"):
+            if get_model_ref(entity):
                 model_name = self._entity_to_model_name(entity)
             # If entity is unbound and entity modeling is enabled, apply prefix
             elif cfg.ENTITY_MODELING_CONFIG.enabled:

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -1164,7 +1164,7 @@ class DbtCoreAdapter:
 
         return updated_files
 
-    def save_dbt_schema(
+    def save_schema_file(
         self,
         entity_id: str,
         model_name: str,

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from trellis_datamodel import config as cfg
-from trellis_datamodel.models.entity_keys import get_model_ref, get_native_data_type
+from trellis_datamodel.models.entity_keys import get_model_ref, get_physical_datatype
 from trellis_datamodel.utils.yaml_handler import YamlHandler
 from trellis_datamodel.utils.origin import parse_origin
 from .base import (
@@ -1105,7 +1105,7 @@ class DbtCoreAdapter:
                         # time this column is synced, never overwrite an
                         # existing value (#111).
                         col_payload["data_type_fallback"] = _canonicalize_catalog_type(
-                            get_native_data_type(field)
+                            get_physical_datatype(field)
                         ) or field.get("datatype")
                     else:
                         col_payload["data_type"] = field.get("datatype")
@@ -1273,7 +1273,7 @@ class DbtCoreAdapter:
             col: dict = {"name": field["name"]}
             if field.get("source") == "dbt":
                 col["data_type_fallback"] = _canonicalize_catalog_type(
-                    get_native_data_type(field)
+                    get_physical_datatype(field)
                 ) or field["datatype"]
             else:
                 col["data_type"] = field["datatype"]

--- a/trellis_datamodel/adapters/dbt_core.py
+++ b/trellis_datamodel/adapters/dbt_core.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from trellis_datamodel import config as cfg
-from trellis_datamodel.models.entity_keys import get_model_ref
+from trellis_datamodel.models.entity_keys import get_model_ref, get_native_data_type
 from trellis_datamodel.utils.yaml_handler import YamlHandler
 from trellis_datamodel.utils.origin import parse_origin
 from .base import (
@@ -1105,7 +1105,7 @@ class DbtCoreAdapter:
                         # time this column is synced, never overwrite an
                         # existing value (#111).
                         col_payload["data_type_fallback"] = _canonicalize_catalog_type(
-                            field.get("dbt_data_type")
+                            get_native_data_type(field)
                         ) or field.get("datatype")
                     else:
                         col_payload["data_type"] = field.get("datatype")
@@ -1273,7 +1273,7 @@ class DbtCoreAdapter:
             col: dict = {"name": field["name"]}
             if field.get("source") == "dbt":
                 col["data_type_fallback"] = _canonicalize_catalog_type(
-                    field.get("dbt_data_type")
+                    get_native_data_type(field)
                 ) or field["datatype"]
             else:
                 col["data_type"] = field["datatype"]

--- a/trellis_datamodel/config.py
+++ b/trellis_datamodel/config.py
@@ -88,6 +88,8 @@ if _TEST_DIR:
     )
     DBT_PROJECT_PATH: str = _TEST_DIR
     DBT_MODEL_PATHS: list[str] = ["3_core"]
+    BRUIN_PIPELINE_PATH: Optional[str] = None
+    BRUIN_ASSET_PATHS: Optional[list[str]] = None
     FRONTEND_BUILD_DIR: str = os.path.join(_TEST_DIR, "frontend/build")
     DBT_COMPANY_DUMMY_PATH: str = os.path.join(_TEST_DIR, "dbt_company_dummy")
     LINEAGE_LAYERS: list[str] = []
@@ -112,6 +114,8 @@ else:
     CANVAS_LAYOUT_VERSION_CONTROL: bool = True
     DBT_PROJECT_PATH: str = ""
     DBT_MODEL_PATHS: list[str] = []
+    BRUIN_PIPELINE_PATH: Optional[str] = None
+    BRUIN_ASSET_PATHS: Optional[list[str]] = None
     FRONTEND_BUILD_DIR: str = ""
     DBT_COMPANY_DUMMY_PATH: str = ""
     LINEAGE_LAYERS: list[str] = []
@@ -162,6 +166,17 @@ def _resolve_project_path(config_path: str, config: dict[str, Any]) -> str:
         return ""
     base_dir = _resolve_base_path(config_path)
     return _resolve_path(base_dir, project_path)
+
+
+def _resolve_bruin_pipeline_path(
+    config_path: str, config: dict[str, Any]
+) -> Optional[str]:
+    """Resolve bruin_pipeline_path with config directory fallback."""
+    pipeline_path = config.get("bruin_pipeline_path")
+    if not pipeline_path:
+        return None
+    base_dir = _resolve_base_path(config_path)
+    return _resolve_path(base_dir, pipeline_path)
 
 
 def _resolve_manifest_path(
@@ -485,7 +500,7 @@ def find_config_file(config_override: Optional[str] = None) -> Optional[str]:
 
 def load_config(config_path: Optional[str] = None) -> None:
     """Load and resolve all paths from config file."""
-    global FRAMEWORK, MANIFEST_PATH, DATA_MODEL_PATH, DBT_MODEL_PATHS, CATALOG_PATH, DBT_PROJECT_PATH, CANVAS_LAYOUT_PATH, CANVAS_LAYOUT_VERSION_CONTROL, CONFIG_PATH, FRONTEND_BUILD_DIR, DBT_COMPANY_DUMMY_PATH, LINEAGE_LAYERS, GUIDANCE_CONFIG, LINEAGE_ENABLED, EXPOSURES_ENABLED, EXPOSURES_DEFAULT_LAYOUT, MODELING_STYLE, Bus_MATRIX_ENABLED, BUSINESS_EVENTS_ENABLED, BUSINESS_EVENTS_PATH, DIMENSIONAL_MODELING_CONFIG, ENTITY_MODELING_CONFIG
+    global FRAMEWORK, MANIFEST_PATH, DATA_MODEL_PATH, DBT_MODEL_PATHS, CATALOG_PATH, DBT_PROJECT_PATH, CANVAS_LAYOUT_PATH, CANVAS_LAYOUT_VERSION_CONTROL, CONFIG_PATH, FRONTEND_BUILD_DIR, DBT_COMPANY_DUMMY_PATH, LINEAGE_LAYERS, GUIDANCE_CONFIG, LINEAGE_ENABLED, EXPOSURES_ENABLED, EXPOSURES_DEFAULT_LAYOUT, MODELING_STYLE, Bus_MATRIX_ENABLED, BUSINESS_EVENTS_ENABLED, BUSINESS_EVENTS_PATH, DIMENSIONAL_MODELING_CONFIG, ENTITY_MODELING_CONFIG, BRUIN_PIPELINE_PATH, BRUIN_ASSET_PATHS
 
     # Skip loading config file in test mode (paths already set via environment)
     # unless a config file is explicitly selected (TRELLIS_CONFIG_PATH or CLI --config).
@@ -523,6 +538,13 @@ def load_config(config_path: Optional[str] = None) -> None:
     # 4. Model path filters
     if "dbt_model_paths" in config:
         DBT_MODEL_PATHS = config["dbt_model_paths"]
+
+    # 4b. Bruin pipeline path and asset paths
+    BRUIN_PIPELINE_PATH = _resolve_bruin_pipeline_path(CONFIG_PATH, config)
+    if "bruin_asset_paths" in config:
+        BRUIN_ASSET_PATHS = config["bruin_asset_paths"]
+    else:
+        BRUIN_ASSET_PATHS = None
 
     # 5. Canvas layout path
     CANVAS_LAYOUT_PATH = _resolve_canvas_layout_path(

--- a/trellis_datamodel/config.py
+++ b/trellis_datamodel/config.py
@@ -88,8 +88,6 @@ if _TEST_DIR:
     )
     DBT_PROJECT_PATH: str = _TEST_DIR
     DBT_MODEL_PATHS: list[str] = ["3_core"]
-    BRUIN_PIPELINE_PATH: Optional[str] = None
-    BRUIN_ASSET_PATHS: Optional[list[str]] = None
     FRONTEND_BUILD_DIR: str = os.path.join(_TEST_DIR, "frontend/build")
     DBT_COMPANY_DUMMY_PATH: str = os.path.join(_TEST_DIR, "dbt_company_dummy")
     LINEAGE_LAYERS: list[str] = []
@@ -114,8 +112,6 @@ else:
     CANVAS_LAYOUT_VERSION_CONTROL: bool = True
     DBT_PROJECT_PATH: str = ""
     DBT_MODEL_PATHS: list[str] = []
-    BRUIN_PIPELINE_PATH: Optional[str] = None
-    BRUIN_ASSET_PATHS: Optional[list[str]] = None
     FRONTEND_BUILD_DIR: str = ""
     DBT_COMPANY_DUMMY_PATH: str = ""
     LINEAGE_LAYERS: list[str] = []
@@ -166,17 +162,6 @@ def _resolve_project_path(config_path: str, config: dict[str, Any]) -> str:
         return ""
     base_dir = _resolve_base_path(config_path)
     return _resolve_path(base_dir, project_path)
-
-
-def _resolve_bruin_pipeline_path(
-    config_path: str, config: dict[str, Any]
-) -> Optional[str]:
-    """Resolve bruin_pipeline_path with config directory fallback."""
-    pipeline_path = config.get("bruin_pipeline_path")
-    if not pipeline_path:
-        return None
-    base_dir = _resolve_base_path(config_path)
-    return _resolve_path(base_dir, pipeline_path)
 
 
 def _resolve_manifest_path(
@@ -500,7 +485,7 @@ def find_config_file(config_override: Optional[str] = None) -> Optional[str]:
 
 def load_config(config_path: Optional[str] = None) -> None:
     """Load and resolve all paths from config file."""
-    global FRAMEWORK, MANIFEST_PATH, DATA_MODEL_PATH, DBT_MODEL_PATHS, CATALOG_PATH, DBT_PROJECT_PATH, CANVAS_LAYOUT_PATH, CANVAS_LAYOUT_VERSION_CONTROL, CONFIG_PATH, FRONTEND_BUILD_DIR, DBT_COMPANY_DUMMY_PATH, LINEAGE_LAYERS, GUIDANCE_CONFIG, LINEAGE_ENABLED, EXPOSURES_ENABLED, EXPOSURES_DEFAULT_LAYOUT, MODELING_STYLE, Bus_MATRIX_ENABLED, BUSINESS_EVENTS_ENABLED, BUSINESS_EVENTS_PATH, DIMENSIONAL_MODELING_CONFIG, ENTITY_MODELING_CONFIG, BRUIN_PIPELINE_PATH, BRUIN_ASSET_PATHS
+    global FRAMEWORK, MANIFEST_PATH, DATA_MODEL_PATH, DBT_MODEL_PATHS, CATALOG_PATH, DBT_PROJECT_PATH, CANVAS_LAYOUT_PATH, CANVAS_LAYOUT_VERSION_CONTROL, CONFIG_PATH, FRONTEND_BUILD_DIR, DBT_COMPANY_DUMMY_PATH, LINEAGE_LAYERS, GUIDANCE_CONFIG, LINEAGE_ENABLED, EXPOSURES_ENABLED, EXPOSURES_DEFAULT_LAYOUT, MODELING_STYLE, Bus_MATRIX_ENABLED, BUSINESS_EVENTS_ENABLED, BUSINESS_EVENTS_PATH, DIMENSIONAL_MODELING_CONFIG, ENTITY_MODELING_CONFIG
 
     # Skip loading config file in test mode (paths already set via environment)
     # unless a config file is explicitly selected (TRELLIS_CONFIG_PATH or CLI --config).
@@ -538,13 +523,6 @@ def load_config(config_path: Optional[str] = None) -> None:
     # 4. Model path filters
     if "dbt_model_paths" in config:
         DBT_MODEL_PATHS = config["dbt_model_paths"]
-
-    # 4b. Bruin pipeline path and asset paths
-    BRUIN_PIPELINE_PATH = _resolve_bruin_pipeline_path(CONFIG_PATH, config)
-    if "bruin_asset_paths" in config:
-        BRUIN_ASSET_PATHS = config["bruin_asset_paths"]
-    else:
-        BRUIN_ASSET_PATHS = None
 
     # 5. Canvas layout path
     CANVAS_LAYOUT_PATH = _resolve_canvas_layout_path(

--- a/trellis_datamodel/models/__init__.py
+++ b/trellis_datamodel/models/__init__.py
@@ -2,7 +2,6 @@
 
 from .schemas import (
     DataModelUpdate,
-    DbtSchemaRequest,
     ModelSchemaRequest,
 )
 from .business_event import (
@@ -19,7 +18,6 @@ from .business_event import (
 
 __all__ = [
     "DataModelUpdate",
-    "DbtSchemaRequest",
     "ModelSchemaRequest",
     "BusinessEvent",
     "BusinessEventType",

--- a/trellis_datamodel/models/entity_keys.py
+++ b/trellis_datamodel/models/entity_keys.py
@@ -1,0 +1,44 @@
+"""Generic entity-key accessors with read-compat for legacy dbt-prefixed keys.
+
+`model_ref` / `framework_tags` are the current field names in data_model.yml.
+`dbt_model` / `dbt_tags` are read for backward compatibility with files written
+before this generalization; only the new names are ever written.
+
+Lookup is presence-based, not truthiness-based: if the new key is present at all,
+it wins, even when its value is None or []. An explicitly cleared binding must not
+fall back to a stale legacy value.
+"""
+from typing import Any, Optional
+
+MODEL_REF_KEY = "model_ref"
+LEGACY_MODEL_REF_KEY = "dbt_model"
+FRAMEWORK_TAGS_KEY = "framework_tags"
+LEGACY_FRAMEWORK_TAGS_KEY = "dbt_tags"
+
+
+def get_model_ref(entity: dict[str, Any]) -> Optional[str]:
+    if MODEL_REF_KEY in entity:
+        return entity[MODEL_REF_KEY] or None
+    return entity.get(LEGACY_MODEL_REF_KEY) or None
+
+
+def set_model_ref(entity: dict[str, Any], value: Optional[str]) -> None:
+    entity.pop(LEGACY_MODEL_REF_KEY, None)
+    entity.pop(MODEL_REF_KEY, None)
+    if value:
+        entity[MODEL_REF_KEY] = value
+
+
+def get_framework_tags(entity: dict[str, Any]) -> list[str]:
+    if FRAMEWORK_TAGS_KEY in entity:
+        return list(entity[FRAMEWORK_TAGS_KEY] or [])
+    return list(entity.get(LEGACY_FRAMEWORK_TAGS_KEY) or [])
+
+
+def set_framework_tags(entity: dict[str, Any], tags: list[str]) -> None:
+    entity.pop(LEGACY_FRAMEWORK_TAGS_KEY, None)
+    entity[FRAMEWORK_TAGS_KEY] = list(tags)
+
+
+def has_legacy_keys(entity: dict[str, Any]) -> bool:
+    return LEGACY_MODEL_REF_KEY in entity or LEGACY_FRAMEWORK_TAGS_KEY in entity

--- a/trellis_datamodel/models/entity_keys.py
+++ b/trellis_datamodel/models/entity_keys.py
@@ -1,8 +1,15 @@
 """Generic entity-key accessors with read-compat for legacy dbt-prefixed keys.
 
-`model_ref` / `framework_tags` are the current field names in data_model.yml.
-`dbt_model` / `dbt_tags` are read for backward compatibility with files written
-before this generalization; only the new names are ever written.
+`model_ref` / `framework_tags` / `physical_datatype` are the current field names
+in data_model.yml. `dbt_model` / `dbt_tags` / `dbt_data_type` are read for
+backward compatibility with files written before this generalization; only the
+new names are ever written.
+
+`physical_datatype` pairs with a column's `datatype`: `datatype` is Trellis's
+logical bucket (a closed set — text, int, float, bool, date, timestamp, unknown),
+while `physical_datatype` is the concrete type the framework's catalog reports
+for that column (varchar, timestamp, numeric(38,0)). Keeping both means a push
+writes back the precise type rather than downgrading it to the bucket.
 
 Lookup is presence-based, not truthiness-based: if the new key is present at all,
 it wins, even when its value is None or []. An explicitly cleared binding must not
@@ -14,8 +21,8 @@ MODEL_REF_KEY = "model_ref"
 LEGACY_MODEL_REF_KEY = "dbt_model"
 FRAMEWORK_TAGS_KEY = "framework_tags"
 LEGACY_FRAMEWORK_TAGS_KEY = "dbt_tags"
-NATIVE_DATA_TYPE_KEY = "native_data_type"
-LEGACY_NATIVE_DATA_TYPE_KEY = "dbt_data_type"
+PHYSICAL_DATATYPE_KEY = "physical_datatype"
+LEGACY_PHYSICAL_DATATYPE_KEY = "dbt_data_type"
 
 
 def get_model_ref(entity: dict[str, Any]) -> Optional[str]:
@@ -46,15 +53,18 @@ def has_legacy_keys(entity: dict[str, Any]) -> bool:
     return LEGACY_MODEL_REF_KEY in entity or LEGACY_FRAMEWORK_TAGS_KEY in entity
 
 
-def get_native_data_type(field: dict[str, Any]) -> Optional[str]:
-    """Read a drafted field's raw adapter/warehouse type, new key first."""
-    if NATIVE_DATA_TYPE_KEY in field:
-        return field[NATIVE_DATA_TYPE_KEY] or None
-    return field.get(LEGACY_NATIVE_DATA_TYPE_KEY) or None
+def get_physical_datatype(field: dict[str, Any]) -> Optional[str]:
+    """Read a field's concrete framework/warehouse type, new key first.
+
+    Contrast with the field's `datatype`, which is the coarse logical bucket.
+    """
+    if PHYSICAL_DATATYPE_KEY in field:
+        return field[PHYSICAL_DATATYPE_KEY] or None
+    return field.get(LEGACY_PHYSICAL_DATATYPE_KEY) or None
 
 
-def set_native_data_type(field: dict[str, Any], value: Optional[str]) -> None:
-    field.pop(LEGACY_NATIVE_DATA_TYPE_KEY, None)
-    field.pop(NATIVE_DATA_TYPE_KEY, None)
+def set_physical_datatype(field: dict[str, Any], value: Optional[str]) -> None:
+    field.pop(LEGACY_PHYSICAL_DATATYPE_KEY, None)
+    field.pop(PHYSICAL_DATATYPE_KEY, None)
     if value:
-        field[NATIVE_DATA_TYPE_KEY] = value
+        field[PHYSICAL_DATATYPE_KEY] = value

--- a/trellis_datamodel/models/entity_keys.py
+++ b/trellis_datamodel/models/entity_keys.py
@@ -14,6 +14,8 @@ MODEL_REF_KEY = "model_ref"
 LEGACY_MODEL_REF_KEY = "dbt_model"
 FRAMEWORK_TAGS_KEY = "framework_tags"
 LEGACY_FRAMEWORK_TAGS_KEY = "dbt_tags"
+NATIVE_DATA_TYPE_KEY = "native_data_type"
+LEGACY_NATIVE_DATA_TYPE_KEY = "dbt_data_type"
 
 
 def get_model_ref(entity: dict[str, Any]) -> Optional[str]:
@@ -42,3 +44,17 @@ def set_framework_tags(entity: dict[str, Any], tags: list[str]) -> None:
 
 def has_legacy_keys(entity: dict[str, Any]) -> bool:
     return LEGACY_MODEL_REF_KEY in entity or LEGACY_FRAMEWORK_TAGS_KEY in entity
+
+
+def get_native_data_type(field: dict[str, Any]) -> Optional[str]:
+    """Read a drafted field's raw adapter/warehouse type, new key first."""
+    if NATIVE_DATA_TYPE_KEY in field:
+        return field[NATIVE_DATA_TYPE_KEY] or None
+    return field.get(LEGACY_NATIVE_DATA_TYPE_KEY) or None
+
+
+def set_native_data_type(field: dict[str, Any], value: Optional[str]) -> None:
+    field.pop(LEGACY_NATIVE_DATA_TYPE_KEY, None)
+    field.pop(NATIVE_DATA_TYPE_KEY, None)
+    if value:
+        field[NATIVE_DATA_TYPE_KEY] = value

--- a/trellis_datamodel/models/schemas.py
+++ b/trellis_datamodel/models/schemas.py
@@ -8,6 +8,7 @@ from enum import Enum
 class FrameworkEnum(str, Enum):
     """Framework options."""
     DBT_CORE = "dbt-core"
+    BRUIN = "bruin"
 
 
 class ModelingStyleEnum(str, Enum):

--- a/trellis_datamodel/models/schemas.py
+++ b/trellis_datamodel/models/schemas.py
@@ -8,7 +8,6 @@ from enum import Enum
 class FrameworkEnum(str, Enum):
     """Framework options."""
     DBT_CORE = "dbt-core"
-    BRUIN = "bruin"
 
 
 class ModelingStyleEnum(str, Enum):
@@ -82,8 +81,6 @@ class ConfigSchema(BaseModel):
     data_model_file: str = Field(default="data_model.yml", description="Path to data model file")
     dbt_model_paths: List[str] = Field(default_factory=list, description="Path patterns to filter models")
     dbt_company_dummy_path: Optional[str] = Field(default=None, description="Optional path to company dummy project")
-    bruin_pipeline_path: Optional[str] = Field(default=None, description="Path to Bruin pipeline directory")
-    bruin_asset_paths: Optional[List[str]] = Field(default=None, description="Path patterns to filter Bruin assets")
     lineage: LineageConfig = Field(default_factory=LineageConfig)
     entity_creation_guidance: EntityCreationGuidance = Field(default_factory=EntityCreationGuidance)
     exposures: ExposuresConfig = Field(default_factory=ExposuresConfig)

--- a/trellis_datamodel/models/schemas.py
+++ b/trellis_datamodel/models/schemas.py
@@ -101,18 +101,19 @@ class DataModelUpdate(BaseModel):
     source_colors: Optional[Dict[str, str]] = None  # Map of source name to color from canvas_layout.yml
 
 
-class DbtSchemaRequest(BaseModel):
-    """Schema for creating a new dbt schema file."""
-    entity_id: str
-    model_name: str
-    fields: List[Dict[str, Any]]
-    description: Optional[str] = None
-    tags: Optional[List[str]] = None
-
-
 class ModelSchemaRequest(BaseModel):
-    """Schema for updating model columns and metadata."""
-    columns: List[Dict[str, Any]]
+    """Schema for creating/updating a model's schema file.
+
+    Supports two call shapes used by the schema routes:
+    - POST /api/schema: entity_id + model_name + fields (resolves the model
+      binding from entity_id and writes the given fields as columns).
+    - POST /api/models/{model_name}/schema: columns (+ optional version),
+      updating an already-identified model's schema in place.
+    """
+    entity_id: Optional[str] = None
+    model_name: Optional[str] = None
+    fields: Optional[List[Dict[str, Any]]] = None
+    columns: Optional[List[Dict[str, Any]]] = None
     description: Optional[str] = None
     tags: Optional[List[str]] = None
     version: Optional[int] = None

--- a/trellis_datamodel/models/schemas.py
+++ b/trellis_datamodel/models/schemas.py
@@ -82,6 +82,8 @@ class ConfigSchema(BaseModel):
     data_model_file: str = Field(default="data_model.yml", description="Path to data model file")
     dbt_model_paths: List[str] = Field(default_factory=list, description="Path patterns to filter models")
     dbt_company_dummy_path: Optional[str] = Field(default=None, description="Optional path to company dummy project")
+    bruin_pipeline_path: Optional[str] = Field(default=None, description="Path to Bruin pipeline directory")
+    bruin_asset_paths: Optional[List[str]] = Field(default=None, description="Path patterns to filter Bruin assets")
     lineage: LineageConfig = Field(default_factory=LineageConfig)
     entity_creation_guidance: EntityCreationGuidance = Field(default_factory=EntityCreationGuidance)
     exposures: ExposuresConfig = Field(default_factory=ExposuresConfig)

--- a/trellis_datamodel/routes/config.py
+++ b/trellis_datamodel/routes/config.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, Optional
 from fastapi import APIRouter, HTTPException, Query
 
 from trellis_datamodel import __version__ as trellis_version
+from trellis_datamodel.adapters import get_adapter
 from trellis_datamodel.config import find_config_file, reload_config
 from trellis_datamodel.exceptions import ConfigurationError, ValidationError
 from trellis_datamodel.models.schemas import (
@@ -215,8 +216,7 @@ async def reload_config_endpoint() -> Dict[str, Any]:
         reload_config()
 
         # Clear adapter caches that depend on config
-        from trellis_datamodel.adapters.dbt_core import DbtCoreAdapter
-        DbtCoreAdapter.reset_inference_cache()
+        get_adapter().reset_inference_cache()
 
         logger.info("Configuration reloaded successfully via API")
         return {

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -18,7 +18,9 @@ from trellis_datamodel.models.entity_keys import (
     FRAMEWORK_TAGS_KEY,
     LEGACY_FRAMEWORK_TAGS_KEY,
     get_model_ref,
+    set_model_ref,
     get_framework_tags,
+    set_framework_tags,
 )
 
 router = APIRouter(prefix="/api", tags=["data-model"])
@@ -293,15 +295,15 @@ async def get_data_model():
         # For unbound entities: read from persisted YAML
         entities = merged_data.get("entities", [])
         for entity in entities:
-            dbt_model = entity.get("dbt_model")
+            model_ref = get_model_ref(entity)
             additional_models = entity.get("additional_models", [])
 
             # `tags` for display/export is computed here, never persisted:
-            # the union of dbt_tags + ui_tags for bound entities, or the
+            # the union of framework_tags + ui_tags for bound entities, or the
             # entity's own `tags` field for unbound entities.
             entity["tags"] = compute_display_tags(entity)
 
-            if dbt_model:
+            if model_ref:
                 # Bound entity: extract source systems from lineage
                 # Extract for primary model
                 source_systems = set()
@@ -314,7 +316,7 @@ async def get_data_model():
                                 if cfg.CATALOG_PATH and os.path.exists(cfg.CATALOG_PATH)
                                 else None
                             ),
-                            dbt_model,
+                            model_ref,
                         )
                         source_systems.update(primary_sources)
                 except Exception:
@@ -383,17 +385,22 @@ def _split_model_and_layout(
             if existing_entity_id and "roles" in existing_entity:
                 existing_roles_by_id[existing_entity_id] = existing_entity.get("roles")
 
-    # Preserve a bound entity's reconcile-owned `dbt_tags` when auto-save
-    # omits it. `dbt_tags` mirrors schema.yml and is never intentionally
+    # Preserve a bound entity's reconcile-owned `framework_tags` when auto-save
+    # omits it. `framework_tags` mirrors schema.yml and is never intentionally
     # sent by auto-save.ts for bound entities (only ui_tags is) — omission
     # here must not be read as "clear it", unlike unbound entities where
     # `tags` is freely editable and an omission does mean the user cleared it.
-    existing_dbt_tags_by_id: Dict[str, Any] = {}
+    existing_framework_tags_by_id: Dict[str, Any] = {}
     if existing_model_data:
         for existing_entity in existing_model_data.get("entities", []):
             existing_entity_id = existing_entity.get("id")
-            if existing_entity_id and "dbt_tags" in existing_entity:
-                existing_dbt_tags_by_id[existing_entity_id] = existing_entity.get("dbt_tags")
+            if existing_entity_id and (
+                FRAMEWORK_TAGS_KEY in existing_entity
+                or LEGACY_FRAMEWORK_TAGS_KEY in existing_entity
+            ):
+                existing_framework_tags_by_id[existing_entity_id] = get_framework_tags(
+                    existing_entity
+                )
 
     # Split entities
     entities = content.get("entities", [])
@@ -414,8 +421,8 @@ def _split_model_and_layout(
         }
         if "description" in entity:
             model_entity["description"] = entity["description"]
-        if "dbt_model" in entity:
-            model_entity["dbt_model"] = entity["dbt_model"]
+        if MODEL_REF_KEY in entity or LEGACY_MODEL_REF_KEY in entity:
+            set_model_ref(model_entity, get_model_ref(entity))
         if "additional_models" in entity:
             model_entity["additional_models"] = entity["additional_models"]
         if "drafted_fields" in entity:
@@ -427,13 +434,13 @@ def _split_model_and_layout(
             model_entity["drafted_fields"] = drafted_fields
         # `tags` is only a persisted field for unbound entities (their single,
         # freely-editable tag list). Bound entities never persist `tags` —
-        # only `dbt_tags` (reconcile-owned) and `ui_tags` (user-added).
-        if "tags" in entity and not entity.get("dbt_model"):
+        # only `framework_tags` (reconcile-owned) and `ui_tags` (user-added).
+        if "tags" in entity and not get_model_ref(entity):
             model_entity["tags"] = entity["tags"]
-        if "dbt_tags" in entity:
-            model_entity["dbt_tags"] = entity["dbt_tags"]
-        elif entity.get("dbt_model") and entity_id in existing_dbt_tags_by_id:
-            model_entity["dbt_tags"] = existing_dbt_tags_by_id[entity_id]
+        if FRAMEWORK_TAGS_KEY in entity or LEGACY_FRAMEWORK_TAGS_KEY in entity:
+            set_framework_tags(model_entity, get_framework_tags(entity))
+        elif get_model_ref(entity) and entity_id in existing_framework_tags_by_id:
+            set_framework_tags(model_entity, existing_framework_tags_by_id[entity_id])
         if "ui_tags" in entity:
             model_entity["ui_tags"] = entity["ui_tags"]
         if "domain" in entity:
@@ -460,7 +467,7 @@ def _split_model_and_layout(
             # Incoming payload omitted the roles field entirely — preserve existing
             model_entity["roles"] = existing_roles_by_id[entity_id]
         # Only persist source_system for unbound entities (not for bound entities)
-        if "source_system" in entity and not entity.get("dbt_model"):
+        if "source_system" in entity and not get_model_ref(entity):
             model_entity["source_system"] = entity["source_system"]
 
         model_data["entities"].append(model_entity)
@@ -543,7 +550,7 @@ async def get_source_system_suggestions():
             entities = model_data.get("entities", [])
             for entity in entities:
                 # Only collect from unbound entities (mock sources)
-                if not entity.get("dbt_model") and entity.get("source_system"):
+                if not get_model_ref(entity) and entity.get("source_system"):
                     source_systems = entity.get("source_system", [])
                     if isinstance(source_systems, list):
                         for source in source_systems:
@@ -561,10 +568,10 @@ async def get_source_system_suggestions():
 
             entities = model_data.get("entities", [])
             for entity in entities:
-                dbt_model = entity.get("dbt_model")
+                model_ref = get_model_ref(entity)
                 additional_models = entity.get("additional_models", [])
 
-                if dbt_model:
+                if model_ref:
                     # Extract from primary model
                     try:
                         sources = extract_source_systems_for_model(
@@ -574,7 +581,7 @@ async def get_source_system_suggestions():
                                 if cfg.CATALOG_PATH and os.path.exists(cfg.CATALOG_PATH)
                                 else None
                             ),
-                            dbt_model,
+                            model_ref,
                         )
                         suggestions.update(sources)
                     except Exception:

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -12,8 +12,51 @@ from trellis_datamodel.services.reconciliation import compute_display_tags
 from trellis_datamodel.adapters import get_adapter
 from trellis_datamodel.utils.yaml_handler import YamlHandler
 from trellis_datamodel.utils.origin import parse_origin
+from trellis_datamodel.models.entity_keys import (
+    MODEL_REF_KEY,
+    LEGACY_MODEL_REF_KEY,
+    FRAMEWORK_TAGS_KEY,
+    LEGACY_FRAMEWORK_TAGS_KEY,
+    get_model_ref,
+    get_framework_tags,
+)
 
 router = APIRouter(prefix="/api", tags=["data-model"])
+
+
+# TODO(sprint-6): remove once frontend reads model_ref
+def _add_legacy_key_aliases(data_model: Dict[str, Any]) -> Dict[str, Any]:
+    """Decorate outgoing entity dicts with legacy dbt_model/dbt_tags aliases.
+
+    This is a serialization-only shim: it operates on copies of the entity
+    dicts and must never mutate (or cause persistence of) the dicts that get
+    saved to disk. It exists so the frontend, which still reads
+    `dbt_model`/`dbt_tags`, keeps resolving bindings while backend code
+    migrates to the generic `model_ref`/`framework_tags` keys.
+    """
+    entities = data_model.get("entities")
+    if not entities:
+        return data_model
+
+    aliased_entities = []
+    for entity in entities:
+        aliased_entity = dict(entity)
+
+        model_ref = get_model_ref(aliased_entity)
+        if model_ref is not None:
+            aliased_entity[MODEL_REF_KEY] = model_ref
+            aliased_entity[LEGACY_MODEL_REF_KEY] = model_ref
+
+        if FRAMEWORK_TAGS_KEY in aliased_entity or LEGACY_FRAMEWORK_TAGS_KEY in aliased_entity:
+            framework_tags = get_framework_tags(aliased_entity)
+            aliased_entity[FRAMEWORK_TAGS_KEY] = framework_tags
+            aliased_entity[LEGACY_FRAMEWORK_TAGS_KEY] = framework_tags
+
+        aliased_entities.append(aliased_entity)
+
+    result = dict(data_model)
+    result["entities"] = aliased_entities
+    return result
 
 
 def _normalize_field_origin(field: Dict[str, Any]) -> None:
@@ -307,7 +350,7 @@ async def get_data_model():
                     pass
                 # If not present, entity won't have source_system field (optional)
 
-        return merged_data
+        return _add_legacy_key_aliases(merged_data)
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Error reading data model: {str(e)}"

--- a/trellis_datamodel/routes/data_model.py
+++ b/trellis_datamodel/routes/data_model.py
@@ -26,41 +26,6 @@ from trellis_datamodel.models.entity_keys import (
 router = APIRouter(prefix="/api", tags=["data-model"])
 
 
-# TODO(sprint-6): remove once frontend reads model_ref
-def _add_legacy_key_aliases(data_model: Dict[str, Any]) -> Dict[str, Any]:
-    """Decorate outgoing entity dicts with legacy dbt_model/dbt_tags aliases.
-
-    This is a serialization-only shim: it operates on copies of the entity
-    dicts and must never mutate (or cause persistence of) the dicts that get
-    saved to disk. It exists so the frontend, which still reads
-    `dbt_model`/`dbt_tags`, keeps resolving bindings while backend code
-    migrates to the generic `model_ref`/`framework_tags` keys.
-    """
-    entities = data_model.get("entities")
-    if not entities:
-        return data_model
-
-    aliased_entities = []
-    for entity in entities:
-        aliased_entity = dict(entity)
-
-        model_ref = get_model_ref(aliased_entity)
-        if model_ref is not None:
-            aliased_entity[MODEL_REF_KEY] = model_ref
-            aliased_entity[LEGACY_MODEL_REF_KEY] = model_ref
-
-        if FRAMEWORK_TAGS_KEY in aliased_entity or LEGACY_FRAMEWORK_TAGS_KEY in aliased_entity:
-            framework_tags = get_framework_tags(aliased_entity)
-            aliased_entity[FRAMEWORK_TAGS_KEY] = framework_tags
-            aliased_entity[LEGACY_FRAMEWORK_TAGS_KEY] = framework_tags
-
-        aliased_entities.append(aliased_entity)
-
-    result = dict(data_model)
-    result["entities"] = aliased_entities
-    return result
-
-
 def _normalize_field_origin(field: Dict[str, Any]) -> None:
     origin = parse_origin(field.get("origin"))
     if origin:
@@ -352,7 +317,7 @@ async def get_data_model():
                     pass
                 # If not present, entity won't have source_system field (optional)
 
-        return _add_legacy_key_aliases(merged_data)
+        return merged_data
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Error reading data model: {str(e)}"

--- a/trellis_datamodel/routes/manifest.py
+++ b/trellis_datamodel/routes/manifest.py
@@ -84,7 +84,7 @@ async def get_config_info():
 
     adapter = get_adapter()
     try:
-        model_dirs = adapter.get_model_dirs()  # type: ignore[attr-defined]
+        model_dirs = adapter.get_model_dirs()
     except Exception:
         model_dirs = []
 

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/api", tags=["reconciliation"])
 
 
 @router.post("/reconcile")
-async def reconcile_dbt_endpoint():
+async def reconcile_framework_endpoint():
     """Reconcile dbt manifest columns into data_model.yml with provenance tags.
 
     Reads the current manifest, merges materialized columns (source='dbt')

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -8,7 +8,8 @@ from trellis_datamodel.routes.data_model import _add_legacy_key_aliases
 router = APIRouter(prefix="/api", tags=["reconciliation"])
 
 
-@router.post("/reconcile-dbt")
+@router.post("/reconcile")
+@router.post("/reconcile-dbt", include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def reconcile_dbt_endpoint():
     """Reconcile dbt manifest columns into data_model.yml with provenance tags.
 

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -3,13 +3,11 @@
 from fastapi import APIRouter
 
 from trellis_datamodel.services.reconciliation import reconcile_framework
-from trellis_datamodel.routes.data_model import _add_legacy_key_aliases
 
 router = APIRouter(prefix="/api", tags=["reconciliation"])
 
 
 @router.post("/reconcile")
-@router.post("/reconcile-dbt", include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def reconcile_dbt_endpoint():
     """Reconcile dbt manifest columns into data_model.yml with provenance tags.
 
@@ -22,5 +20,5 @@ async def reconcile_dbt_endpoint():
     return {
         "status": "success",
         "changed": changed,
-        "data_model": _add_legacy_key_aliases(data_model),
+        "data_model": data_model,
     }

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from trellis_datamodel.services.reconciliation import reconcile_dbt
+from trellis_datamodel.services.reconciliation import reconcile_framework
 from trellis_datamodel.routes.data_model import _add_legacy_key_aliases
 
 router = APIRouter(prefix="/api", tags=["reconciliation"])
@@ -17,7 +17,7 @@ async def reconcile_dbt_endpoint():
     Non-destructive: entities whose model is absent from the manifest are
     left untouched (handles partial dbt compiles).
     """
-    data_model, changed = reconcile_dbt()
+    data_model, changed = reconcile_framework()
     return {
         "status": "success",
         "changed": changed,

--- a/trellis_datamodel/routes/reconcile.py
+++ b/trellis_datamodel/routes/reconcile.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from trellis_datamodel.services.reconciliation import reconcile_dbt
+from trellis_datamodel.routes.data_model import _add_legacy_key_aliases
 
 router = APIRouter(prefix="/api", tags=["reconciliation"])
 
@@ -17,4 +18,8 @@ async def reconcile_dbt_endpoint():
     left untouched (handles partial dbt compiles).
     """
     data_model, changed = reconcile_dbt()
-    return {"status": "success", "changed": changed, "data_model": data_model}
+    return {
+        "status": "success",
+        "changed": changed,
+        "data_model": _add_legacy_key_aliases(data_model),
+    }

--- a/trellis_datamodel/routes/schema.py
+++ b/trellis_datamodel/routes/schema.py
@@ -22,7 +22,6 @@ router = APIRouter(prefix="/api", tags=["schema"])
 
 
 @router.post("/schema", response_model=FileOperationResponse)
-@router.post("/dbt-schema", response_model=FileOperationResponse, include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
     """Generate and save a schema YAML file for the drafted fields."""
     output_path = save_model_schema_from_request(
@@ -40,7 +39,6 @@ async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
 
 
 @router.post("/sync-tests", response_model=SyncTestsResponse)
-@router.post("/sync-dbt-tests", response_model=SyncTestsResponse, include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def sync_dbt_tests_endpoint():
     """Sync relationship tests from data model to schema files."""
     updated_files = sync_framework_tests()

--- a/trellis_datamodel/routes/schema.py
+++ b/trellis_datamodel/routes/schema.py
@@ -21,7 +21,8 @@ from trellis_datamodel.services.schema import (
 router = APIRouter(prefix="/api", tags=["schema"])
 
 
-@router.post("/dbt-schema", response_model=FileOperationResponse)
+@router.post("/schema", response_model=FileOperationResponse)
+@router.post("/dbt-schema", response_model=FileOperationResponse, include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
     """Generate and save a schema YAML file for the drafted fields."""
     output_path = save_model_schema_from_request(
@@ -38,7 +39,8 @@ async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
     )
 
 
-@router.post("/sync-dbt-tests", response_model=SyncTestsResponse)
+@router.post("/sync-tests", response_model=SyncTestsResponse)
+@router.post("/sync-dbt-tests", response_model=SyncTestsResponse, include_in_schema=False)  # TODO(sprint-6): remove after frontend migration
 async def sync_dbt_tests_endpoint():
     """Sync relationship tests from data model to schema files."""
     updated_files = sync_framework_tests()

--- a/trellis_datamodel/routes/schema.py
+++ b/trellis_datamodel/routes/schema.py
@@ -13,8 +13,8 @@ from trellis_datamodel.models.schemas import (
 from trellis_datamodel.services.schema import (
     get_model_schema,
     infer_relationships,
-    save_dbt_schema,
-    sync_dbt_tests,
+    save_model_schema_from_request,
+    sync_framework_tests,
     update_model_schema,
 )
 
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/api", tags=["schema"])
 @router.post("/dbt-schema", response_model=FileOperationResponse)
 async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
     """Generate and save a schema YAML file for the drafted fields."""
-    output_path = save_dbt_schema(
+    output_path = save_model_schema_from_request(
         entity_id=request.entity_id,
         model_name=request.model_name,
         fields=request.fields,
@@ -41,7 +41,7 @@ async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
 @router.post("/sync-dbt-tests", response_model=SyncTestsResponse)
 async def sync_dbt_tests_endpoint():
     """Sync relationship tests from data model to schema files."""
-    updated_files = sync_dbt_tests()
+    updated_files = sync_framework_tests()
 
     return SyncTestsResponse(
         message=f"Updated {len(updated_files)} file(s)",

--- a/trellis_datamodel/routes/schema.py
+++ b/trellis_datamodel/routes/schema.py
@@ -3,7 +3,6 @@
 from fastapi import APIRouter
 
 from trellis_datamodel.models.schemas import (
-    DbtSchemaRequest,
     FileOperationResponse,
     ModelSchemaRequest,
     ModelSchemaResponse,
@@ -22,7 +21,7 @@ router = APIRouter(prefix="/api", tags=["schema"])
 
 
 @router.post("/schema", response_model=FileOperationResponse)
-async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
+async def save_model_schema_endpoint(request: ModelSchemaRequest):
     """Generate and save a schema YAML file for the drafted fields."""
     output_path = save_model_schema_from_request(
         entity_id=request.entity_id,
@@ -39,7 +38,7 @@ async def save_dbt_schema_endpoint(request: DbtSchemaRequest):
 
 
 @router.post("/sync-tests", response_model=SyncTestsResponse)
-async def sync_dbt_tests_endpoint():
+async def sync_framework_tests_endpoint():
     """Sync relationship tests from data model to schema files."""
     updated_files = sync_framework_tests()
 

--- a/trellis_datamodel/services/bus_matrix.py
+++ b/trellis_datamodel/services/bus_matrix.py
@@ -71,8 +71,8 @@ def get_bus_matrix(
     facts = [e for e in entities if e.get("entity_type") == "fact"]
 
     # `tags` for display/filtering is computed here, never persisted: the
-    # union of dbt_tags + ui_tags for bound entities, or the entity's own
-    # `tags` field for unbound entities.
+    # union of framework_tags + ui_tags for bound entities, or the entity's
+    # own `tags` field for unbound entities.
     for d in dimensions:
         d["tags"] = compute_display_tags(d)
     for f in facts:

--- a/trellis_datamodel/services/exposures.py
+++ b/trellis_datamodel/services/exposures.py
@@ -22,6 +22,7 @@ import yaml
 
 from trellis_datamodel import config as cfg
 from trellis_datamodel.exceptions import FeatureDisabledError
+from trellis_datamodel.models.entity_keys import get_model_ref
 
 
 def _parse_ref(ref_value: str) -> tuple[str, str | None]:
@@ -98,7 +99,7 @@ def _find_entities_for_model(unique_id: str, data_model: dict[str, Any]) -> list
     """
     Find all entity IDs that are bound to the given model unique_id.
 
-    Checks both dbt_model and additional_models fields.
+    Checks both the bound model reference and additional_models fields.
     """
     entity_ids = []
     entities = data_model.get("entities", [])
@@ -107,8 +108,8 @@ def _find_entities_for_model(unique_id: str, data_model: dict[str, Any]) -> list
         if not entity_id:
             continue
 
-        # Check primary dbt_model
-        if entity.get("dbt_model") == unique_id:
+        # Check primary model binding
+        if get_model_ref(entity) == unique_id:
             entity_ids.append(entity_id)
             continue
 

--- a/trellis_datamodel/services/lineage.py
+++ b/trellis_datamodel/services/lineage.py
@@ -1,8 +1,10 @@
 """
 Lineage extraction service.
 
-Extracts table-level upstream lineage from dbt manifest.json and catalog.json files.
-Uses native manifest parsing (primary) with optional dbt-colibri support.
+Extracts table-level upstream lineage from the active framework's manifest.json
+and catalog.json files (currently dbt-core only; other frameworks may add
+support later). Uses native manifest parsing (primary) with optional
+dbt-colibri support.
 """
 
 import json

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -68,11 +68,11 @@ def _parse_description_with_origin(
     return raw_description, None
 
 
-def _map_dbt_type(dbt_type: str | None) -> str:
-    """Map a dbt/warehouse column type string to a DraftedField datatype enum value."""
-    if not dbt_type:
+def _map_column_type(column_type: str | None) -> str:
+    """Map a framework/warehouse column type string to a DraftedField datatype enum value."""
+    if not column_type:
         return "unknown"
-    t = dbt_type.lower().strip()
+    t = column_type.lower().strip()
     if t in _DATE_EXACT:
         return "date"
     for prefix in _TIMESTAMP_PREFIXES:
@@ -139,7 +139,7 @@ def reconcile_entity_fields(
 
         # dbt is authoritative for these attributes
         field["name"] = col_name
-        field["datatype"] = _map_dbt_type(col.get("type"))
+        field["datatype"] = _map_column_type(col.get("type"))
         field["source"] = "dbt"
         raw_type = col.get("type")
         if raw_type:
@@ -294,7 +294,7 @@ def reconcile_data_model(
 # IO wrapper
 # ---------------------------------------------------------------------------
 
-def reconcile_dbt() -> tuple[dict[str, Any], bool]:
+def reconcile_framework() -> tuple[dict[str, Any], bool]:
     """
     Load manifest + data_model.yml, reconcile, write back if changed.
 

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -22,7 +22,7 @@ from trellis_datamodel.models.entity_keys import (
     get_model_ref,
     set_framework_tags,
     set_model_ref,
-    set_native_data_type,
+    set_physical_datatype,
 )
 
 
@@ -145,7 +145,7 @@ def reconcile_entity_fields(
         # Preserve the exact warehouse/adapter type (e.g. "varchar") alongside
         # the coarse UI bucket above, so pushing back to the adapter doesn't
         # downgrade a precise type to the bucket's generic default (#111).
-        set_native_data_type(field, col.get("type"))
+        set_physical_datatype(field, col.get("type"))
         desc = col.get("description")
         if desc is not None:
             # Parse origin from description if embedded

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -22,6 +22,7 @@ from trellis_datamodel.models.entity_keys import (
     get_model_ref,
     set_framework_tags,
     set_model_ref,
+    set_native_data_type,
 )
 
 
@@ -141,14 +142,10 @@ def reconcile_entity_fields(
         field["name"] = col_name
         field["datatype"] = _map_column_type(col.get("type"))
         field["source"] = "dbt"
-        raw_type = col.get("type")
-        if raw_type:
-            # Preserve the exact warehouse/dbt type (e.g. "varchar") alongside
-            # the coarse UI bucket above, so pushing back to dbt doesn't
-            # downgrade a precise type to the bucket's generic default (#111).
-            field["dbt_data_type"] = raw_type
-        elif "dbt_data_type" in field:
-            del field["dbt_data_type"]
+        # Preserve the exact warehouse/adapter type (e.g. "varchar") alongside
+        # the coarse UI bucket above, so pushing back to the adapter doesn't
+        # downgrade a precise type to the bucket's generic default (#111).
+        set_native_data_type(field, col.get("type"))
         desc = col.get("description")
         if desc is not None:
             # Parse origin from description if embedded

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -1,7 +1,8 @@
 """
-Provenance-aware reconciliation of dbt manifest columns into data_model.yml.
+Provenance-aware reconciliation of framework manifest columns into data_model.yml.
 
-Governing rule: when Trellis and dbt disagree, dbt is right.
+Governing rule: the active framework's materialized model wins over a
+drafted concept.
 - manifest_columns=None means the model is absent from a (possibly partial)
   manifest — the non-destructive invariant applies: existing fields untouched.
 - Reconciliation is idempotent: reconciling an already-reconciled model
@@ -15,6 +16,13 @@ import os
 from typing import Any
 
 import yaml
+
+from trellis_datamodel.models.entity_keys import (
+    get_framework_tags,
+    get_model_ref,
+    set_framework_tags,
+    set_model_ref,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +177,7 @@ def reconcile_entity_tags(
     existing_tags: list[str],
     manifest_tags: list[str] | None,
 ) -> list[str]:
-    """dbt is authoritative for the mirrored `dbt_tags` field.
+    """The active framework is authoritative for the mirrored `framework_tags` field.
     manifest_tags=None -> model absent from manifest, non-destructive (unchanged).
     manifest_tags=[] (present, no tags) -> mirrored tags cleared.
     """
@@ -181,17 +189,18 @@ def reconcile_entity_tags(
 def compute_display_tags(entity: dict[str, Any]) -> list[str]:
     """The tag list to show/export for an entity — never persisted.
 
-    Bound entities: the union of `dbt_tags` (dbt-owned, reconcile-refreshed)
-    and `ui_tags` (user-added via the Trellis tag editor), deduplicated,
-    dbt_tags first. Unbound entities have no schema.yml to mirror — `tags`
-    is their single, freely-editable, already-authoritative field.
+    Bound entities: the union of `framework_tags` (framework-owned,
+    reconcile-refreshed) and `ui_tags` (user-added via the Trellis tag
+    editor), deduplicated, framework_tags first. Unbound entities have no
+    schema.yml to mirror — `tags` is their single, freely-editable,
+    already-authoritative field.
     """
-    if entity.get("dbt_model"):
-        dbt_tags = entity.get("dbt_tags") or []
+    if get_model_ref(entity):
+        framework_tags = get_framework_tags(entity)
         ui_tags = entity.get("ui_tags") or []
         seen: set[str] = set()
         result: list[str] = []
-        for tag in [*dbt_tags, *ui_tags]:
+        for tag in [*framework_tags, *ui_tags]:
             if tag not in seen:
                 seen.add(tag)
                 result.append(tag)
@@ -228,13 +237,13 @@ def reconcile_data_model(
     changed = False
 
     for entity in result.get("entities", []):
-        dbt_model = entity.get("dbt_model")
-        if not dbt_model:
+        model_ref = get_model_ref(entity)
+        if not model_ref:
             continue  # unbound — untouched
 
         # None signals model absent from manifest (non-destructive)
-        manifest_columns = manifest_by_id.get(dbt_model, None)
-        if dbt_model not in manifest_by_id:
+        manifest_columns = manifest_by_id.get(model_ref, None)
+        if model_ref not in manifest_by_id:
             manifest_columns = None
 
         existing = entity.get("drafted_fields") or []
@@ -244,34 +253,39 @@ def reconcile_data_model(
             entity["drafted_fields"] = reconciled
             changed = True
 
-        manifest_tags = manifest_tags_by_id.get(dbt_model) if dbt_model in manifest_by_id else None
+        manifest_tags = manifest_tags_by_id.get(model_ref) if model_ref in manifest_by_id else None
         legacy_tags = entity.get("tags") or []
-        existing_dbt_tags = entity.get("dbt_tags") or []
-        reconciled_dbt_tags = reconcile_entity_tags(existing_dbt_tags, manifest_tags)
+        existing_framework_tags = get_framework_tags(entity)
+        reconciled_framework_tags = reconcile_entity_tags(existing_framework_tags, manifest_tags)
 
         # One-time migration: a bound entity's legacy `tags` value (from
-        # before the dbt_tags/ui_tags split existed) is folded into ui_tags
-        # ONLY if it represents real legacy/user-curated data — i.e. it
-        # differs from what dbt reconciliation says right now. A value that
-        # already matches is dbt's own tag list from an earlier run under
-        # the old field name, not something the user added, and must NOT be
-        # copied into ui_tags (that would wrongly mark dbt's tags as
-        # Trellis-authored and defeat the read-only/removable UI split).
-        # The legacy `tags` key itself is always retired afterward — bound
-        # entities never persist `tags` going forward, only dbt_tags/ui_tags.
+        # before the framework_tags/ui_tags split existed) is folded into
+        # ui_tags ONLY if it represents real legacy/user-curated data — i.e.
+        # it differs from what framework reconciliation says right now. A
+        # value that already matches is the framework's own tag list from an
+        # earlier run under the old field name, not something the user
+        # added, and must NOT be copied into ui_tags (that would wrongly
+        # mark the framework's tags as Trellis-authored and defeat the
+        # read-only/removable UI split). The legacy `tags` key itself is
+        # always retired afterward — bound entities never persist `tags`
+        # going forward, only framework_tags/ui_tags.
         if "tags" in entity:
             if (
                 "ui_tags" not in entity
                 and legacy_tags
-                and legacy_tags != reconciled_dbt_tags
+                and legacy_tags != reconciled_framework_tags
             ):
                 entity["ui_tags"] = list(legacy_tags)
             del entity["tags"]
             changed = True
 
-        if reconciled_dbt_tags != existing_dbt_tags:
-            entity["dbt_tags"] = reconciled_dbt_tags
+        if reconciled_framework_tags != existing_framework_tags:
             changed = True
+
+        # Normalize key spellings (migrates any legacy dbt_model/dbt_tags
+        # keys onto model_ref/framework_tags) even when values are unchanged.
+        set_model_ref(entity, model_ref)
+        set_framework_tags(entity, reconciled_framework_tags)
 
     return result, changed
 

--- a/trellis_datamodel/services/schema.py
+++ b/trellis_datamodel/services/schema.py
@@ -32,7 +32,7 @@ from trellis_datamodel.utils.path_validation import (
 )
 
 
-def save_dbt_schema(
+def save_model_schema_from_request(
     entity_id: str,
     model_name: str,
     fields: list[dict[str, str]],
@@ -72,7 +72,7 @@ def save_dbt_schema(
         raise FileOperationError(f"Error saving schema: {str(e)}") from e
 
 
-def sync_dbt_tests() -> list[Path]:
+def sync_framework_tests() -> list[Path]:
     """
     Sync relationship tests from data model to schema files.
 

--- a/trellis_datamodel/services/schema.py
+++ b/trellis_datamodel/services/schema.py
@@ -60,7 +60,7 @@ def save_model_schema_from_request(
 
     try:
         adapter = get_adapter()
-        output_path = adapter.save_dbt_schema(
+        output_path = adapter.save_schema_file(
             entity_id=entity_id,
             model_name=model_name,
             fields=fields,

--- a/trellis_datamodel/tests/_entity_compat.py
+++ b/trellis_datamodel/tests/_entity_compat.py
@@ -1,0 +1,59 @@
+"""Shared entity-key compat accessors for characterization tests.
+
+These helpers read the model binding and framework-mirrored tags with a
+new-key-first, legacy-key-fallback, presence-based lookup — mirroring the
+`model_ref`/`framework_tags` generalization planned for
+`trellis_datamodel/models/entity_keys.py` (not yet built as of this test).
+
+Tests that read entity dict keys through these helpers (instead of raw
+`"dbt_model"`/`"dbt_tags"` literals) survive the future rename unmodified:
+only fixture keys change, never assertions.
+
+Lookup is presence-based, not truthiness-based: if the new key is present at
+all, it wins, even when its value is `None` or `[]`. An explicitly cleared
+binding must not fall back to a stale legacy value.
+"""
+from typing import Any, Optional
+
+MODEL_REF_KEY = "model_ref"
+LEGACY_MODEL_REF_KEY = "dbt_model"
+FRAMEWORK_TAGS_KEY = "framework_tags"
+LEGACY_FRAMEWORK_TAGS_KEY = "dbt_tags"
+
+
+def get_model_ref(entity: dict[str, Any]) -> Optional[str]:
+    """Return the entity's bound model reference, new key first."""
+    if MODEL_REF_KEY in entity:
+        return entity[MODEL_REF_KEY] or None
+    return entity.get(LEGACY_MODEL_REF_KEY) or None
+
+
+def get_framework_tags(entity: dict[str, Any]) -> list:
+    """Return the entity's framework-mirrored tags, new key first."""
+    if FRAMEWORK_TAGS_KEY in entity:
+        return list(entity[FRAMEWORK_TAGS_KEY] or [])
+    return list(entity.get(LEGACY_FRAMEWORK_TAGS_KEY) or [])
+
+
+def _normalize_entity(entity: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `entity` with the binding/tags collapsed onto the
+    generic key names, for spelling-independent comparison in tests.
+
+    This is the one place a raw key literal is allowed; assertions built on
+    top of this helper never depend on which spelling the underlying code
+    currently uses.
+    """
+    normalized = {
+        k: v
+        for k, v in entity.items()
+        if k
+        not in (
+            MODEL_REF_KEY,
+            LEGACY_MODEL_REF_KEY,
+            FRAMEWORK_TAGS_KEY,
+            LEGACY_FRAMEWORK_TAGS_KEY,
+        )
+    }
+    normalized[MODEL_REF_KEY] = get_model_ref(entity)
+    normalized[FRAMEWORK_TAGS_KEY] = get_framework_tags(entity)
+    return normalized

--- a/trellis_datamodel/tests/conftest.py
+++ b/trellis_datamodel/tests/conftest.py
@@ -218,6 +218,30 @@ class FakeAdapter:
     def reset_inference_cache(self):
         return None
 
+    def get_lineage(self, unique_id):
+        raise NotImplementedError(
+            "get_lineage is not yet part of TransformationAdapter; deferred to the "
+            "BruinAdapter spec (services/lineage.py still parses dbt manifest/catalog directly)."
+        )
+
+    def get_exposures(self):
+        raise NotImplementedError(
+            "get_exposures is not yet part of TransformationAdapter; deferred to the "
+            "BruinAdapter spec (services/exposures.py still reads manifest.json/exposures.yml directly)."
+        )
+
+    def get_source_systems_for_model(self, unique_id):
+        raise NotImplementedError(
+            "get_source_systems_for_model is not yet part of TransformationAdapter; deferred to "
+            "the BruinAdapter spec (routes/data_model.py still reads manifest/catalog directly)."
+        )
+
+    def get_project_status(self):
+        raise NotImplementedError(
+            "get_project_status is not yet part of TransformationAdapter; deferred to the "
+            "BruinAdapter spec (routes/manifest.py still reports dbt paths directly)."
+        )
+
 
 @pytest.fixture
 def fake_adapter():

--- a/trellis_datamodel/tests/conftest.py
+++ b/trellis_datamodel/tests/conftest.py
@@ -202,6 +202,22 @@ class FakeAdapter:
     def sync_relationships(self, entities, relationships):
         return []
 
+    def save_schema_file(
+        self, entity_id, model_name, fields, description=None, tags=None
+    ):
+        from pathlib import Path
+
+        return Path(f"{model_name}.yml")
+
+    def infer_entity_types(self):
+        return {}
+
+    def get_model_dirs(self):
+        return []
+
+    def reset_inference_cache(self):
+        return None
+
 
 @pytest.fixture
 def fake_adapter():

--- a/trellis_datamodel/tests/conftest.py
+++ b/trellis_datamodel/tests/conftest.py
@@ -156,6 +156,59 @@ class _PatchedASGITransport(httpx.ASGITransport):
         return False
 
 
+class FakeAdapter:
+    """In-memory TransformationAdapter test double.
+
+    Backed by a plain list[ModelInfo] (`self.models`) that tests mutate
+    directly. Proves reconciliation and other adapter consumers depend only
+    on the TransformationAdapter protocol, not on dbt specifics.
+    """
+
+    def __init__(self, models=None):
+        self.models = models if models is not None else []
+
+    def get_models(self):
+        return self.models
+
+    def get_model_schema(self, model_name, version=None):
+        for model in self.models:
+            if model.get("name") == model_name and (
+                version is None or model.get("version") == version
+            ):
+                return {
+                    "model_name": model_name,
+                    "description": model.get("description") or "",
+                    "columns": [
+                        {
+                            "name": col.get("name"),
+                            "data_type": col.get("type"),
+                            "description": col.get("description"),
+                        }
+                        for col in model.get("columns", [])
+                    ],
+                    "tags": model.get("tags") or [],
+                    "file_path": model.get("file_path") or "",
+                }
+        return {"model_name": model_name, "description": "", "columns": [], "tags": []}
+
+    def save_model_schema(self, model_name, columns, description=None, tags=None, version=None):
+        from pathlib import Path
+
+        return Path(f"{model_name}.yml")
+
+    def infer_relationships(self, include_unbound=False):
+        return []
+
+    def sync_relationships(self, entities, relationships):
+        return []
+
+
+@pytest.fixture
+def fake_adapter():
+    """Construct a fresh FakeAdapter with no models; tests set `.models`."""
+    return FakeAdapter()
+
+
 @pytest.fixture
 def test_client(mock_manifest):
     """Create a synchronous test client against the ASGI app.

--- a/trellis_datamodel/tests/test_adapter.py
+++ b/trellis_datamodel/tests/test_adapter.py
@@ -9,13 +9,18 @@ def test_entity_typeddict_uses_generic_model_ref():
     assert "dbt_model" not in hints
 
 
-def test_get_adapter_raises_not_implemented_for_bruin(monkeypatch):
+def test_get_adapter_raises_value_error_for_unknown_framework(monkeypatch):
+    """An unsupported framework must fail loudly, never fall through to dbt behavior.
+
+    The error names the frameworks that are actually supported, so adding one is a
+    matter of implementing an adapter rather than teaching this message about it.
+    """
     from trellis_datamodel import config as cfg
     from trellis_datamodel.adapters import get_adapter
 
-    monkeypatch.setattr(cfg, "FRAMEWORK", "bruin")
+    monkeypatch.setattr(cfg, "FRAMEWORK", "some-unsupported-framework")
 
-    with pytest.raises(NotImplementedError, match="Bruin adapter not yet implemented"):
+    with pytest.raises(ValueError, match="dbt-core"):
         get_adapter()
 
 

--- a/trellis_datamodel/tests/test_adapter.py
+++ b/trellis_datamodel/tests/test_adapter.py
@@ -1,6 +1,35 @@
+import pytest
+
+
 def test_entity_typeddict_uses_generic_model_ref():
     from trellis_datamodel.adapters.base import Entity
 
     hints = Entity.__annotations__
     assert "model_ref" in hints
     assert "dbt_model" not in hints
+
+
+def test_get_adapter_raises_not_implemented_for_bruin(monkeypatch):
+    from trellis_datamodel import config as cfg
+    from trellis_datamodel.adapters import get_adapter
+
+    monkeypatch.setattr(cfg, "FRAMEWORK", "bruin")
+
+    with pytest.raises(NotImplementedError, match="Bruin adapter not yet implemented"):
+        get_adapter()
+
+
+def test_get_adapter_still_returns_dbt_core_adapter_for_dbt_core(monkeypatch):
+    from trellis_datamodel import config as cfg
+    from trellis_datamodel.adapters import DbtCoreAdapter, get_adapter
+
+    monkeypatch.setattr(cfg, "FRAMEWORK", "dbt-core")
+    monkeypatch.setattr(cfg, "MANIFEST_PATH", "/tmp/manifest.json")
+    monkeypatch.setattr(cfg, "CATALOG_PATH", "/tmp/catalog.json")
+    monkeypatch.setattr(cfg, "DBT_PROJECT_PATH", "/tmp/dbt_project")
+    monkeypatch.setattr(cfg, "DATA_MODEL_PATH", "/tmp/data_model.yml")
+    monkeypatch.setattr(cfg, "DBT_MODEL_PATHS", ["models"])
+
+    adapter = get_adapter()
+
+    assert isinstance(adapter, DbtCoreAdapter)

--- a/trellis_datamodel/tests/test_adapter.py
+++ b/trellis_datamodel/tests/test_adapter.py
@@ -1,0 +1,6 @@
+def test_entity_typeddict_uses_generic_model_ref():
+    from trellis_datamodel.adapters.base import Entity
+
+    hints = Entity.__annotations__
+    assert "model_ref" in hints
+    assert "dbt_model" not in hints

--- a/trellis_datamodel/tests/test_adapter_future_surface.py
+++ b/trellis_datamodel/tests/test_adapter_future_surface.py
@@ -1,0 +1,64 @@
+"""
+Strict-xfail contract tests pinning the adapter surface deferred to the
+BruinAdapter spec.
+
+These tests are meant to FAIL (as xfail), not pass. They document the
+subsystems that still bypass TransformationAdapter and read dbt files
+(manifest.json / catalog.json / schema.yml) directly: services/lineage.py,
+services/exposures.py, routes/manifest.py, and the source-system extraction
+in routes/data_model.py. Because they are marked `strict=True`, an
+unexpected pass (XPASS) becomes a hard failure, so this deferred-work list
+cannot be silently forgotten or half-implemented.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+FUTURE_REASON = (
+    "Deferred to the BruinAdapter spec: this subsystem still reads dbt files "
+    "directly instead of going through TransformationAdapter. "
+    "When implemented, remove the xfail mark — strict=True makes an "
+    "unexpected pass a hard failure so this cannot be silently skipped."
+)
+
+
+@pytest.mark.xfail(strict=True, reason=FUTURE_REASON)
+def test_adapter_exposes_get_lineage(fake_adapter):
+    """services/lineage.py parses manifest.json/catalog.json directly."""
+    upstream = fake_adapter.get_lineage("model.fake.customer")
+    assert [n["unique_id"] for n in upstream] == ["model.fake.stg_customer"]
+
+
+@pytest.mark.xfail(strict=True, reason=FUTURE_REASON)
+def test_adapter_exposes_get_exposures(fake_adapter):
+    """services/exposures.py reads manifest.json + probes DBT_PROJECT_PATH for exposures.yml."""
+    assert fake_adapter.get_exposures()[0]["name"] == "fake_dashboard"
+
+
+@pytest.mark.xfail(strict=True, reason=FUTURE_REASON)
+def test_adapter_exposes_get_source_systems_for_model(fake_adapter):
+    """routes/data_model.py:266-290,514-548 reads manifest/catalog for source-system extraction."""
+    assert fake_adapter.get_source_systems_for_model("model.fake.customer") == ["crm"]
+
+
+@pytest.mark.xfail(strict=True, reason=FUTURE_REASON)
+def test_adapter_exposes_get_project_status(fake_adapter):
+    """routes/manifest.py:50-110 reports dbt manifest/catalog/project paths directly."""
+    status = fake_adapter.get_project_status()
+    assert {"artifacts_present", "project_path", "model_paths_configured"} <= status.keys()
+
+
+@pytest.mark.xfail(strict=True, reason=FUTURE_REASON)
+def test_no_service_reads_framework_artifacts_directly():
+    """The end state: only adapters/ may name manifest.json / catalog.json / schema.yml."""
+    repo_root = Path(__file__).resolve().parents[2]
+    offenders = [
+        str(p)
+        for p in repo_root.joinpath("trellis_datamodel").rglob("*.py")
+        if "adapters" not in p.parts
+        and "tests" not in p.parts
+        and re.search(r"manifest\.json|catalog\.json|MANIFEST_PATH|CATALOG_PATH", p.read_text())
+    ]
+    assert offenders == []

--- a/trellis_datamodel/tests/test_adapter_protocol_surface.py
+++ b/trellis_datamodel/tests/test_adapter_protocol_surface.py
@@ -1,0 +1,55 @@
+"""
+Characterization tests for the TransformationAdapter protocol surface.
+
+The protocol is the contract. Anything a service calls on an adapter must be
+declared here, or the abstraction is fictional. These tests close the
+adapter-boundary loopholes described in Sprint 4B of the
+generalize-transformation-adapter spec: methods called on adapter instances
+without being declared on the protocol, and modules that reach around
+`get_adapter()` to import `DbtCoreAdapter` directly.
+"""
+
+from pathlib import Path
+
+from trellis_datamodel.adapters.base import TransformationAdapter
+from trellis_datamodel.adapters.dbt_core import DbtCoreAdapter
+from trellis_datamodel.tests.conftest import FakeAdapter
+
+REQUIRED_PROTOCOL_METHODS = {
+    "get_models",
+    "get_model_schema",
+    "save_model_schema",
+    "infer_relationships",
+    "sync_relationships",
+    "save_schema_file",
+    "infer_entity_types",
+    "get_model_dirs",
+    "reset_inference_cache",
+}
+
+
+def test_protocol_declares_every_method_services_call():
+    declared = {n for n in dir(TransformationAdapter) if not n.startswith("_")}
+    assert REQUIRED_PROTOCOL_METHODS <= declared
+
+
+def test_dbt_core_adapter_satisfies_protocol():
+    for name in REQUIRED_PROTOCOL_METHODS:
+        assert callable(getattr(DbtCoreAdapter, name, None)), name
+
+
+def test_fake_adapter_satisfies_protocol():
+    for name in REQUIRED_PROTOCOL_METHODS:
+        assert callable(getattr(FakeAdapter, name, None)), name
+
+
+def test_no_service_or_route_imports_dbt_core_adapter_directly():
+    repo_root = Path(__file__).resolve().parents[2]
+    hits = [
+        p
+        for p in repo_root.joinpath("trellis_datamodel").rglob("*.py")
+        if "adapters" not in p.parts
+        and "tests" not in p.parts
+        and "DbtCoreAdapter" in p.read_text()
+    ]
+    assert hits == []

--- a/trellis_datamodel/tests/test_api_contract_snapshot.py
+++ b/trellis_datamodel/tests/test_api_contract_snapshot.py
@@ -75,3 +75,82 @@ def test_post_data_model_accepts_legacy_payload(test_client, temp_data_model_pat
     entity = response.json()["entities"][0]
     assert entity["dbt_model"] == "model.proj.orders"
     assert entity["dbt_tags"] == ["nightly"]
+
+
+def test_get_data_model_emits_both_legacy_and_new_keys(test_client, temp_data_model_path):
+    """GET /api/data-model must emit both the legacy dbt_model/dbt_tags keys and
+    the generic model_ref/framework_tags keys so unmigrated frontend clients
+    keep resolving bindings while consumers can start migrating to the new
+    spelling."""
+    model_data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "customers",
+                "label": "Customers",
+                "dbt_model": "model.proj.customers",
+                "dbt_tags": ["nightly", "customer_360"],
+                "ui_tags": ["pii"],
+            },
+            {
+                "id": "notes",
+                "label": "Notes",
+            },
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(model_data, f)
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    entities = {e["id"]: e for e in response.json()["entities"]}
+
+    bound = entities["customers"]
+    assert bound["model_ref"] == bound["dbt_model"]
+    assert bound["model_ref"] == "model.proj.customers"
+    assert bound["framework_tags"] == bound["dbt_tags"]
+    assert bound["framework_tags"] == ["nightly", "customer_360"]
+
+
+def test_dual_key_emission_is_response_only_not_persisted(test_client, temp_data_model_path):
+    """The GET-time legacy-key alias shim must decorate the response only; the
+    on-disk YAML must never gain the shim-added keys. This is checked by
+    seeding disk with the new-key spelling directly (bypassing the API) and
+    confirming the legacy keys the response adds never leak back to disk."""
+    model_data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "products",
+                "label": "Products",
+                "model_ref": "model.proj.products",
+                "framework_tags": ["nightly"],
+                "ui_tags": ["core"],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(model_data, f)
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    entity = response.json()["entities"][0]
+    # Shim adds both spellings to the response...
+    assert entity["model_ref"] == "model.proj.products"
+    assert entity["dbt_model"] == "model.proj.products"
+    assert entity["framework_tags"] == ["nightly"]
+    assert entity["dbt_tags"] == ["nightly"]
+
+    # ...but the on-disk file is untouched: no legacy keys were persisted.
+    with open(temp_data_model_path, "r") as f:
+        saved = yaml.safe_load(f)
+    saved_entity = saved["entities"][0]
+    for key in LEGACY_KEYS:
+        assert key not in saved_entity, (
+            f"legacy key '{key}' must not be persisted to disk by the "
+            "response-only shim"
+        )
+    assert saved_entity["model_ref"] == "model.proj.products"
+    assert saved_entity["framework_tags"] == ["nightly"]

--- a/trellis_datamodel/tests/test_api_contract_snapshot.py
+++ b/trellis_datamodel/tests/test_api_contract_snapshot.py
@@ -45,7 +45,12 @@ def test_get_data_model_response_shape(test_client, temp_data_model_path):
 
 def test_post_data_model_accepts_legacy_payload(test_client, temp_data_model_path):
     """POST /api/data-model accepts a payload keyed by `dbt_model`/`dbt_tags`
-    and a subsequent GET resolves the binding from what was persisted."""
+    and a subsequent GET resolves the binding from what was persisted.
+
+    Post-rename (Sprint 2 Stream C): the internal read/write path now
+    persists the generic `model_ref`/`framework_tags` keys to disk, never the
+    legacy spelling — this is the tripwire firing as documented above.
+    """
     payload = {
         "version": 0.1,
         "entities": [
@@ -66,15 +71,20 @@ def test_post_data_model_accepts_legacy_payload(test_client, temp_data_model_pat
         saved = yaml.safe_load(f)
     saved_entity = saved["entities"][0]
     for key in LEGACY_KEYS:
-        assert key in saved_entity or key == "dbt_tags"
-    assert saved_entity["dbt_model"] == "model.proj.orders"
-    assert saved_entity["dbt_tags"] == ["nightly"]
+        assert key not in saved_entity, (
+            f"legacy key '{key}' must not be persisted to disk"
+        )
+    assert saved_entity["model_ref"] == "model.proj.orders"
+    assert saved_entity["framework_tags"] == ["nightly"]
 
     response = test_client.get("/api/data-model")
     assert response.status_code == 200
     entity = response.json()["entities"][0]
+    # GET still emits both spellings via the response-only alias shim.
     assert entity["dbt_model"] == "model.proj.orders"
     assert entity["dbt_tags"] == ["nightly"]
+    assert entity["model_ref"] == "model.proj.orders"
+    assert entity["framework_tags"] == ["nightly"]
 
 
 def test_get_data_model_emits_both_legacy_and_new_keys(test_client, temp_data_model_path):

--- a/trellis_datamodel/tests/test_api_contract_snapshot.py
+++ b/trellis_datamodel/tests/test_api_contract_snapshot.py
@@ -80,26 +80,26 @@ def test_post_data_model_accepts_legacy_payload(test_client, temp_data_model_pat
     response = test_client.get("/api/data-model")
     assert response.status_code == 200
     entity = response.json()["entities"][0]
-    # GET still emits both spellings via the response-only alias shim.
-    assert entity["dbt_model"] == "model.proj.orders"
-    assert entity["dbt_tags"] == ["nightly"]
+    # Sprint 6: the GET-time dual-key alias shim was retired now that the
+    # frontend reads model_ref/framework_tags exclusively. The persisted
+    # (generic) keys are what GET reflects back.
     assert entity["model_ref"] == "model.proj.orders"
     assert entity["framework_tags"] == ["nightly"]
 
 
-def test_get_data_model_emits_both_legacy_and_new_keys(test_client, temp_data_model_path):
-    """GET /api/data-model must emit both the legacy dbt_model/dbt_tags keys and
-    the generic model_ref/framework_tags keys so unmigrated frontend clients
-    keep resolving bindings while consumers can start migrating to the new
-    spelling."""
+def test_get_data_model_no_longer_emits_legacy_keys(test_client, temp_data_model_path):
+    """Sprint 6: the transitional GET-time dual-key alias shim has been
+    removed. When the data model is stored in the current model_ref/
+    framework_tags spelling, the response must not gain dbt_model/dbt_tags
+    keys for any entity."""
     model_data = {
         "version": 0.1,
         "entities": [
             {
                 "id": "customers",
                 "label": "Customers",
-                "dbt_model": "model.proj.customers",
-                "dbt_tags": ["nightly", "customer_360"],
+                "model_ref": "model.proj.customers",
+                "framework_tags": ["nightly", "customer_360"],
                 "ui_tags": ["pii"],
             },
             {
@@ -114,53 +114,11 @@ def test_get_data_model_emits_both_legacy_and_new_keys(test_client, temp_data_mo
 
     response = test_client.get("/api/data-model")
     assert response.status_code == 200
-    entities = {e["id"]: e for e in response.json()["entities"]}
+    entities = response.json()["entities"]
 
-    bound = entities["customers"]
-    assert bound["model_ref"] == bound["dbt_model"]
-    assert bound["model_ref"] == "model.proj.customers"
-    assert bound["framework_tags"] == bound["dbt_tags"]
-    assert bound["framework_tags"] == ["nightly", "customer_360"]
-
-
-def test_dual_key_emission_is_response_only_not_persisted(test_client, temp_data_model_path):
-    """The GET-time legacy-key alias shim must decorate the response only; the
-    on-disk YAML must never gain the shim-added keys. This is checked by
-    seeding disk with the new-key spelling directly (bypassing the API) and
-    confirming the legacy keys the response adds never leak back to disk."""
-    model_data = {
-        "version": 0.1,
-        "entities": [
-            {
-                "id": "products",
-                "label": "Products",
-                "model_ref": "model.proj.products",
-                "framework_tags": ["nightly"],
-                "ui_tags": ["core"],
-            }
-        ],
-        "relationships": [],
-    }
-    with open(temp_data_model_path, "w") as f:
-        yaml.dump(model_data, f)
-
-    response = test_client.get("/api/data-model")
-    assert response.status_code == 200
-    entity = response.json()["entities"][0]
-    # Shim adds both spellings to the response...
-    assert entity["model_ref"] == "model.proj.products"
-    assert entity["dbt_model"] == "model.proj.products"
-    assert entity["framework_tags"] == ["nightly"]
-    assert entity["dbt_tags"] == ["nightly"]
-
-    # ...but the on-disk file is untouched: no legacy keys were persisted.
-    with open(temp_data_model_path, "r") as f:
-        saved = yaml.safe_load(f)
-    saved_entity = saved["entities"][0]
-    for key in LEGACY_KEYS:
-        assert key not in saved_entity, (
-            f"legacy key '{key}' must not be persisted to disk by the "
-            "response-only shim"
-        )
-    assert saved_entity["model_ref"] == "model.proj.products"
-    assert saved_entity["framework_tags"] == ["nightly"]
+    for entity in entities:
+        for key in LEGACY_KEYS:
+            assert key not in entity, (
+                f"legacy key '{key}' must no longer be emitted in GET response "
+                f"for entity '{entity.get('id')}'"
+            )

--- a/trellis_datamodel/tests/test_api_contract_snapshot.py
+++ b/trellis_datamodel/tests/test_api_contract_snapshot.py
@@ -1,0 +1,77 @@
+"""Snapshot of the data-model API wire format before key generalization.
+
+Sprint 0 tripwire: these tests deliberately hard-code the *current*
+`dbt_model`/`dbt_tags` spelling. When the wire format is later renamed to
+`model_ref`/`framework_tags`, this file must fail loudly so the rename is
+never silently missed.
+"""
+
+import yaml
+
+LEGACY_KEYS = ("dbt_model", "dbt_tags")
+
+
+def test_get_data_model_response_shape(test_client, temp_data_model_path):
+    """GET /api/data-model exposes the binding and mirrored tags under the
+    legacy `dbt_model`/`dbt_tags` keys today."""
+    model_data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "dbt_tags": ["nightly", "customer_360"],
+                "ui_tags": ["pii"],
+            }
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(model_data, f)
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    entity = response.json()["entities"][0]
+
+    for key in LEGACY_KEYS:
+        assert key in entity, f"expected legacy key '{key}' in GET response entity"
+
+    assert entity["dbt_model"] == "model.proj.users"
+    assert entity["dbt_tags"] == ["nightly", "customer_360"]
+    # Computed display tags mirror dbt_tags + ui_tags for bound entities.
+    assert entity["tags"] == ["nightly", "customer_360", "pii"]
+
+
+def test_post_data_model_accepts_legacy_payload(test_client, temp_data_model_path):
+    """POST /api/data-model accepts a payload keyed by `dbt_model`/`dbt_tags`
+    and a subsequent GET resolves the binding from what was persisted."""
+    payload = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "orders",
+                "label": "Orders",
+                "dbt_model": "model.proj.orders",
+                "dbt_tags": ["nightly"],
+            }
+        ],
+        "relationships": [],
+    }
+    response = test_client.post("/api/data-model", json=payload)
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+    with open(temp_data_model_path, "r") as f:
+        saved = yaml.safe_load(f)
+    saved_entity = saved["entities"][0]
+    for key in LEGACY_KEYS:
+        assert key in saved_entity or key == "dbt_tags"
+    assert saved_entity["dbt_model"] == "model.proj.orders"
+    assert saved_entity["dbt_tags"] == ["nightly"]
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    entity = response.json()["entities"][0]
+    assert entity["dbt_model"] == "model.proj.orders"
+    assert entity["dbt_tags"] == ["nightly"]

--- a/trellis_datamodel/tests/test_bus_matrix.py
+++ b/trellis_datamodel/tests/test_bus_matrix.py
@@ -369,3 +369,44 @@ class TestBusMatrixEndpoint:
             get_bus_matrix()
 
         assert "not configured" in str(exc_info.value).lower()
+
+
+def test_bus_matrix_tag_source_for_bound_vs_unbound_entity(
+    temp_data_model_path, enable_bus_matrix
+):
+    """A bound dimension's displayed tags are the union of its
+    framework-mirrored tags and ui_tags; an unbound dimension's displayed
+    tags are simply its own `tags` field."""
+    from trellis_datamodel.tests._entity_compat import get_model_ref
+
+    data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "dim_bound",
+                "entity_type": "dimension",
+                "dbt_model": "model.project.dim_bound",
+                "dbt_tags": ["nightly", "core"],
+                "ui_tags": ["pii"],
+            },
+            {
+                "id": "dim_unbound",
+                "entity_type": "dimension",
+                "tags": ["draft-tag"],
+            },
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(data, f)
+
+    result = get_bus_matrix()
+
+    bound = next(d for d in result["dimensions"] if d["id"] == "dim_bound")
+    unbound = next(d for d in result["dimensions"] if d["id"] == "dim_unbound")
+
+    assert get_model_ref(bound) == "model.project.dim_bound"
+    assert bound["tags"] == ["nightly", "core", "pii"]
+
+    assert get_model_ref(unbound) is None
+    assert unbound["tags"] == ["draft-tag"]

--- a/trellis_datamodel/tests/test_config.py
+++ b/trellis_datamodel/tests/test_config.py
@@ -426,39 +426,19 @@ def test_entity_modeling_disabled_when_dimensional_model(monkeypatch, tmp_path):
     assert cfg.ENTITY_MODELING_CONFIG.entity_prefix == []
 
 
-def test_framework_enum_supports_bruin():
+def test_framework_enum_lists_only_implemented_frameworks():
+    """The enum advertises what Trellis can actually do.
+
+    A framework value only becomes selectable once its adapter exists, so a user
+    cannot configure a framework that has no working implementation behind it.
+    """
     from trellis_datamodel.models.schemas import FrameworkEnum
 
-    assert FrameworkEnum.BRUIN == "bruin"
-    assert FrameworkEnum("bruin") is FrameworkEnum.BRUIN
+    assert [f.value for f in FrameworkEnum] == ["dbt-core"]
 
 
-# ===== Bruin Config Scaffolding Tests (Sprint 4 Stream B) =====
-
-
-def test_load_config_resolves_bruin_pipeline_path(monkeypatch, tmp_path):
-    """Bruin framework config resolves pipeline path and asset paths."""
-    _prepare_config(monkeypatch)
-    config_path = _write_config(
-        tmp_path,
-        """
-        framework: bruin
-        bruin_pipeline_path: ./pipeline
-        bruin_asset_paths:
-          - assets
-        """,
-    )
-
-    cfg.load_config(str(config_path))
-
-    assert cfg.FRAMEWORK == "bruin"
-    assert os.path.isabs(cfg.BRUIN_PIPELINE_PATH)
-    assert cfg.BRUIN_PIPELINE_PATH == os.path.abspath(tmp_path / "pipeline")
-    assert cfg.BRUIN_ASSET_PATHS == ["assets"]
-
-
-def test_existing_dbt_config_unaffected_by_bruin_fields(monkeypatch):
-    """Loading this repo's real trellis.yml (dbt-based) is unaffected by bruin fields."""
+def test_repo_trellis_yml_loads(monkeypatch):
+    """Loading this repo's real trellis.yml (dbt-based) resolves as expected."""
     _prepare_config(monkeypatch)
     repo_root = Path(__file__).resolve().parents[2]
     config_path = repo_root / "trellis.yml"
@@ -472,5 +452,3 @@ def test_existing_dbt_config_unaffected_by_bruin_fields(monkeypatch):
     assert cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix == ["fact__"]
     assert cfg.EXPOSURES_ENABLED is True
     assert cfg.BUSINESS_EVENTS_ENABLED is True
-    assert cfg.BRUIN_PIPELINE_PATH is None
-    assert cfg.BRUIN_ASSET_PATHS is None

--- a/trellis_datamodel/tests/test_config.py
+++ b/trellis_datamodel/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for configuration loading."""
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -430,3 +431,46 @@ def test_framework_enum_supports_bruin():
 
     assert FrameworkEnum.BRUIN == "bruin"
     assert FrameworkEnum("bruin") is FrameworkEnum.BRUIN
+
+
+# ===== Bruin Config Scaffolding Tests (Sprint 4 Stream B) =====
+
+
+def test_load_config_resolves_bruin_pipeline_path(monkeypatch, tmp_path):
+    """Bruin framework config resolves pipeline path and asset paths."""
+    _prepare_config(monkeypatch)
+    config_path = _write_config(
+        tmp_path,
+        """
+        framework: bruin
+        bruin_pipeline_path: ./pipeline
+        bruin_asset_paths:
+          - assets
+        """,
+    )
+
+    cfg.load_config(str(config_path))
+
+    assert cfg.FRAMEWORK == "bruin"
+    assert os.path.isabs(cfg.BRUIN_PIPELINE_PATH)
+    assert cfg.BRUIN_PIPELINE_PATH == os.path.abspath(tmp_path / "pipeline")
+    assert cfg.BRUIN_ASSET_PATHS == ["assets"]
+
+
+def test_existing_dbt_config_unaffected_by_bruin_fields(monkeypatch):
+    """Loading this repo's real trellis.yml (dbt-based) is unaffected by bruin fields."""
+    _prepare_config(monkeypatch)
+    repo_root = Path(__file__).resolve().parents[2]
+    config_path = repo_root / "trellis.yml"
+
+    cfg.load_config(str(config_path))
+
+    assert cfg.FRAMEWORK == "dbt-core"
+    assert cfg.DBT_PROJECT_PATH == os.path.abspath(repo_root / "dbt_demo")
+    assert cfg.MODELING_STYLE == "dimensional_model"
+    assert cfg.DIMENSIONAL_MODELING_CONFIG.dimension_prefix == ["dim__"]
+    assert cfg.DIMENSIONAL_MODELING_CONFIG.fact_prefix == ["fact__"]
+    assert cfg.EXPOSURES_ENABLED is True
+    assert cfg.BUSINESS_EVENTS_ENABLED is True
+    assert cfg.BRUIN_PIPELINE_PATH is None
+    assert cfg.BRUIN_ASSET_PATHS is None

--- a/trellis_datamodel/tests/test_config.py
+++ b/trellis_datamodel/tests/test_config.py
@@ -423,3 +423,10 @@ def test_entity_modeling_disabled_when_dimensional_model(monkeypatch, tmp_path):
     assert cfg.MODELING_STYLE == "dimensional_model"
     assert cfg.ENTITY_MODELING_CONFIG.enabled is False
     assert cfg.ENTITY_MODELING_CONFIG.entity_prefix == []
+
+
+def test_framework_enum_supports_bruin():
+    from trellis_datamodel.models.schemas import FrameworkEnum
+
+    assert FrameworkEnum.BRUIN == "bruin"
+    assert FrameworkEnum("bruin") is FrameworkEnum.BRUIN

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -298,6 +298,86 @@ class TestSaveDataModel:
         # The other unique entity is unaffected
         assert "users" in entity_ids
 
+    def test_save_writes_generic_keys_to_disk(self, test_client, temp_data_model_path):
+        """POST persists model_ref/framework_tags to disk; no legacy dbt_* keys,
+        even when the incoming payload uses the legacy dbt_model/dbt_tags names."""
+        payload = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.proj.users",
+                    "dbt_tags": ["nightly", "customer_360"],
+                }
+            ],
+            "relationships": [],
+        }
+        response = test_client.post("/api/data-model", json=payload)
+        assert response.status_code == 200
+
+        with open(temp_data_model_path, "r") as f:
+            saved = yaml.safe_load(f)
+
+        entity = saved["entities"][0]
+        assert entity["model_ref"] == "model.proj.users"
+        assert entity["framework_tags"] == ["nightly", "customer_360"]
+        assert "dbt_model" not in entity, "legacy key must not be written to disk"
+        assert "dbt_tags" not in entity, "legacy key must not be written to disk"
+
+    def test_save_preserves_mirrored_tags_when_autosave_omits_them_legacy_payload(
+        self, test_client, temp_data_model_path
+    ):
+        """A bound entity's reconcile-owned framework tags must survive an
+        autosave that uses the legacy dbt_model/ui_tags payload shape (today's
+        live frontend), even though the file on disk now stores
+        model_ref/framework_tags."""
+        with open(temp_data_model_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "version": 0.1,
+                    "entities": [
+                        {
+                            "id": "users",
+                            "label": "Users",
+                            "model_ref": "model.proj.users",
+                            "framework_tags": ["nightly", "customer_360"],
+                        }
+                    ],
+                    "relationships": [],
+                },
+                f,
+            )
+
+        # Legacy-shaped autosave payload: dbt_model + ui_tags only, no
+        # dbt_tags/framework_tags key at all — exactly what auto-save.ts sends
+        # today for a bound entity.
+        payload = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.proj.users",
+                    "ui_tags": ["pii"],
+                }
+            ],
+            "relationships": [],
+        }
+        response = test_client.post("/api/data-model", json=payload)
+        assert response.status_code == 200
+
+        with open(temp_data_model_path, "r") as f:
+            saved = yaml.safe_load(f)
+
+        entity = saved["entities"][0]
+        assert get_model_ref(entity) == "model.proj.users"
+        assert get_framework_tags(entity) == ["nightly", "customer_360"], (
+            "bound entity's reconcile-owned framework tags were wiped by a "
+            f"legacy-shaped autosave payload; got: {get_framework_tags(entity)}"
+        )
+        assert entity["ui_tags"] == ["pii"]
+
     def test_preserves_existing_roles_when_omitted_from_payload(
         self, test_client, temp_data_model_path
     ):
@@ -456,11 +536,11 @@ def test_split_preserves_ui_tags_key():
     model_data, _layout_data = _split_model_and_layout(content)
 
     users_entity = next(e for e in model_data["entities"] if e["id"] == "users")
-    assert users_entity["dbt_tags"] == ["nightly"]
+    assert get_framework_tags(users_entity) == ["nightly"]
     assert users_entity["ui_tags"] == ["pii"]
 
     orders_entity = next(e for e in model_data["entities"] if e["id"] == "orders")
-    assert orders_entity["dbt_tags"] == ["nightly"]
+    assert get_framework_tags(orders_entity) == ["nightly"]
     assert "ui_tags" not in orders_entity
 
 
@@ -503,8 +583,8 @@ def test_split_preserves_bound_entity_dbt_tags_when_omitted_by_autosave():
     )
 
     users_entity = model_data["entities"][0]
-    assert users_entity["dbt_tags"] == ["nightly", "customer_360"], (
-        f"bound entity's reconcile-owned dbt_tags were wiped on autosave; got: {users_entity.get('dbt_tags')}"
+    assert get_framework_tags(users_entity) == ["nightly", "customer_360"], (
+        f"bound entity's reconcile-owned dbt_tags were wiped on autosave; got: {get_framework_tags(users_entity)}"
     )
     assert users_entity["ui_tags"] == ["pii"]
 

--- a/trellis_datamodel/tests/test_data_model.py
+++ b/trellis_datamodel/tests/test_data_model.py
@@ -4,6 +4,8 @@ import os
 import yaml
 import pytest
 
+from trellis_datamodel.tests._entity_compat import get_model_ref, get_framework_tags
+
 
 class TestGetDataModel:
     """Tests for GET /api/data-model endpoint."""
@@ -564,3 +566,126 @@ def test_split_does_not_preserve_tags_for_unbound_entity_when_omitted():
     assert "tags" not in entity, (
         f"unbound entity's intentionally-cleared tags were resurrected; got: {entity.get('tags')}"
     )
+
+
+def test_autosave_omitting_mirrored_tags_does_not_clear_them():
+    """A bound entity's framework-mirrored tags are reconcile-owned: auto-save
+    never sends them (only ui_tags). Omitting the key on save must not clear
+    the previously-reconciled tags already on disk."""
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    existing_model_data = {
+        "entities": [
+            {
+                "id": "users",
+                "dbt_model": "model.proj.users",
+                "dbt_tags": ["nightly", "customer_360"],
+            },
+        ]
+    }
+
+    # Exactly what auto-save.ts sends for a bound entity: ui_tags only, no
+    # mirrored-tags key at all.
+    incoming_content = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "ui_tags": ["pii"],
+                "position": {"x": 0, "y": 0},
+            },
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(
+        incoming_content, existing_model_data
+    )
+
+    entity = model_data["entities"][0]
+    assert get_model_ref(entity) == "model.proj.users"
+    assert get_framework_tags(entity) == ["nightly", "customer_360"], (
+        "bound entity's reconcile-owned mirrored tags were wiped on autosave; "
+        f"got: {get_framework_tags(entity)}"
+    )
+    assert entity["ui_tags"] == ["pii"]
+
+
+def test_autosave_omitting_tags_does_clear_them():
+    """An unbound entity's `tags` field is freely editable — there is no
+    schema.yml to reconcile against. Omitting the key on save (how auto-save.ts
+    signals the user cleared all tags) must genuinely clear it, not resurrect
+    the previous value from disk."""
+    from trellis_datamodel.routes.data_model import _split_model_and_layout
+
+    existing_model_data = {
+        "entities": [
+            {"id": "draft_entity", "tags": ["old-draft-tag"]},
+        ]
+    }
+
+    incoming_content = {
+        "version": 0.1,
+        "entities": [
+            {"id": "draft_entity", "label": "Draft Entity", "position": {"x": 0, "y": 0}},
+        ],
+        "relationships": [],
+    }
+
+    model_data, _layout_data = _split_model_and_layout(
+        incoming_content, existing_model_data
+    )
+
+    entity = model_data["entities"][0]
+    assert get_model_ref(entity) is None
+    assert "tags" not in entity, (
+        f"unbound entity's intentionally-cleared tags were resurrected; got: {entity.get('tags')}"
+    )
+
+
+def test_get_data_model_computes_display_tags_for_bound_and_unbound(
+    test_client, temp_data_model_path
+):
+    """GET /api/data-model computes display tags as the union of
+    framework-mirrored tags + ui_tags for bound entities, and passes through
+    the entity's own `tags` field unchanged for unbound entities — without
+    persisting the computed value back to disk."""
+    model_data = {
+        "version": 0.1,
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "dbt_model": "model.proj.users",
+                "dbt_tags": ["nightly", "customer_360"],
+                "ui_tags": ["pii"],
+            },
+            {"id": "draft", "label": "Draft", "tags": ["draft-tag"]},
+        ],
+        "relationships": [],
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.dump(model_data, f)
+
+    response = test_client.get("/api/data-model")
+    assert response.status_code == 200
+    entities = response.json()["entities"]
+
+    users = next(e for e in entities if e["id"] == "users")
+    assert get_model_ref(users) == "model.proj.users"
+    assert users["tags"] == ["nightly", "customer_360", "pii"]
+
+    draft = next(e for e in entities if e["id"] == "draft")
+    assert get_model_ref(draft) is None
+    assert draft["tags"] == ["draft-tag"]
+
+    with open(temp_data_model_path, "r") as f:
+        on_disk = yaml.safe_load(f)
+    on_disk_users = next(e for e in on_disk["entities"] if e["id"] == "users")
+    on_disk_draft = next(e for e in on_disk["entities"] if e["id"] == "draft")
+    assert "tags" not in on_disk_users, (
+        "computed display tags must never be written back to data_model.yml"
+    )
+    assert on_disk_draft["tags"] == ["draft-tag"]

--- a/trellis_datamodel/tests/test_datamodel_roundtrip_golden.py
+++ b/trellis_datamodel/tests/test_datamodel_roundtrip_golden.py
@@ -13,6 +13,8 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
+import pytest
+
 from trellis_datamodel import config as cfg
 from trellis_datamodel.routes.data_model import load_data_model_raw, save_data_model_raw
 
@@ -39,7 +41,11 @@ def _normalize_entity(entity: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def test_dbt_demo_data_model_loads_and_roundtrips_semantically(monkeypatch, tmp_path):
-    assert DBT_DEMO_DATA_MODEL.exists(), f"expected fixture at {DBT_DEMO_DATA_MODEL}"
+    # dbt_demo/ is gitignored (local-only sample project) and is not present
+    # in a fresh CI checkout; skip rather than fail when it's absent, matching
+    # the convention in test_demo_origin_fixtures.py.
+    if not DBT_DEMO_DATA_MODEL.exists():
+        pytest.skip(f"dbt_demo fixture not present at {DBT_DEMO_DATA_MODEL}")
 
     # Load the original fixture through the real load path.
     monkeypatch.setattr(cfg, "DATA_MODEL_PATH", str(DBT_DEMO_DATA_MODEL))

--- a/trellis_datamodel/tests/test_datamodel_roundtrip_golden.py
+++ b/trellis_datamodel/tests/test_datamodel_roundtrip_golden.py
@@ -1,0 +1,75 @@
+"""Golden characterization test for data_model.yml round-tripping.
+
+Locks current load/save behavior for `dbt_demo/data_model.yml` before the
+planned `dbt_model` -> `model_ref` / `dbt_tags` -> `framework_tags` rename
+(see specs/2026-07-31-generalize-transformation-adapter/). This test must
+keep passing across that rename: `_normalize_entity` below is the single
+place allowed to know both the old and new key literals.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from trellis_datamodel import config as cfg
+from trellis_datamodel.routes.data_model import load_data_model_raw, save_data_model_raw
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DBT_DEMO_DATA_MODEL = REPO_ROOT / "dbt_demo" / "data_model.yml"
+
+
+def _normalize_entity(entity: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize an entity dict to a rename-agnostic semantic shape.
+
+    This is the ONE place in this test file allowed to reference the raw
+    key literals (`model_ref`/`dbt_model`, `framework_tags`/`dbt_tags`).
+    Everything else in this file must assert only on the normalized form.
+    """
+    return {
+        "model_binding": entity.get("model_ref") or entity.get("dbt_model"),
+        "framework_tags": entity.get("framework_tags") or entity.get("dbt_tags"),
+        "ui_tags": entity.get("ui_tags"),
+        "additional_models": entity.get("additional_models"),
+        "drafted_fields": entity.get("drafted_fields"),
+        "entity_type": entity.get("entity_type"),
+        "description": entity.get("description"),
+    }
+
+
+def test_dbt_demo_data_model_loads_and_roundtrips_semantically(monkeypatch, tmp_path):
+    assert DBT_DEMO_DATA_MODEL.exists(), f"expected fixture at {DBT_DEMO_DATA_MODEL}"
+
+    # Load the original fixture through the real load path.
+    monkeypatch.setattr(cfg, "DATA_MODEL_PATH", str(DBT_DEMO_DATA_MODEL))
+    original_model = load_data_model_raw()
+
+    original_entities = original_model.get("entities") or []
+    assert original_entities, "expected at least one entity in dbt_demo/data_model.yml"
+
+    original_by_id = {
+        entity["id"]: _normalize_entity(entity) for entity in original_entities
+    }
+
+    # Save to a temp path via the real save path, then reload through the
+    # real load path again.
+    temp_path = tmp_path / "data_model.yml"
+    monkeypatch.setattr(cfg, "DATA_MODEL_PATH", str(temp_path))
+    save_data_model_raw(original_model)
+
+    assert os.path.exists(temp_path)
+
+    reloaded_model = load_data_model_raw()
+    reloaded_entities = reloaded_model.get("entities") or []
+
+    reloaded_by_id = {
+        entity["id"]: _normalize_entity(entity) for entity in reloaded_entities
+    }
+
+    assert set(reloaded_by_id.keys()) == set(original_by_id.keys())
+
+    for entity_id, original_normalized in original_by_id.items():
+        assert reloaded_by_id[entity_id] == original_normalized, (
+            f"entity {entity_id!r} changed semantically after round-trip"
+        )

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -2585,3 +2585,83 @@ class TestModelSchemaVersionHandling:
         assert v2_cols[0]["description"] == "Updated PK"
         assert versions[2].get("config", {}).get("tags") == ["core"]
         assert updated["models"][0]["latest_version"] == 2
+
+
+class TestFrameworkNeutralSchemaEndpoints:
+    """Framework-neutral /api/schema and /api/sync-tests must behave
+    identically to their legacy /api/dbt-schema and /api/sync-dbt-tests
+    counterparts. Both path sets must keep working (frontend still calls
+    the legacy paths until Sprint 5)."""
+
+    def _write_users_model(self, temp_dir):
+        sql_dir = os.path.join(temp_dir, "models", "3_core")
+        os.makedirs(sql_dir, exist_ok=True)
+        with open(os.path.join(sql_dir, "users.yml"), "w") as f:
+            yaml.dump({"version": 2, "models": [{"name": "users", "columns": []}]}, f)
+        return sql_dir
+
+    @staticmethod
+    def _write_data_model(temp_data_model_path):
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {"id": "users", "label": "Users", "position": {"x": 0, "y": 0}},
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+    def test_new_framework_endpoints_respond(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        self._write_users_model(temp_dir)
+        self._write_data_model(temp_data_model_path)
+
+        response = test_client.post(
+            "/api/schema",
+            json={
+                "entity_id": "users",
+                "model_name": "users",
+                "fields": [
+                    {"name": "id", "datatype": "int", "description": "Primary key"}
+                ],
+            },
+        )
+        assert response.status_code == 200
+        with open(response.json()["file_path"], "r") as f:
+            schema = yaml.safe_load(f)
+        col = schema["models"][0]["columns"][0]
+        assert col["name"] == "id"
+        assert col["description"] == "Primary key"
+
+        sync_response = test_client.post("/api/sync-tests")
+        assert sync_response.status_code == 200
+        assert sync_response.json()["status"] == "success"
+
+    def test_legacy_dbt_endpoints_still_respond(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        self._write_users_model(temp_dir)
+        self._write_data_model(temp_data_model_path)
+
+        response = test_client.post(
+            "/api/dbt-schema",
+            json={
+                "entity_id": "users",
+                "model_name": "users",
+                "fields": [
+                    {"name": "id", "datatype": "int", "description": "Primary key"}
+                ],
+            },
+        )
+        assert response.status_code == 200
+        with open(response.json()["file_path"], "r") as f:
+            schema = yaml.safe_load(f)
+        col = schema["models"][0]["columns"][0]
+        assert col["name"] == "id"
+        assert col["description"] == "Primary key"
+
+        sync_response = test_client.post("/api/sync-dbt-tests")
+        assert sync_response.status_code == 200
+        assert sync_response.json()["status"] == "success"

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -462,6 +462,70 @@ def test_round_trip_demo_origin(monkeypatch, temp_dir):
     assert read_col.get("description") == "Net sales"
 
 
+class TestFrameworkNeutralServiceFunctionNames:
+    """save_dbt_schema/sync_dbt_tests were renamed to framework-neutral names
+    (save_model_schema_from_request/sync_framework_tests). These tests call
+    the new names directly and assert they produce the same results as the
+    equivalent HTTP-level tests below."""
+
+    def test_save_model_schema_from_request_creates_schema_file(
+        self, test_client, temp_dir
+    ):
+        from trellis_datamodel.services.schema import save_model_schema_from_request
+
+        output_path = save_model_schema_from_request(
+            entity_id="users",
+            model_name="users",
+            fields=[
+                {"name": "id", "datatype": "int"},
+                {"name": "email", "datatype": "text", "description": "User email"},
+            ],
+            description="User entity",
+        )
+
+        with open(output_path, "r") as f:
+            schema = yaml.safe_load(f)
+
+        assert schema["version"] == 2
+        assert len(schema["models"]) == 1
+        model = schema["models"][0]
+        assert model["name"] == "users"
+        assert model["description"] == "User entity"
+        assert len(model["columns"]) == 2
+
+    def test_sync_framework_tests_syncs_relationship_tests(
+        self, test_client, temp_dir, temp_data_model_path
+    ):
+        from trellis_datamodel.services.schema import sync_framework_tests
+
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {"id": "users", "label": "Users", "position": {"x": 0, "y": 0}},
+                {
+                    "id": "orders",
+                    "label": "Orders",
+                    "position": {"x": 100, "y": 0},
+                    "drafted_fields": [{"name": "user_id", "datatype": "int"}],
+                },
+            ],
+            "relationships": [
+                {
+                    "source": "users",
+                    "target": "orders",
+                    "type": "one_to_many",
+                    "source_field": "id",
+                    "target_field": "user_id",
+                }
+            ],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        updated_files = sync_framework_tests()
+        assert len(updated_files) == 2  # One for each entity
+
+
 class TestSaveDbtSchema:
     """Tests for POST /api/dbt-schema endpoint."""
 

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -493,6 +493,44 @@ class TestSaveDbtSchema:
         assert model["description"] == "User entity"
         assert len(model["columns"]) == 2
 
+    def test_save_model_schema_path_for_entity_using_generic_model_ref(
+        self, test_client, temp_dir, temp_data_model_path
+    ):
+        """When an entity is bound using ONLY the generic `model_ref` key (no
+        legacy `dbt_model`), save_dbt_schema must still recognize the binding
+        and resolve the schema file name/path from the bound model, not from
+        whatever (possibly stale) model_name the caller passed in."""
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "model_ref": "model.project.users_v2",
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        request_data = {
+            "entity_id": "users",
+            "model_name": "stale_wrong_name",
+            "fields": [{"name": "id", "datatype": "int"}],
+        }
+        response = test_client.post("/api/dbt-schema", json=request_data)
+        assert response.status_code == 200
+
+        result = response.json()
+        # The bound model name (derived from model_ref, project-prefix
+        # stripped) must win over the caller-supplied model_name.
+        assert os.path.basename(result["file_path"]) == "users_v2.yml"
+
+        with open(result["file_path"], "r") as f:
+            schema = yaml.safe_load(f)
+        assert schema["models"][0]["name"] == "users_v2"
+
     def test_push_is_non_destructive_for_unlisted_columns(
         self, test_client, temp_dir, mock_manifest
     ):
@@ -1308,6 +1346,102 @@ class TestSyncDbtTests:
         assert len(rel_tests) == 1
         assert "relationships" in rel_tests[0]
         assert rel_tests[0]["relationships"]["arguments"]["to"] == "ref('cool_stuff')"
+
+    def test_sync_relationships_resolves_entity_bound_via_generic_model_ref(
+        self, test_client, temp_dir, temp_data_model_path, mock_manifest
+    ):
+        """Entities bound using ONLY the generic `model_ref` key (no legacy
+        `dbt_model`) must still resolve correctly: the FK column's relationship
+        test must reference the bound dbt model name (derived from model_ref),
+        and the schema file must be written to the manifest-derived nested
+        path for the FK-holding entity, not a fallback top-level file."""
+        manifest_data = {
+            "nodes": {
+                "model.project.dim_customers": {
+                    "unique_id": "model.project.dim_customers",
+                    "resource_type": "model",
+                    "name": "dim_customers",
+                    "original_file_path": "models/3_core/dim_customers.sql",
+                    "columns": {},
+                    "config": {},
+                    "tags": [],
+                },
+                "model.project.orders": {
+                    "unique_id": "model.project.orders",
+                    "resource_type": "model",
+                    "name": "orders",
+                    "original_file_path": "models/3_core/orders.sql",
+                    "columns": {},
+                    "config": {},
+                    "tags": [],
+                },
+            }
+        }
+        with open(mock_manifest, "w") as f:
+            json.dump(manifest_data, f)
+
+        sql_dir = os.path.join(temp_dir, "models", "3_core")
+        os.makedirs(sql_dir, exist_ok=True)
+        for name in ("dim_customers", "orders"):
+            with open(os.path.join(sql_dir, f"{name}.sql"), "w") as f:
+                f.write("SELECT 1")
+
+        orders_yml = os.path.join(sql_dir, "orders.yml")
+        with open(orders_yml, "w") as f:
+            yaml.dump({"version": 2, "models": [{"name": "orders", "columns": []}]}, f)
+
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "cust",
+                    "label": "Customers",
+                    "model_ref": "model.project.dim_customers",
+                },
+                {
+                    "id": "orders",
+                    "label": "Orders",
+                    "model_ref": "model.project.orders",
+                    "drafted_fields": [{"name": "customer_id", "datatype": "int"}],
+                },
+            ],
+            "relationships": [
+                {
+                    "source": "cust",
+                    "target": "orders",
+                    "type": "one_to_many",
+                    "source_field": "id",
+                    "target_field": "customer_id",
+                }
+            ],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        response = test_client.post("/api/sync-dbt-tests")
+        assert response.status_code == 200
+
+        # The FK-holding entity ("orders") is bound via model_ref only, so the
+        # nested manifest-derived yml path must be updated in place.
+        with open(orders_yml, "r") as f:
+            saved = yaml.safe_load(f)
+        col = next(
+            c for c in saved["models"][0]["columns"] if c["name"] == "customer_id"
+        )
+        rel_tests = col["data_tests"]
+        assert len(rel_tests) == 1
+        # The ref entity ("cust") is bound via model_ref to "dim_customers",
+        # which differs from its entity id — proving model_ref (not just the
+        # entity id) was used to resolve the dbt model name.
+        assert (
+            rel_tests[0]["relationships"]["arguments"]["to"]
+            == "ref('dim_customers')"
+        )
+
+        # A stray top-level fallback file must NOT have been created, which
+        # would indicate the model_ref-only binding wasn't recognized.
+        fallback_path = os.path.join(temp_dir, "models", "orders.yml")
+        assert not os.path.exists(fallback_path)
 
 
 def test_sync_relationships_preserves_dbt_only_tag_when_pushing_trellis_tag(

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -38,9 +38,9 @@ def test_materialize_writes_meta_origin(test_client, temp_dir, mock_manifest, or
         {"DH2": "CBUS.AMOUNT"},
     ]
 
-    # Site 2: POST /api/dbt-schema
+    # Site 2: POST /api/schema
     response = test_client.post(
-        "/api/dbt-schema",
+        "/api/schema",
         json={
             "entity_id": "sales",
             "model_name": "sales",
@@ -96,7 +96,7 @@ def test_sync_dbt_tests_writes_meta_origin(
     with open(temp_data_model_path, "w") as f:
         yaml.dump(data_model, f)
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     yml_path = os.path.join(sql_dir, "users.yml")
@@ -172,7 +172,7 @@ def test_push_to_dbt_preserves_native_column_type(
     with open(temp_data_model_path, "w") as f:
         yaml.dump(data_model, f)
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     yml_path = os.path.join(sql_dir, "users.yml")
@@ -241,7 +241,7 @@ def test_push_to_dbt_does_not_overwrite_with_catalog_normalized_type(
     with open(temp_data_model_path, "w") as f:
         yaml.dump(data_model, f)
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     yml_path = os.path.join(sql_dir, "users.yml")
@@ -294,7 +294,7 @@ def test_push_to_dbt_backfills_missing_type_for_new_dbt_column(
     with open(temp_data_model_path, "w") as f:
         yaml.dump(data_model, f)
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     yml_path = os.path.join(sql_dir, "users.yml")
@@ -341,7 +341,7 @@ def test_push_to_dbt_does_not_canonicalize_ambiguous_number_type(
     with open(temp_data_model_path, "w") as f:
         yaml.dump(data_model, f)
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     yml_path = os.path.join(sql_dir, "users.yml")
@@ -527,7 +527,7 @@ class TestFrameworkNeutralServiceFunctionNames:
 
 
 class TestSaveDbtSchema:
-    """Tests for POST /api/dbt-schema endpoint."""
+    """Tests for POST /api/schema endpoint."""
 
     def test_creates_schema_file(self, test_client, temp_dir):
         request_data = {
@@ -539,7 +539,7 @@ class TestSaveDbtSchema:
             ],
             "description": "User entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         result = response.json()
@@ -583,7 +583,7 @@ class TestSaveDbtSchema:
             "model_name": "stale_wrong_name",
             "fields": [{"name": "id", "datatype": "int"}],
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         result = response.json()
@@ -626,7 +626,7 @@ class TestSaveDbtSchema:
 
         # Push only id + name — legacy_col must survive
         response = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "users",
                 "model_name": "users",
@@ -739,7 +739,7 @@ class TestSaveDbtSchema:
             "tags": ["core"],
         }
 
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         with open(yml_path, "r") as f:
@@ -787,7 +787,7 @@ class TestSaveDbtSchema:
             yaml.dump(data_model, f)
 
         response = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "orders",
                 "model_name": "orders",
@@ -835,7 +835,7 @@ class TestSaveDbtSchema:
             yaml.dump(data_model, f)
 
         response = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "passports",
                 "model_name": "passports",
@@ -883,7 +883,7 @@ class TestSaveDbtSchema:
             yaml.dump(data_model_with_rel, f)
 
         response = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "orders",
                 "model_name": "orders",
@@ -911,7 +911,7 @@ class TestSaveDbtSchema:
             yaml.dump(data_model_no_rel, f)
 
         response2 = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "orders",
                 "model_name": "orders",
@@ -930,7 +930,7 @@ class TestSaveDbtSchema:
 
 
 class TestSyncDbtTests:
-    """Tests for POST /api/sync-dbt-tests endpoint."""
+    """Tests for POST /api/sync-tests endpoint."""
 
     def test_syncs_relationship_tests(
         self, test_client, temp_dir, temp_data_model_path
@@ -960,7 +960,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         result = response.json()
@@ -1016,7 +1016,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         with open(yml_path, "r") as f:
@@ -1072,7 +1072,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # fct_orders.yml should have the relationship test (FK on target)
@@ -1133,7 +1133,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # orders.yml should contain a relationship test pointing to customers (dbt model name)
@@ -1189,7 +1189,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # orders.yml should contain a relationship test (FK is on source/orders)
@@ -1267,7 +1267,7 @@ class TestSyncDbtTests:
             yaml.dump(data_model, f)
 
         # First sync: FK should be on orders
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         orders_yml = os.path.join(temp_dir, "models", "3_core", "orders.yml")
@@ -1294,7 +1294,7 @@ class TestSyncDbtTests:
             yaml.dump(data_model, f)
 
         # Second sync: FK should move to orders, old FK on customers should be removed
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # Verify orders.yml still has the test (FK is still on orders, just different semantics)
@@ -1363,7 +1363,7 @@ class TestSyncDbtTests:
             yaml.dump(data_model, f)
 
         # Initial sync: FK should be on cool_stuff
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         cool_stuff_yml = os.path.join(temp_dir, "models", "3_core", "cool_stuff.yml")
@@ -1383,7 +1383,7 @@ class TestSyncDbtTests:
             yaml.dump(data_model, f)
 
         # Second sync: FK should move to department, stale test removed from cool_stuff
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # Verify cool_stuff.yml no longer has the relationship test
@@ -1482,7 +1482,7 @@ class TestSyncDbtTests:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/sync-dbt-tests")
+        response = test_client.post("/api/sync-tests")
         assert response.status_code == 200
 
         # The FK-holding entity ("orders") is bound via model_ref only, so the
@@ -1544,7 +1544,7 @@ def test_sync_relationships_preserves_dbt_only_tag_when_pushing_trellis_tag(
             f,
         )
 
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
 
     with open(yml_path, "r") as f:
@@ -1588,7 +1588,7 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
         )
 
     # Push: pii added, nightly must survive
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
     with open(yml_path, "r") as f:
         after_add = yaml.safe_load(f)["models"][0]["tags"]
@@ -1606,7 +1606,7 @@ def test_full_round_trip_dbt_tag_survives_trellis_add_push_is_additive_only(
             },
             f,
         )
-    response = test_client.post("/api/sync-dbt-tests")
+    response = test_client.post("/api/sync-tests")
     assert response.status_code == 200
     with open(yml_path, "r") as f:
         after_second_push = yaml.safe_load(f)["models"][0]["tags"]
@@ -2229,7 +2229,7 @@ class TestEntityPrefixApplication:
             "fields": [{"name": "id", "datatype": "int"}],
             "description": "Customer entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         # Verify prefix was applied in saved schema
@@ -2301,7 +2301,7 @@ class TestEntityPrefixApplication:
             "fields": [{"name": "order_id", "datatype": "int"}],
             "description": "Order entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         # Verify no double prefix in saved schema
@@ -2351,7 +2351,7 @@ class TestEntityPrefixApplication:
             "fields": [{"name": "id", "datatype": "int"}],
             "description": "Customer entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         # Verify no double prefix (case-insensitive match)
@@ -2405,7 +2405,7 @@ class TestEntityPrefixApplication:
             "fields": [{"name": "product_id", "datatype": "int"}],
             "description": "Product entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         # Verify first prefix was applied
@@ -2455,7 +2455,7 @@ class TestEntityPrefixApplication:
             "fields": [{"name": "category_id", "datatype": "int"}],
             "description": "Category entity",
         }
-        response = test_client.post("/api/dbt-schema", json=request_data)
+        response = test_client.post("/api/schema", json=request_data)
         assert response.status_code == 200
 
         # Verify no prefix was applied
@@ -2588,10 +2588,9 @@ class TestModelSchemaVersionHandling:
 
 
 class TestFrameworkNeutralSchemaEndpoints:
-    """Framework-neutral /api/schema and /api/sync-tests must behave
-    identically to their legacy /api/dbt-schema and /api/sync-dbt-tests
-    counterparts. Both path sets must keep working (frontend still calls
-    the legacy paths until Sprint 5)."""
+    """Framework-neutral /api/schema and /api/sync-tests endpoints work
+    end-to-end. The legacy /api/dbt-schema and /api/sync-dbt-tests aliases
+    were removed in Sprint 6 once the frontend fully migrated."""
 
     def _write_users_model(self, temp_dir):
         sql_dir = os.path.join(temp_dir, "models", "3_core")
@@ -2636,32 +2635,5 @@ class TestFrameworkNeutralSchemaEndpoints:
         assert col["description"] == "Primary key"
 
         sync_response = test_client.post("/api/sync-tests")
-        assert sync_response.status_code == 200
-        assert sync_response.json()["status"] == "success"
-
-    def test_legacy_dbt_endpoints_still_respond(
-        self, test_client, temp_dir, mock_manifest, temp_data_model_path
-    ):
-        self._write_users_model(temp_dir)
-        self._write_data_model(temp_data_model_path)
-
-        response = test_client.post(
-            "/api/dbt-schema",
-            json={
-                "entity_id": "users",
-                "model_name": "users",
-                "fields": [
-                    {"name": "id", "datatype": "int", "description": "Primary key"}
-                ],
-            },
-        )
-        assert response.status_code == 200
-        with open(response.json()["file_path"], "r") as f:
-            schema = yaml.safe_load(f)
-        col = schema["models"][0]["columns"][0]
-        assert col["name"] == "id"
-        assert col["description"] == "Primary key"
-
-        sync_response = test_client.post("/api/sync-dbt-tests")
         assert sync_response.status_code == 200
         assert sync_response.json()["status"] == "success"

--- a/trellis_datamodel/tests/test_dbt_schema.py
+++ b/trellis_datamodel/tests/test_dbt_schema.py
@@ -426,7 +426,7 @@ def test_round_trip_demo_origin(monkeypatch, temp_dir):
         model_paths=["3-entity"],
     )
 
-    yml_path = adapter.save_dbt_schema(
+    yml_path = adapter.save_schema_file(
         entity_id=entity_id,
         model_name=model_name,
         fields=[

--- a/trellis_datamodel/tests/test_entity_keys.py
+++ b/trellis_datamodel/tests/test_entity_keys.py
@@ -1,5 +1,6 @@
 from trellis_datamodel.models.entity_keys import (
     get_model_ref, set_model_ref, get_framework_tags, set_framework_tags, has_legacy_keys,
+    get_native_data_type, set_native_data_type,
 )
 
 def test_get_model_ref_reads_new_key():
@@ -47,3 +48,25 @@ def test_set_framework_tags_writes_only_new_key_and_drops_legacy():
 def test_has_legacy_keys_detects_migration_need():
     assert has_legacy_keys({"dbt_model": "x"}) is True
     assert has_legacy_keys({"model_ref": "x"}) is False
+
+def test_get_native_data_type_reads_new_key():
+    assert get_native_data_type({"native_data_type": "varchar"}) == "varchar"
+
+def test_get_native_data_type_reads_legacy_dbt_data_type_key():
+    assert get_native_data_type({"dbt_data_type": "varchar"}) == "varchar"
+
+def test_get_native_data_type_prefers_new_key_even_when_new_key_is_none():
+    assert get_native_data_type({"native_data_type": None, "dbt_data_type": "stale"}) is None
+
+def test_get_native_data_type_none_when_absent():
+    assert get_native_data_type({}) is None
+
+def test_set_native_data_type_writes_only_new_key_and_drops_legacy():
+    field = {"dbt_data_type": "old", "name": "keep me"}
+    set_native_data_type(field, "varchar")
+    assert field == {"native_data_type": "varchar", "name": "keep me"}
+
+def test_set_native_data_type_none_clears_both_keys():
+    field = {"dbt_data_type": "old", "native_data_type": "newer"}
+    set_native_data_type(field, None)
+    assert field == {}

--- a/trellis_datamodel/tests/test_entity_keys.py
+++ b/trellis_datamodel/tests/test_entity_keys.py
@@ -1,0 +1,49 @@
+from trellis_datamodel.models.entity_keys import (
+    get_model_ref, set_model_ref, get_framework_tags, set_framework_tags, has_legacy_keys,
+)
+
+def test_get_model_ref_reads_new_key():
+    assert get_model_ref({"model_ref": "model.x.y"}) == "model.x.y"
+
+def test_get_model_ref_reads_legacy_dbt_model_key():
+    assert get_model_ref({"dbt_model": "model.x.y"}) == "model.x.y"
+
+def test_get_model_ref_prefers_new_key_even_when_new_key_is_none():
+    assert get_model_ref({"model_ref": None, "dbt_model": "stale"}) is None
+
+def test_get_model_ref_none_when_unbound():
+    assert get_model_ref({}) is None
+
+def test_set_model_ref_writes_only_new_key_and_drops_legacy():
+    entity = {"dbt_model": "old", "label": "keep me"}
+    set_model_ref(entity, "model.x.y")
+    assert entity == {"model_ref": "model.x.y", "label": "keep me"}
+
+def test_set_model_ref_none_clears_both_keys():
+    entity = {"dbt_model": "old", "model_ref": "newer"}
+    set_model_ref(entity, None)
+    assert entity == {}
+
+def test_get_framework_tags_reads_new_key():
+    assert get_framework_tags({"framework_tags": ["a"]}) == ["a"]
+
+def test_get_framework_tags_reads_legacy_dbt_tags_key():
+    assert get_framework_tags({"dbt_tags": ["a"]}) == ["a"]
+
+def test_get_framework_tags_prefers_new_key_even_when_empty():
+    assert get_framework_tags({"framework_tags": [], "dbt_tags": ["stale"]}) == []
+
+def test_get_framework_tags_returns_new_list_not_alias():
+    source = ["a"]
+    result = get_framework_tags({"framework_tags": source})
+    result.append("b")
+    assert source == ["a"]
+
+def test_set_framework_tags_writes_only_new_key_and_drops_legacy():
+    entity = {"dbt_tags": ["old"]}
+    set_framework_tags(entity, ["a", "b"])
+    assert entity == {"framework_tags": ["a", "b"]}
+
+def test_has_legacy_keys_detects_migration_need():
+    assert has_legacy_keys({"dbt_model": "x"}) is True
+    assert has_legacy_keys({"model_ref": "x"}) is False

--- a/trellis_datamodel/tests/test_entity_keys.py
+++ b/trellis_datamodel/tests/test_entity_keys.py
@@ -1,6 +1,6 @@
 from trellis_datamodel.models.entity_keys import (
     get_model_ref, set_model_ref, get_framework_tags, set_framework_tags, has_legacy_keys,
-    get_native_data_type, set_native_data_type,
+    get_physical_datatype, set_physical_datatype,
 )
 
 def test_get_model_ref_reads_new_key():
@@ -49,24 +49,24 @@ def test_has_legacy_keys_detects_migration_need():
     assert has_legacy_keys({"dbt_model": "x"}) is True
     assert has_legacy_keys({"model_ref": "x"}) is False
 
-def test_get_native_data_type_reads_new_key():
-    assert get_native_data_type({"native_data_type": "varchar"}) == "varchar"
+def test_get_physical_datatype_reads_new_key():
+    assert get_physical_datatype({"physical_datatype": "varchar"}) == "varchar"
 
-def test_get_native_data_type_reads_legacy_dbt_data_type_key():
-    assert get_native_data_type({"dbt_data_type": "varchar"}) == "varchar"
+def test_get_physical_datatype_reads_legacy_dbt_data_type_key():
+    assert get_physical_datatype({"dbt_data_type": "varchar"}) == "varchar"
 
-def test_get_native_data_type_prefers_new_key_even_when_new_key_is_none():
-    assert get_native_data_type({"native_data_type": None, "dbt_data_type": "stale"}) is None
+def test_get_physical_datatype_prefers_new_key_even_when_new_key_is_none():
+    assert get_physical_datatype({"physical_datatype": None, "dbt_data_type": "stale"}) is None
 
-def test_get_native_data_type_none_when_absent():
-    assert get_native_data_type({}) is None
+def test_get_physical_datatype_none_when_absent():
+    assert get_physical_datatype({}) is None
 
-def test_set_native_data_type_writes_only_new_key_and_drops_legacy():
+def test_set_physical_datatype_writes_only_new_key_and_drops_legacy():
     field = {"dbt_data_type": "old", "name": "keep me"}
-    set_native_data_type(field, "varchar")
-    assert field == {"native_data_type": "varchar", "name": "keep me"}
+    set_physical_datatype(field, "varchar")
+    assert field == {"physical_datatype": "varchar", "name": "keep me"}
 
-def test_set_native_data_type_none_clears_both_keys():
-    field = {"dbt_data_type": "old", "native_data_type": "newer"}
-    set_native_data_type(field, None)
+def test_set_physical_datatype_none_clears_both_keys():
+    field = {"dbt_data_type": "old", "physical_datatype": "newer"}
+    set_physical_datatype(field, None)
     assert field == {}

--- a/trellis_datamodel/tests/test_exceptions.py
+++ b/trellis_datamodel/tests/test_exceptions.py
@@ -54,7 +54,7 @@ def test_configuration_error_maps_to_400(test_client: TestClient, monkeypatch):
 
         # This should trigger ConfigurationError from path validation
         response = test_client.post(
-            "/api/dbt-schema",
+            "/api/schema",
             json={
                 "entity_id": "test",
                 "model_name": "test",

--- a/trellis_datamodel/tests/test_exposures.py
+++ b/trellis_datamodel/tests/test_exposures.py
@@ -135,3 +135,19 @@ def test_entity_ids_for_model_matches_primary_binding_and_additional_models():
 
     assert set(entity_ids) == {"orders", "sales_summary"}
     assert "customers" not in entity_ids
+
+
+def test_entity_ids_for_model_matches_entity_using_generic_model_ref():
+    """_find_entities_for_model must resolve the model binding via the
+    generic `model_ref` key, not just the legacy `dbt_model` key."""
+    data_model = {
+        "entities": [
+            {"id": "orders", "model_ref": "model.project.orders"},
+            {"id": "customers", "model_ref": "model.project.customers"},
+        ]
+    }
+
+    entity_ids = _find_entities_for_model("model.project.orders", data_model)
+
+    assert set(entity_ids) == {"orders"}
+    assert "customers" not in entity_ids

--- a/trellis_datamodel/tests/test_exposures.py
+++ b/trellis_datamodel/tests/test_exposures.py
@@ -6,7 +6,8 @@ import textwrap
 from pathlib import Path
 
 import trellis_datamodel.config as cfg
-from trellis_datamodel.services.exposures import get_exposures
+from trellis_datamodel.services.exposures import get_exposures, _find_entities_for_model
+from trellis_datamodel.tests._entity_compat import get_model_ref
 
 
 def _prepare_config(monkeypatch):
@@ -108,3 +109,29 @@ def test_exposures_api_returns_200_when_enabled(monkeypatch, tmp_path, test_clie
     data = response.json()
     assert "exposures" in data
     assert "entityUsage" in data
+
+
+def test_entity_ids_for_model_matches_primary_binding_and_additional_models():
+    """_find_entities_for_model matches entities bound via their primary
+    model reference as well as entities that merely list the model under
+    additional_models, and does not match unrelated entities."""
+    data_model = {
+        "entities": [
+            {"id": "orders", "dbt_model": "model.project.orders"},
+            {
+                "id": "sales_summary",
+                "dbt_model": "model.project.sales_summary",
+                "additional_models": ["model.project.orders"],
+            },
+            {"id": "customers", "dbt_model": "model.project.customers"},
+        ]
+    }
+
+    # Sanity check the fixture itself resolves through the compat helper.
+    orders_entity = data_model["entities"][0]
+    assert get_model_ref(orders_entity) == "model.project.orders"
+
+    entity_ids = _find_entities_for_model("model.project.orders", data_model)
+
+    assert set(entity_ids) == {"orders", "sales_summary"}
+    assert "customers" not in entity_ids

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -70,14 +70,14 @@ class TestReconcileDbtEndpoint:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "dbt_data_type": "integer",
+                            "native_data_type": "integer",
                             "description": "Primary key",
                             "source": "dbt",
                         },
                         {
                             "name": "name",
                             "datatype": "text",
-                            "dbt_data_type": "varchar",
+                            "native_data_type": "varchar",
                             "description": "Full name",
                             "source": "dbt",
                         },

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -6,6 +6,15 @@ import yaml
 import pytest
 
 
+def test_map_column_type_renamed_from_map_dbt_type():
+    """_map_dbt_type was renamed to the framework-neutral _map_column_type."""
+    from trellis_datamodel.services.reconciliation import _map_column_type
+
+    assert _map_column_type("bigint") == "int"
+    assert _map_column_type("varchar") == "text"
+    assert _map_column_type(None) == "unknown"
+
+
 class TestReconcileDbtEndpoint:
     """Tests for POST /api/reconcile-dbt."""
 
@@ -90,6 +99,41 @@ class TestReconcileDbtEndpoint:
         response = test_client.post("/api/reconcile-dbt")
         assert response.status_code == 200
         assert response.json()["changed"] is False
+
+    def test_reconcile_framework_function_matches_endpoint_behavior(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        """The framework-neutral `reconcile_framework()` service function
+        (renamed from `reconcile_dbt()`) is callable directly and produces
+        the same result as the /api/reconcile-dbt endpoint."""
+        from trellis_datamodel.services.reconciliation import reconcile_framework
+
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        result, changed = reconcile_framework()
+        assert changed is True
+
+        entities = result["entities"]
+        users = next(e for e in entities if e["id"] == "users")
+        fields = users["drafted_fields"]
+        assert len(fields) == 2
+        assert all(f["source"] == "dbt" for f in fields)
+        names = [f["name"] for f in fields]
+        assert "id" in names
+        assert "name" in names
 
     def test_absent_model_non_destructive(
         self, test_client, temp_dir, mock_manifest, temp_data_model_path

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -1,4 +1,4 @@
-"""Tests for POST /api/reconcile-dbt endpoint."""
+"""Tests for POST /api/reconcile endpoint."""
 
 import os
 import json
@@ -16,7 +16,7 @@ def test_map_column_type_renamed_from_map_dbt_type():
 
 
 class TestReconcileDbtEndpoint:
-    """Tests for POST /api/reconcile-dbt."""
+    """Tests for POST /api/reconcile."""
 
     def test_reconciles_bound_entity_from_manifest(
         self, test_client, temp_dir, mock_manifest, temp_data_model_path
@@ -38,7 +38,7 @@ class TestReconcileDbtEndpoint:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/reconcile-dbt")
+        response = test_client.post("/api/reconcile")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
@@ -89,14 +89,14 @@ class TestReconcileDbtEndpoint:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/reconcile-dbt")
+        response = test_client.post("/api/reconcile")
         assert response.status_code == 200
         assert response.json()["changed"] is False
 
     def test_noop_when_no_data_model(self, test_client, temp_dir, mock_manifest):
         """Missing data_model.yml is a no-op — endpoint succeeds without error."""
         # No data_model.yml written
-        response = test_client.post("/api/reconcile-dbt")
+        response = test_client.post("/api/reconcile")
         assert response.status_code == 200
         assert response.json()["changed"] is False
 
@@ -105,7 +105,7 @@ class TestReconcileDbtEndpoint:
     ):
         """The framework-neutral `reconcile_framework()` service function
         (renamed from `reconcile_dbt()`) is callable directly and produces
-        the same result as the /api/reconcile-dbt endpoint."""
+        the same result as the /api/reconcile endpoint."""
         from trellis_datamodel.services.reconciliation import reconcile_framework
 
         data_model = {
@@ -156,7 +156,7 @@ class TestReconcileDbtEndpoint:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        response = test_client.post("/api/reconcile-dbt")
+        response = test_client.post("/api/reconcile")
         assert response.status_code == 200
         data = response.json()
         assert data["changed"] is False
@@ -165,9 +165,9 @@ class TestReconcileDbtEndpoint:
 
 
 class TestFrameworkNeutralReconcileEndpoint:
-    """POST /api/reconcile (framework-neutral) must behave identically to
-    the legacy POST /api/reconcile-dbt. Both must keep working (frontend
-    still calls the legacy path until Sprint 5)."""
+    """POST /api/reconcile (framework-neutral) works end-to-end. The legacy
+    POST /api/reconcile-dbt alias was removed in Sprint 6 once the frontend
+    fully migrated."""
 
     @staticmethod
     def _write_data_model(temp_data_model_path):
@@ -192,25 +192,6 @@ class TestFrameworkNeutralReconcileEndpoint:
         self._write_data_model(temp_data_model_path)
 
         response = test_client.post("/api/reconcile")
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "success"
-        assert data["changed"] is True
-
-        entities = data["data_model"]["entities"]
-        users = next(e for e in entities if e["id"] == "users")
-        fields = users["drafted_fields"]
-        assert len(fields) == 2
-        names = [f["name"] for f in fields]
-        assert "id" in names
-        assert "name" in names
-
-    def test_legacy_dbt_endpoints_still_respond(
-        self, test_client, temp_dir, mock_manifest, temp_data_model_path
-    ):
-        self._write_data_model(temp_data_model_path)
-
-        response = test_client.post("/api/reconcile-dbt")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -162,3 +162,64 @@ class TestReconcileDbtEndpoint:
         assert data["changed"] is False
         fields = data["data_model"]["entities"][0]["drafted_fields"]
         assert fields == [{"name": "sku", "datatype": "text", "source": "dbt"}]
+
+
+class TestFrameworkNeutralReconcileEndpoint:
+    """POST /api/reconcile (framework-neutral) must behave identically to
+    the legacy POST /api/reconcile-dbt. Both must keep working (frontend
+    still calls the legacy path until Sprint 5)."""
+
+    @staticmethod
+    def _write_data_model(temp_data_model_path):
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+    def test_new_framework_endpoints_respond(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        self._write_data_model(temp_data_model_path)
+
+        response = test_client.post("/api/reconcile")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["changed"] is True
+
+        entities = data["data_model"]["entities"]
+        users = next(e for e in entities if e["id"] == "users")
+        fields = users["drafted_fields"]
+        assert len(fields) == 2
+        names = [f["name"] for f in fields]
+        assert "id" in names
+        assert "name" in names
+
+    def test_legacy_dbt_endpoints_still_respond(
+        self, test_client, temp_dir, mock_manifest, temp_data_model_path
+    ):
+        self._write_data_model(temp_data_model_path)
+
+        response = test_client.post("/api/reconcile-dbt")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["changed"] is True
+
+        entities = data["data_model"]["entities"]
+        users = next(e for e in entities if e["id"] == "users")
+        fields = users["drafted_fields"]
+        assert len(fields) == 2
+        names = [f["name"] for f in fields]
+        assert "id" in names
+        assert "name" in names

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -70,14 +70,14 @@ class TestReconcileDbtEndpoint:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "native_data_type": "integer",
+                            "physical_datatype": "integer",
                             "description": "Primary key",
                             "source": "dbt",
                         },
                         {
                             "name": "name",
                             "datatype": "text",
-                            "native_data_type": "varchar",
+                            "physical_datatype": "varchar",
                             "description": "Full name",
                             "source": "dbt",
                         },

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -6,7 +6,7 @@ from trellis_datamodel.services.reconciliation import (
     reconcile_entity_fields,
     reconcile_entity_tags,
     reconcile_data_model,
-    reconcile_dbt,
+    reconcile_framework,
     compute_display_tags,
 )
 from trellis_datamodel.tests._entity_compat import get_model_ref, get_framework_tags
@@ -547,7 +547,7 @@ class TestReconcileKeyGeneralization:
 
 
 class TestReconcileDbtIOWrapper:
-    """Characterization tests for the reconcile_dbt() IO wrapper (load manifest
+    """Characterization tests for the reconcile_framework() IO wrapper (load manifest
     + data_model.yml, reconcile, write back if changed). These exercise the
     full on-disk round trip via the real adapter, not just the pure function.
     """
@@ -555,7 +555,7 @@ class TestReconcileDbtIOWrapper:
     def test_reconcile_is_idempotent(
         self, test_client, mock_manifest, temp_data_model_path
     ):
-        """Running reconcile_dbt() twice against the mock manifest reports
+        """Running reconcile_framework() twice against the mock manifest reports
         changed=False on the second run and produces a byte-identical
         data_model.yml file on disk."""
         data_model = {
@@ -573,13 +573,13 @@ class TestReconcileDbtIOWrapper:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        first_result, first_changed = reconcile_dbt()
+        first_result, first_changed = reconcile_framework()
         assert first_changed is True
 
         with open(temp_data_model_path, "r") as f:
             file_contents_after_first = f.read()
 
-        second_result, second_changed = reconcile_dbt()
+        second_result, second_changed = reconcile_framework()
         assert second_changed is False
 
         with open(temp_data_model_path, "r") as f:
@@ -611,7 +611,7 @@ class TestReconcileDbtIOWrapper:
         with open(temp_data_model_path, "w") as f:
             yaml.dump(data_model, f)
 
-        result, changed = reconcile_dbt()
+        result, changed = reconcile_framework()
         assert changed is False
 
         entity = result["entities"][0]

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -1,12 +1,15 @@
 """Tests for the dbt reconciliation service."""
 
+import yaml
 import pytest
 from trellis_datamodel.services.reconciliation import (
     reconcile_entity_fields,
     reconcile_entity_tags,
     reconcile_data_model,
+    reconcile_dbt,
     compute_display_tags,
 )
+from trellis_datamodel.tests._entity_compat import get_model_ref, get_framework_tags
 
 
 class TestReconcileEntityFields:
@@ -464,3 +467,91 @@ class TestReconcileIdempotency:
         twice, changed_twice = reconcile_data_model(once, manifest_models)
         assert changed_twice is False
         assert twice == once
+
+
+class TestReconcileDbtIOWrapper:
+    """Characterization tests for the reconcile_dbt() IO wrapper (load manifest
+    + data_model.yml, reconcile, write back if changed). These exercise the
+    full on-disk round trip via the real adapter, not just the pure function.
+    """
+
+    def test_reconcile_is_idempotent(
+        self, test_client, mock_manifest, temp_data_model_path
+    ):
+        """Running reconcile_dbt() twice against the mock manifest reports
+        changed=False on the second run and produces a byte-identical
+        data_model.yml file on disk."""
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "users",
+                    "label": "Users",
+                    "dbt_model": "model.project.users",
+                    "drafted_fields": [],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        first_result, first_changed = reconcile_dbt()
+        assert first_changed is True
+
+        with open(temp_data_model_path, "r") as f:
+            file_contents_after_first = f.read()
+
+        second_result, second_changed = reconcile_dbt()
+        assert second_changed is False
+
+        with open(temp_data_model_path, "r") as f:
+            file_contents_after_second = f.read()
+
+        assert file_contents_after_second == file_contents_after_first
+        assert second_result == first_result
+
+    def test_reconcile_never_deletes_binding_for_model_absent_from_manifest(
+        self, test_client, mock_manifest, temp_data_model_path
+    ):
+        """An entity bound to a model id not present in the manifest survives
+        reconcile with its binding and its previously-mirrored tags intact."""
+        data_model = {
+            "version": 0.1,
+            "entities": [
+                {
+                    "id": "products",
+                    "label": "Products",
+                    "dbt_model": "model.project.products",  # not in mock_manifest
+                    "dbt_tags": ["legacy_mirrored_tag"],
+                    "drafted_fields": [
+                        {"name": "sku", "datatype": "text", "source": "dbt"}
+                    ],
+                }
+            ],
+            "relationships": [],
+        }
+        with open(temp_data_model_path, "w") as f:
+            yaml.dump(data_model, f)
+
+        result, changed = reconcile_dbt()
+        assert changed is False
+
+        entity = result["entities"][0]
+        assert get_model_ref(entity) == "model.project.products"
+        assert get_framework_tags(entity) == ["legacy_mirrored_tag"]
+        assert entity["drafted_fields"] == [
+            {"name": "sku", "datatype": "text", "source": "dbt"}
+        ]
+
+
+class TestComputeDisplayTagsUnionOrder:
+    def test_compute_display_tags_union_order_is_framework_then_ui_deduped(self):
+        """Display tags are the union of framework-mirrored tags then
+        user-added ui_tags, in that order, deduplicated."""
+        entity = {
+            "dbt_model": "model.proj.users",
+            "dbt_tags": ["nightly", "core"],
+            "ui_tags": ["core", "pii"],
+        }
+        assert compute_display_tags(entity) == ["nightly", "core", "pii"]

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -348,7 +348,7 @@ class TestReconcileDataModel:
             {"unique_id": "model.proj.users", "columns": [], "tags": ["nightly", "core"]},
         ]
         result, changed = reconcile_data_model(data_model, manifest_models)
-        assert result["entities"][0]["dbt_tags"] == ["nightly", "core"]
+        assert get_framework_tags(result["entities"][0]) == ["nightly", "core"]
         assert changed is True
 
     def test_reconcile_data_model_leaves_ui_tags_untouched(self):
@@ -386,7 +386,7 @@ class TestTagMigrationSeed:
         result, _ = reconcile_data_model(data_model, manifest_models)
         entity = result["entities"][0]
         assert entity["ui_tags"] == ["pii"]
-        assert entity["dbt_tags"] == ["nightly"]
+        assert get_framework_tags(entity) == ["nightly"]
         assert "tags" not in entity
 
     def test_seed_does_not_reapply_once_ui_tags_exists(self):
@@ -431,7 +431,7 @@ class TestTagMigrationSeed:
         assert "ui_tags" not in entity, (
             f"dbt-mirrored tags were wrongly seeded into ui_tags; got: {entity.get('ui_tags')}"
         )
-        assert entity["dbt_tags"] == ["sdh", "entity", "customer_360"]
+        assert get_framework_tags(entity) == ["sdh", "entity", "customer_360"]
         assert "tags" not in entity
 
 
@@ -467,6 +467,83 @@ class TestReconcileIdempotency:
         twice, changed_twice = reconcile_data_model(once, manifest_models)
         assert changed_twice is False
         assert twice == once
+
+
+class TestReconcileKeyGeneralization:
+    """Reconciliation must read/write the generic model_ref/framework_tags
+    keys via trellis_datamodel.models.entity_keys, migrating any
+    legacy dbt_model/dbt_tags keys it encounters."""
+
+    def test_reconcile_migrates_legacy_keys_to_generic_names(self):
+        """An entity built with legacy dbt_model/dbt_tags keys is migrated
+        to model_ref/framework_tags, with values unchanged (manifest agrees
+        with the existing data, isolating the key rename)."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "dbt_model": "model.project.users",
+                    "dbt_tags": ["nightly"],
+                    "drafted_fields": [
+                        {
+                            "name": "id",
+                            "datatype": "int",
+                            "dbt_data_type": "integer",
+                            "description": "PK",
+                            "source": "dbt",
+                        }
+                    ],
+                }
+            ]
+        }
+        manifest_models = [
+            {
+                "unique_id": "model.project.users",
+                "columns": [{"name": "id", "type": "integer", "description": "PK"}],
+                "tags": ["nightly"],
+            }
+        ]
+        result, _ = reconcile_data_model(data_model, manifest_models)
+        entity = result["entities"][0]
+
+        assert get_model_ref(entity) == "model.project.users"
+        assert get_framework_tags(entity) == ["nightly"]
+        assert "model_ref" in entity
+        assert "framework_tags" in entity
+        assert "dbt_model" not in entity
+        assert "dbt_tags" not in entity
+        assert entity["drafted_fields"] == data_model["entities"][0]["drafted_fields"]
+
+    def test_reconcile_on_already_migrated_entity_is_a_noop(self):
+        """An entity already using the generic key names reconciles to
+        changed=False when the manifest agrees with the existing data."""
+        data_model = {
+            "entities": [
+                {
+                    "id": "users",
+                    "model_ref": "model.project.users",
+                    "framework_tags": ["nightly"],
+                    "drafted_fields": [
+                        {
+                            "name": "id",
+                            "datatype": "int",
+                            "dbt_data_type": "integer",
+                            "description": "PK",
+                            "source": "dbt",
+                        }
+                    ],
+                }
+            ]
+        }
+        manifest_models = [
+            {
+                "unique_id": "model.project.users",
+                "columns": [{"name": "id", "type": "integer", "description": "PK"}],
+                "tags": ["nightly"],
+            }
+        ]
+        result, changed = reconcile_data_model(data_model, manifest_models)
+        assert changed is False
 
 
 class TestReconcileDbtIOWrapper:

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -55,8 +55,8 @@ class TestReconcileEntityFields:
         assert result[6]["datatype"] == "unknown"
 
     def test_preserves_native_dbt_type_alongside_bucket(self):
-        """The raw dbt/warehouse type is preserved in dbt_data_type, not just
-        collapsed into the coarse datatype bucket (#111)."""
+        """The raw dbt/warehouse type is preserved in native_data_type, not
+        just collapsed into the coarse datatype bucket (#111)."""
         result = reconcile_entity_fields(
             existing_fields=[],
             manifest_columns=[
@@ -64,7 +64,7 @@ class TestReconcileEntityFields:
             ],
         )
         assert result[0]["datatype"] == "text"
-        assert result[0]["dbt_data_type"] == "varchar"
+        assert result[0]["native_data_type"] == "varchar"
 
     def test_promotes_matching_draft(self):
         """A draft whose name matches a manifest column is promoted to source=dbt,
@@ -298,7 +298,7 @@ class TestReconcileDataModel:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "dbt_data_type": "integer",
+                            "native_data_type": "integer",
                             "description": "PK",
                             "source": "dbt",
                         }
@@ -477,7 +477,8 @@ class TestReconcileKeyGeneralization:
     def test_reconcile_migrates_legacy_keys_to_generic_names(self):
         """An entity built with legacy dbt_model/dbt_tags keys is migrated
         to model_ref/framework_tags, with values unchanged (manifest agrees
-        with the existing data, isolating the key rename)."""
+        with the existing data, isolating the key rename). The field-level
+        legacy dbt_data_type key is likewise migrated to native_data_type."""
         data_model = {
             "entities": [
                 {
@@ -512,7 +513,15 @@ class TestReconcileKeyGeneralization:
         assert "framework_tags" in entity
         assert "dbt_model" not in entity
         assert "dbt_tags" not in entity
-        assert entity["drafted_fields"] == data_model["entities"][0]["drafted_fields"]
+        assert entity["drafted_fields"] == [
+            {
+                "name": "id",
+                "datatype": "int",
+                "native_data_type": "integer",
+                "description": "PK",
+                "source": "dbt",
+            }
+        ]
 
     def test_reconcile_on_already_migrated_entity_is_a_noop(self):
         """An entity already using the generic key names reconciles to
@@ -527,7 +536,7 @@ class TestReconcileKeyGeneralization:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "dbt_data_type": "integer",
+                            "native_data_type": "integer",
                             "description": "PK",
                             "source": "dbt",
                         }

--- a/trellis_datamodel/tests/test_reconciliation.py
+++ b/trellis_datamodel/tests/test_reconciliation.py
@@ -55,7 +55,7 @@ class TestReconcileEntityFields:
         assert result[6]["datatype"] == "unknown"
 
     def test_preserves_native_dbt_type_alongside_bucket(self):
-        """The raw dbt/warehouse type is preserved in native_data_type, not
+        """The raw dbt/warehouse type is preserved in physical_datatype, not
         just collapsed into the coarse datatype bucket (#111)."""
         result = reconcile_entity_fields(
             existing_fields=[],
@@ -64,7 +64,7 @@ class TestReconcileEntityFields:
             ],
         )
         assert result[0]["datatype"] == "text"
-        assert result[0]["native_data_type"] == "varchar"
+        assert result[0]["physical_datatype"] == "varchar"
 
     def test_promotes_matching_draft(self):
         """A draft whose name matches a manifest column is promoted to source=dbt,
@@ -298,7 +298,7 @@ class TestReconcileDataModel:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "native_data_type": "integer",
+                            "physical_datatype": "integer",
                             "description": "PK",
                             "source": "dbt",
                         }
@@ -478,7 +478,7 @@ class TestReconcileKeyGeneralization:
         """An entity built with legacy dbt_model/dbt_tags keys is migrated
         to model_ref/framework_tags, with values unchanged (manifest agrees
         with the existing data, isolating the key rename). The field-level
-        legacy dbt_data_type key is likewise migrated to native_data_type."""
+        legacy dbt_data_type key is likewise migrated to physical_datatype."""
         data_model = {
             "entities": [
                 {
@@ -517,7 +517,7 @@ class TestReconcileKeyGeneralization:
             {
                 "name": "id",
                 "datatype": "int",
-                "native_data_type": "integer",
+                "physical_datatype": "integer",
                 "description": "PK",
                 "source": "dbt",
             }
@@ -536,7 +536,7 @@ class TestReconcileKeyGeneralization:
                         {
                             "name": "id",
                             "datatype": "int",
-                            "native_data_type": "integer",
+                            "physical_datatype": "integer",
                             "description": "PK",
                             "source": "dbt",
                         }

--- a/trellis_datamodel/tests/test_reconciliation_with_fake_adapter.py
+++ b/trellis_datamodel/tests/test_reconciliation_with_fake_adapter.py
@@ -1,0 +1,66 @@
+"""
+Proves TransformationAdapter is a real abstraction: reconciliation works
+against a FakeAdapter test double exactly as it does against DbtCoreAdapter,
+driven solely by the adapter's get_models() output.
+"""
+
+import yaml
+
+from trellis_datamodel.services.reconciliation import reconcile_framework
+
+
+def test_reconcile_framework_uses_fake_adapter_get_models(
+    monkeypatch, temp_data_model_path, fake_adapter
+):
+    """reconcile_framework() should reconcile using only get_models() from
+    whatever adapter get_adapter() returns — here, a FakeAdapter, not dbt."""
+    data_model = {
+        "entities": [
+            {
+                "id": "users",
+                "label": "Users",
+                "model_ref": "model.project.users",
+                "drafted_fields": [
+                    {"name": "id", "datatype": "int", "source": "draft"},
+                ],
+            }
+        ]
+    }
+    with open(temp_data_model_path, "w") as f:
+        yaml.safe_dump(data_model, f)
+
+    fake_adapter.models = [
+        {
+            "unique_id": "model.project.users",
+            "name": "users",
+            "version": None,
+            "schema": "public",
+            "table": "users",
+            "columns": [
+                {"name": "id", "type": "integer", "description": "Primary key"},
+                {"name": "email", "type": "varchar", "description": "Email address"},
+            ],
+            "description": "Users table",
+            "materialization": "table",
+            "file_path": "models/3_core/users.sql",
+            "tags": ["core"],
+        }
+    ]
+
+    import trellis_datamodel.adapters as adapters_module
+
+    monkeypatch.setattr(adapters_module, "get_adapter", lambda: fake_adapter)
+
+    reconciled, changed = reconcile_framework()
+
+    assert changed is True
+    fields = reconciled["entities"][0]["drafted_fields"]
+    names = [f["name"] for f in fields]
+    assert names == ["id", "email"]
+
+    email_field = next(f for f in fields if f["name"] == "email")
+    assert email_field["datatype"] == "text"
+    assert email_field["source"] == "dbt"
+    assert email_field["description"] == "Email address"
+
+    assert reconciled["entities"][0]["framework_tags"] == ["core"]


### PR DESCRIPTION
## Summary

Generalizes Trellis's hard-coded dbt-specific naming and branching logic so a second framework (Bruin) can be added by writing an adapter, not by re-threading if framework == "..." branches through every service file.

- Renamed dbt_model/dbt_tags entity fields to model_ref/framework_tags throughout data_model.yml, with permanent read-compat for old field names on disk (no user migration required)
- Removed direct dbt branching/naming from routes/data_model.py, services/reconciliation.py, services/schema.py, services/exposures.py, services/bus_matrix.py, adapters/dbt_core.py — all framework-specific behavior now goes through the TransformationAdapter protocol
- Closed the adapter-boundary loopholes: save_schema_file, infer_entity_types, get_model_dirs, reset_inference_cache are now declared on TransformationAdapter (previously called on adapter instances without being part of the protocol); no module outside adapters/ imports DbtCoreAdapter directly anymore
- Renamed dbt-named service functions and HTTP endpoints to framework-neutral names (reconcile_framework, sync_framework_tests, _map_column_type, /api/reconcile, /api/schema, /api/sync-tests); legacy paths were aliased during the transition and removed once the frontend migrated
- Added FrameworkEnum.BRUIN plus bruin_pipeline_path/bruin_asset_paths config scaffolding; the adapter factory raises a clear NotImplementedError for framework: bruin instead of silently falling through to dbt behavior
- Added a FakeAdapter test double proving reces work against a non-dbt adapter, not justDbtCoreAdapter
- Pinned the adapter-boundary gaps that are genuinely out of scope for this PR (lineage, exposures, manifest status, source-system extraction still read dbt artifacts directly) with @pytest.mark.xfail(strict=True) contract tests, so
they can't be silently forgotten or half-impr follow-up spec lands
igrated ~26 non-test frontend files (utils, exports, services, components, routes) to read entity bindings via a readModelRef/readFrameworkTags compat helper, then flipped the save path to write model_ref/framework_tags
- Renamed the dbtModels store to frameworkModels and pointed api.ts at the new endpoint paths
- Made the Sidebar's icon/label and the canvas drag MIME type framework-driven off the framework config value instead of assuming dbt; added a placeholder Bruin icon
- Generalized dbt_data_type to native_data_type with the same read-compat treatment
- Removed the transitional dual-key API emission shim and the deprecated dbt_model/dbt_tags frontend type fields now that both sides are fully migrated

## Out of scope

- Implementing BruinAdapter itself — deferre
- Routing services/lineage.py, services/exposures.py, services/manifest.py, routes/manifest.py, routes/data_model.py, routes/lineage.py through the adapter protocol (they still read dbt artifacts directly) — each is pinned by an xfail(strict=True) test in test_adapter_future_surface.py so it can't be silently skipped
- Config UI/wizard changes beyond icon and label switching
- Any change to the actual reconcile algorithm's behavior (one-way, idempotent, absence-is-never-deletion stay exactly
as-is)

## Test plan

- [x] uv run pytest — 471 passed, 5 xfailed (0 unexpected xpass), 0 failed
- [x] cd frontend && npm run check — 0 type errors
- [x] cd frontend && npm run test:unit -- --
- [x] grep -rn 'dbt_model\b\|dbt_tags\b' trellis_datamodel/routes trellis_datamodel/services — zero non-comment lines
- [x] grep -rn 'dbt' trellis_datamodel/route— remaining hits are only comments/docstrings or the intentionally-kept dbt-core config fields (dbt_project_path, dbt_manifest_path, dbt_catalog_path, dbt_model_paths, dbt_company_dummy_path)
- [x] grep -rn 'dbt_model\|dbt_tags' frontenmments or the permanent entity-compat.tsread-compat layer
- [x] uv run pytest trellis_datamodel/tests/.py -v — all pass, confirms no module outside adapters/ imports DbtCoreAdapter
- [x] uv run pytest trellis_datamodel/tests/test_adapter_future_surface.py -v — all XFAIL, zero XPASS
- [x] uv run pytest trellis_datamodel/tests/test_datamodel_roundtrip_golden.py -v — passes with fixture-only key updates, no assertion ever edited
- [x] Loaded dbt_demo/data_model.yml (legacy/save path — round-trips with no data loss,saves as model_ref/framework_tags