### PR TITLE
Fix/warehouse native datatype mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.21.1] - 2026-08-05
 
 ### Fixed
 - **Warehouse-native column types no longer land on `datatype: unknown`**: the reconcile type map only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Warehouse-native column types no longer land on `datatype: unknown`**: the reconcile type map only
+  knew Postgres-style spellings, so a Snowflake `NUMBER` or a BigQuery `BIGNUMERIC` fell through to
+  `unknown` even though the exact type sat right next to it in `physical_datatype`. Parameterized
+  types are now split before matching (`VARCHAR(16777216)` → `text`, `TIMESTAMP_NTZ(9)` →
+  `timestamp`), and the fixed-point families (`number`, `numeric`, `decimal`, `bignumeric`) are
+  scale-aware: an explicit scale of 0 is an `int`, anything else is a `float`. Collection and nested
+  types (`ARRAY`, `STRUCT<...>`, `VARIANT`, `int[]`) stay `unknown` on purpose rather than being
+  collapsed onto their element type. Existing `unknown` values are backfilled the next time
+  reconcile runs, which is on app load.
+
 ## [0.21.0] - 2026-08-03
 
 Adds Bruin as a second supported transformation framework, and finishes the adapter boundary the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.21.0"
+version = "0.21.1"
 description = "Visual data model editor for dbt and Bruin projects"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/trellis_datamodel/services/reconciliation.py
+++ b/trellis_datamodel/services/reconciliation.py
@@ -30,12 +30,37 @@ from trellis_datamodel.models.entity_keys import (
 # dbt type → DraftedField datatype mapping
 # ---------------------------------------------------------------------------
 
-_INT_PREFIXES = ("int", "bigint", "smallint", "tinyint", "serial", "integer")
-_FLOAT_PREFIXES = ("float", "double", "numeric", "decimal", "real", "money")
+_INT_PREFIXES = (
+    "int",
+    "bigint",
+    "smallint",
+    "tinyint",
+    "byteint",
+    "serial",
+    "bigserial",
+    "smallserial",
+    "integer",
+)
+_FLOAT_PREFIXES = ("float", "double", "real", "money")
 _BOOL_PREFIXES = ("bool",)
 _DATE_EXACT = {"date"}
 _TIMESTAMP_PREFIXES = ("timestamp", "datetime")
-_TEXT_PREFIXES = ("varchar", "char", "text", "string", "nvarchar", "nchar", "clob")
+_TEXT_PREFIXES = (
+    "varchar",
+    "char",
+    "text",
+    "string",
+    "nvarchar",
+    "nchar",
+    "clob",
+    "uuid",
+)
+
+# Fixed-point families whose bucket depends on the declared scale: a scale of 0
+# is an integer (Snowflake's NUMBER(38,0) is the canonical case), anything else
+# — including an unparameterized NUMBER, where the catalog does not report the
+# scale — is treated as float, the wider of the two buckets.
+_NUMERIC_BASES = ("number", "numeric", "decimal", "dec", "bignumeric")
 
 _ORIGIN_SEPARATOR = " | Origin: "
 _ORIGIN_PREFIX = "Origin: "
@@ -69,11 +94,37 @@ def _parse_description_with_origin(
     return raw_description, None
 
 
+def _split_column_type(column_type: str) -> tuple[str, list[str]]:
+    """Split a raw warehouse type into its lowercase base name and parameters.
+
+    "NUMBER(38,0)" -> ("number", ["38", "0"])
+    "VARCHAR(16777216)" -> ("varchar", ["16777216"])
+    "TIMESTAMP_NTZ" -> ("timestamp_ntz", [])
+
+    Collection wrappers (ARRAY, STRUCT<...>, "int[]") are deliberately left
+    intact so they fall through to "unknown" rather than being flattened to
+    the bucket of their element type.
+    """
+    t = column_type.lower().strip()
+    open_paren = t.find("(")
+    if open_paren == -1:
+        return t, []
+    base = t[:open_paren].strip()
+    inner = t[open_paren + 1 :].rstrip().removesuffix(")")
+    return base, [arg.strip() for arg in inner.split(",") if arg.strip()]
+
+
 def _map_column_type(column_type: str | None) -> str:
     """Map a framework/warehouse column type string to a DraftedField datatype enum value."""
     if not column_type:
         return "unknown"
-    t = column_type.lower().strip()
+    t, args = _split_column_type(column_type)
+    if t.endswith("[]") or t.startswith(("array", "struct", "map")) or "<" in t:
+        # Collection / nested types have no scalar bucket — don't collapse them
+        # onto their element type.
+        return "unknown"
+    if t in _NUMERIC_BASES:
+        return "int" if len(args) >= 2 and args[1] == "0" else "float"
     if t in _DATE_EXACT:
         return "date"
     for prefix in _TIMESTAMP_PREFIXES:

--- a/trellis_datamodel/tests/test_reconcile_api.py
+++ b/trellis_datamodel/tests/test_reconcile_api.py
@@ -15,6 +15,43 @@ def test_map_column_type_renamed_from_map_dbt_type():
     assert _map_column_type(None) == "unknown"
 
 
+@pytest.mark.parametrize(
+    "raw_type,expected",
+    [
+        # Snowflake catalog spellings — the bare NUMBER case that used to
+        # land on "unknown" despite a perfectly readable physical type.
+        ("NUMBER", "float"),
+        ("NUMBER(38,0)", "int"),
+        ("NUMBER(10,2)", "float"),
+        ("VARCHAR(16777216)", "text"),
+        ("TIMESTAMP_NTZ(9)", "timestamp"),
+        ("BOOLEAN", "bool"),
+        ("FLOAT", "float"),
+        # BigQuery
+        ("INT64", "int"),
+        ("FLOAT64", "float"),
+        ("NUMERIC", "float"),
+        ("BIGNUMERIC", "float"),
+        ("STRING", "text"),
+        ("DATE", "date"),
+        # Postgres / Redshift
+        ("numeric(12,4)", "float"),
+        ("character varying(50)", "text"),
+        ("bigserial", "int"),
+        ("uuid", "text"),
+        # Non-scalar types stay honest rather than guessing a bucket
+        ("VARIANT", "unknown"),
+        ("ARRAY", "unknown"),
+        ("int[]", "unknown"),
+    ],
+)
+def test_map_column_type_warehouse_spellings(raw_type, expected):
+    """Warehouse-native and parameterized types resolve to a logical bucket."""
+    from trellis_datamodel.services.reconciliation import _map_column_type
+
+    assert _map_column_type(raw_type) == expected
+
+
 class TestReconcileDbtEndpoint:
     """Tests for POST /api/reconcile."""
 


### PR DESCRIPTION
## Summary

Warehouse-native column types (Snowflake `NUMBER`, BigQuery `BIGNUMERIC`, parameterized types like `VARCHAR(16777216)`) no longer land on `datatype: unknown`. The reconcile type map only recognized Postgres-style spellings, so these valid warehouse types fell through even though the exact type was already captured in `physical_datatype` alongside them.

## Changes

**`trellis_datamodel/services/reconciliation.py`:**
- Added `_split_column_type()` to split a raw warehouse arameters, so parameterized types resolve correctly(`VARCHAR(16777216)` → `text`, `TIMESTAMP_NTZ(9)` → `timestamp`)
- Extended the type map with warehouse-native spellings: Snowflake (`NUMBER`, `BIGNUMERIC`), BigQuery (`INT64`, `FLOAT64`, `NUMERIC`), additional Postgres families (`byteint`, `bigserial`, `uuid`)
- Made the fixed-point families (`number`, `numeric`, `d scale-aware: explicit scale 0 → `int` (e.g. Snowflake's anything else → `float`. A bare `NUMBER` (where catalog doesn't report scale) takes `float` as the wider bucket
- Collection and nested types (`ARRAY`, `STRUCT<...>`, `VARIANT`, `int[]`) stay `unknown` deliberately — there is no scalar bucket that honestly represents them

**`trellis_datamodel/tests/test_reconcile_api.py`:**
- Added 20 parameterized test cases covering Snowflake, BigQuery, and Postgres/Redshift spellings

**Version:**
- 0.21.0 → 0.21.1 (bug fix, patch bump)

## Impact

Reconciliation is framework-neutral, so Bruin gets this via the same path. Existing `unknown` values are backfilled on the next reconcile pass, which runs on app load. No API, config, or schema change required.

## Testing

All 691 tests pass. New cases explicitly cover edge case)`, `NUMERIC(12,4)`, parameterized text types, andcollection types that should remain `unknown`.