### PR TITLE
Feat/enhance entity binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Model binding from the UI**: Users can search and select a model from an entity's detail view,
+  bind additional models to an existing entity, or drag a model from the Sidebar onto an entity row
+  without opening the detail view.
+
 ### Changed
 - **Entity detail modal is less scroll-heavy to edit.** Bound dbt models show up with the header
   context instead of below the form, so you see what the entity is tied to before digging into
   attributes. Roles & aliases stay collapsed until you open them, and long domain / tag / source
   lists hide behind a `+N more` control so chip walls no longer crowd the form. Attribute editing
   keeps its full-width table; the rest of the modal is tighter and easier to scan.
+- **Bus Matrix usage badges are clearer**: Each badge explains how many related facts or dimensions
+  are associated with that row or column, and fact labels retain their normal casing.
+
+### Fixed
+- **Bus Matrix tooltips no longer get clipped**: Usage explanations remain readable inside the
+  scrollable matrix and size to their content.
 
 ## [0.21.1] - 2026-08-05
 

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -477,7 +477,7 @@
                                     </div>
                                 </th>
                                 {#each sortedFacts as fact}
-                                    <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider bg-gray-50 min-w-[150px]">
+                                    <th class="px-4 py-3 text-left text-xs font-semibold text-gray-700 tracking-wider bg-gray-50 min-w-[150px]">
                                         <div class="flex items-center gap-2">
                                             <Icon icon="lucide:bar-chart-3" class="w-4 h-4 text-blue-600" />
                                             <span
@@ -486,9 +486,9 @@
                                             ></span>
                                             <span class="truncate">{fact.label}</span>
                                             {#if factVisibleDimensionCounts.get(fact.id) !== undefined}
-                                                <Tooltip text={`${factVisibleDimensionCounts.get(fact.id)} currently visible dimensions are connected to this fact.`}>
+                                                <Tooltip text={`${factVisibleDimensionCounts.get(fact.id)} related dimensions`}>
                                                     <span
-                                                        aria-label="{factVisibleDimensionCounts.get(fact.id)} connected dimensions"
+                                                        aria-label="{factVisibleDimensionCounts.get(fact.id)} related dimensions"
                                                         class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-700"
                                                     >
                                                         {factVisibleDimensionCounts.get(fact.id)}
@@ -524,9 +524,9 @@
                                                     title={readModelRef(dimension) ? `Built with dbt: ${readModelRef(dimension)!.split('.').pop()}` : 'Not yet built with dbt'}
                                                 ></span>
                                                 <span class="truncate">{dimension.label}</span>
-                                                <Tooltip text={`${dimensionVisibleFactCounts.get(dimension.id) ?? 0} currently visible facts are connected to this dimension.`}>
+                                                <Tooltip text={`${dimensionVisibleFactCounts.get(dimension.id) ?? 0} related facts`}>
                                                     <span
-                                                        aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} connected facts"
+                                                        aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} related facts"
                                                         class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-green-100 text-green-700 flex-shrink-0"
                                                     >
                                                         {dimensionVisibleFactCounts.get(dimension.id) ?? 0}

--- a/frontend/src/lib/components/BusMatrix.svelte
+++ b/frontend/src/lib/components/BusMatrix.svelte
@@ -4,6 +4,7 @@
     import Icon from '@iconify/svelte';
     import * as XLSX from 'xlsx';
     import { readModelRef } from '$lib/utils/entity-compat';
+    import Tooltip from '$lib/components/Tooltip.svelte';
 
     interface Dimension {
         id: string;
@@ -485,12 +486,14 @@
                                             ></span>
                                             <span class="truncate">{fact.label}</span>
                                             {#if factVisibleDimensionCounts.get(fact.id) !== undefined}
-                                                <span
-                                                    aria-label="{factVisibleDimensionCounts.get(fact.id)} connected dimensions"
-                                                    class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-700"
-                                                >
-                                                    {factVisibleDimensionCounts.get(fact.id)}
-                                                </span>
+                                                <Tooltip text={`${factVisibleDimensionCounts.get(fact.id)} currently visible dimensions are connected to this fact.`}>
+                                                    <span
+                                                        aria-label="{factVisibleDimensionCounts.get(fact.id)} connected dimensions"
+                                                        class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-700"
+                                                    >
+                                                        {factVisibleDimensionCounts.get(fact.id)}
+                                                    </span>
+                                                </Tooltip>
                                             {/if}
                                         </div>
                                     </th>
@@ -521,12 +524,14 @@
                                                     title={readModelRef(dimension) ? `Built with dbt: ${readModelRef(dimension)!.split('.').pop()}` : 'Not yet built with dbt'}
                                                 ></span>
                                                 <span class="truncate">{dimension.label}</span>
-                                                <span
-                                                    aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} connected facts"
-                                                    class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-green-100 text-green-700 flex-shrink-0"
-                                                >
-                                                    {dimensionVisibleFactCounts.get(dimension.id) ?? 0}
-                                                </span>
+                                                <Tooltip text={`${dimensionVisibleFactCounts.get(dimension.id) ?? 0} currently visible facts are connected to this dimension.`}>
+                                                    <span
+                                                        aria-label="{dimensionVisibleFactCounts.get(dimension.id) ?? 0} connected facts"
+                                                        class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold rounded-full bg-green-100 text-green-700 flex-shrink-0"
+                                                    >
+                                                        {dimensionVisibleFactCounts.get(dimension.id) ?? 0}
+                                                    </span>
+                                                </Tooltip>
                                             </div>
                                         </td>
                                         {#each sortedFacts as fact}

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -56,6 +56,29 @@ describe('BusMatrix — dbt build status badges', () => {
 		expect(unboundFactHeader?.querySelector('[title="Not yet built with dbt"]')).toBeTruthy();
 	});
 
+	it('explains what dimension and fact usage counts represent', async () => {
+		render(BusMatrix);
+
+		await waitFor(() => {
+			expect(document.querySelector('table')).toBeTruthy();
+		});
+
+		const dimensionBadge = document.querySelector('[aria-label="1 connected facts"]') as HTMLElement;
+		const factBadge = document.querySelector('[aria-label="1 connected dimensions"]') as HTMLElement;
+
+		await fireEvent.mouseEnter(dimensionBadge.parentElement as HTMLElement);
+		expect(document.querySelector('[role="tooltip"]')?.textContent).toContain(
+			'1 currently visible facts are connected to this dimension.'
+		);
+
+		await fireEvent.mouseEnter(factBadge.parentElement as HTMLElement);
+		expect(
+			Array.from(document.querySelectorAll('[role="tooltip"]')).some(tooltip =>
+				tooltip.textContent?.includes('1 currently visible dimensions are connected to this fact.')
+			)
+		).toBe(true);
+	});
+
 	it('filtering to "Bound" only shows the bound dimension row and bound fact column', async () => {
 		render(BusMatrix);
 

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -101,8 +101,8 @@ describe('BusMatrix — dbt build status badges', () => {
 		expect(table.textContent).not.toContain('Unbound Fact');
 		expect(table.textContent).toContain('Bound Fact');
 
-		// only one connected fact/dimension remains visible, so counts should be 1
-		const countBadges = Array.from(table.querySelectorAll('[aria-label*="connected"]'));
-		expect(countBadges.some((el) => el.getAttribute('aria-label')?.startsWith('1 connected'))).toBe(true);
+		// only one related fact/dimension remains visible, so counts should be 1
+		expect(table.querySelector('[aria-label="1 related facts"]')).toBeTruthy();
+		expect(table.querySelector('[aria-label="1 related dimensions"]')).toBeTruthy();
 	});
 });

--- a/frontend/src/lib/components/BusMatrix.test.ts
+++ b/frontend/src/lib/components/BusMatrix.test.ts
@@ -63,18 +63,18 @@ describe('BusMatrix — dbt build status badges', () => {
 			expect(document.querySelector('table')).toBeTruthy();
 		});
 
-		const dimensionBadge = document.querySelector('[aria-label="1 connected facts"]') as HTMLElement;
-		const factBadge = document.querySelector('[aria-label="1 connected dimensions"]') as HTMLElement;
+		const dimensionBadge = document.querySelector('[aria-label="1 related facts"]') as HTMLElement;
+		const factBadge = document.querySelector('[aria-label="1 related dimensions"]') as HTMLElement;
 
 		await fireEvent.mouseEnter(dimensionBadge.parentElement as HTMLElement);
 		expect(document.querySelector('[role="tooltip"]')?.textContent).toContain(
-			'1 currently visible facts are connected to this dimension.'
+			'1 related facts'
 		);
 
 		await fireEvent.mouseEnter(factBadge.parentElement as HTMLElement);
 		expect(
 			Array.from(document.querySelectorAll('[role="tooltip"]')).some(tooltip =>
-				tooltip.textContent?.includes('1 currently visible dimensions are connected to this fact.')
+				tooltip.textContent?.includes('1 related dimensions')
 			)
 		).toBe(true);
 	});

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -2,11 +2,12 @@
 	import Icon from '@iconify/svelte';
 	import { nodes, edges, entityDetailModal, pushHistory, frameworkModels, modelingStyle } from '$lib/stores';
 	import { getSourceSystemSuggestions, getBusinessEventProcesses, updateModelSchema, getManifest, getModelSchema } from '$lib/api';
-	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn, OriginEntry } from '$lib/types';
+	import type { EntityData, AnnotationType, DraftedField, BusinessEventProcess, AnnotationEntry, EntityRole, ModelSchemaColumn, OriginEntry, ModelInfo } from '$lib/types';
 	import { mergeFields } from '$lib/utils/merged-fields';
 	import type { MergedField } from '$lib/utils/merged-fields';
 	import { computeUiTagsAfterEdit } from '$lib/utils/entity-tags';
 	import { readModelRef, readFrameworkTags } from '$lib/utils/entity-compat';
+	import { bindEntityToModel } from '$lib/utils/entity-binding';
 	import type { Node } from '@xyflow/svelte';
 	import { getContext } from 'svelte';
 	import type { AutoSaveService } from '$lib/services/auto-save';
@@ -14,6 +15,7 @@
 	import { formatEntityAsMarkdown } from '$lib/utils/markdown-export';
 	import { goto } from '$app/navigation';
 	import DropIndicator from './DropIndicator.svelte';
+	import ModelBindingPicker from './ModelBindingPicker.svelte';
 
 	// Get autoSaveService from parent context (set in +layout.svelte)
 	const autoSaveServiceContext = getContext<{ current: AutoSaveService | null }>('autoSaveService');
@@ -175,6 +177,7 @@
 	// Feedback banners for materialize action
 	let materializeWarnings = $state<string[]>([]);
 	let materializeError = $state('');
+	let bindingError = $state('');
 
 	// Merged field list: dbt columns first, then drafted fields that don't collide
 	let mergedFields = $derived<MergedField[]>(mergeFields(boundModel?.columns, editableDraftedFields));
@@ -279,6 +282,15 @@
 		return models;
 	});
 
+	function handleModelSelect(model: ModelInfo) {
+		if (!currentEntity) return;
+		bindingError = '';
+		const changed = bindEntityToModel(currentEntity.id, model);
+		if (!changed) {
+			bindingError = 'This model is already bound to the entity.';
+		}
+	}
+
 	// Full form sync only when opening the modal or switching entities — not when
 	// currentEntity gets a new object reference after manifest refresh / autosave
 	// (otherwise materialize banners and in-progress edits are wiped).
@@ -325,6 +337,7 @@
 		liveSchemaDescriptions = new Map();
 		materializeWarnings = [];
 		materializeError = '';
+		bindingError = '';
 	});
 
 	// Load source system suggestions when modal opens
@@ -1056,21 +1069,32 @@
 						{/if}
 					{/if}
 
-					{#if boundModels.length > 0}
-						<div class="flex min-w-0 flex-1 flex-wrap items-center gap-2 rounded-lg border border-primary-200 bg-primary-50/80 px-3 py-1.5 shadow-sm" data-testid="bound-model-summary">
-							<div class="flex items-center gap-1.5 shrink-0 text-primary-700">
-								<Icon icon="lucide:layers" class="h-4 w-4 shrink-0 text-primary-600" />
-								<span class="text-xs font-semibold">
-									Bound dbt Models ({boundModels.length})
-								</span>
+					<div class="flex min-w-0 flex-1 flex-wrap items-center gap-2" data-testid="model-binding-controls">
+						{#if boundModels.length > 0}
+							<div class="flex min-w-0 flex-1 flex-wrap items-center gap-2 rounded-lg border border-primary-200 bg-primary-50/80 px-3 py-1.5 shadow-sm" data-testid="bound-model-summary">
+								<div class="flex items-center gap-1.5 shrink-0 text-primary-700">
+									<Icon icon="lucide:layers" class="h-4 w-4 shrink-0 text-primary-600" />
+									<span class="text-xs font-semibold">
+										Bound dbt Models ({boundModels.length})
+									</span>
+								</div>
+								{#each boundModels as model}
+									<span class="max-w-full truncate rounded-md border border-primary-200/70 bg-white px-2 py-0.5 font-mono text-xs text-primary-900 shadow-2xs font-medium" title={model}>
+										{model}
+									</span>
+								{/each}
 							</div>
-							{#each boundModels as model}
-								<span class="max-w-full truncate rounded-md border border-primary-200/70 bg-white px-2 py-0.5 font-mono text-xs text-primary-900 shadow-2xs font-medium" title={model}>
-									{model}
-								</span>
-							{/each}
-						</div>
-					{/if}
+						{/if}
+						{#if $frameworkModels.length > 0}
+							<ModelBindingPicker
+								selectedModelIds={boundModels}
+								onSelect={handleModelSelect}
+							/>
+						{/if}
+						{#if bindingError}
+							<span class="text-xs text-danger-700" role="alert">{bindingError}</span>
+						{/if}
+					</div>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -949,18 +949,16 @@
 
 				<div class="flex items-start justify-between">
 					<div class="flex-1">
+						<p class="mb-1 text-[11px] font-bold uppercase tracking-[0.16em] text-primary-700">
+							Entity details
+						</p>
 						<h2
 							id="entity-detail-modal-title"
-							class="text-2xl font-bold text-gray-900 mb-2"
+							class="text-3xl font-bold text-gray-900"
 							style="letter-spacing: -0.02em;"
 						>
-							{entityName || 'Entity'} Details
+							{entityName || 'Entity'}
 						</h2>
-						{#if $modelingStyle === 'dimensional_model'}
-							<p class="text-sm text-gray-600">
-								{entityType === 'dimension' ? 'Dimension' : entityType === 'fact' ? 'Fact' : 'Unclassified'} entity
-							</p>
-						{/if}
 					</div>
 					<button
 						class="p-2 rounded-lg hover:bg-gray-200 text-gray-500 transition-colors"

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -143,6 +143,37 @@ describe('EntityDetailModal — merged dbt+draft fields', () => {
     expect(screen.getByText(/Add Attribute/i)).toBeInTheDocument();
   });
 
+  it('binds an unbound entity from the model picker', async () => {
+    setupUnboundEntityWithDraftOrigin();
+    frameworkModels.set([mockDbtModel]);
+    await renderModal();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'entity_x' }));
+
+    expect((get(nodes).find((node) => node.id === 'node-1')?.data as any).model_ref)
+      .toBe('model.proj.entity_x');
+    expect(screen.getByText('Bound dbt Models (1)')).toBeInTheDocument();
+  });
+
+  it('adds a second selected model as an additional binding', async () => {
+    setupBoundEntityWithDraft();
+    const secondModel = {
+      ...mockDbtModel,
+      unique_id: 'model.proj.entity_x_history',
+      name: 'entity_x_history',
+    };
+    frameworkModels.set([mockDbtModel, secondModel]);
+    await renderModal();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'entity_x_history' }));
+
+    expect((get(nodes).find((node) => node.id === 'node-1')?.data as any).additional_models)
+      .toEqual(['model.proj.entity_x_history']);
+    expect(screen.getByText('Bound dbt Models (2)')).toBeInTheDocument();
+  });
+
   it('renders bound dbt models above the attributes section', async () => {
     setupBoundEntityWithDraft();
     await renderModal();

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import Icon from "@iconify/svelte";
 	import type { Entity, ModelInfo } from "$lib/types";
-	import { entityDetailModal, entitySelection, modelingStyle, frameworkModels } from "$lib/stores";
+	import { entityDetailModal, entitySelection, modelingStyle } from "$lib/stores";
 	import DomainBadge from "./DomainBadge.svelte";
-	import ModelBindingPicker from "./ModelBindingPicker.svelte";
 	import { readModelRef } from "$lib/utils/entity-compat";
 	import { bindEntityToModel } from "$lib/utils/entity-binding";
 
@@ -101,6 +100,50 @@
 		entityDetailModal.set({ open: true, entityId: entity.id });
 	}
 
+	let isDragOver = $state(false);
+
+	function handleModelDragOver(event: DragEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		isDragOver = true;
+		if (event.dataTransfer) {
+			event.dataTransfer.dropEffect = "copy";
+		}
+	}
+
+	function handleModelDragEnter(event: DragEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		isDragOver = true;
+	}
+
+	function handleModelDragLeave(event: DragEvent) {
+		const currentTarget = event.currentTarget as HTMLElement;
+		const relatedTarget = event.relatedTarget;
+		if (relatedTarget instanceof HTMLElement && currentTarget.contains(relatedTarget)) {
+			return;
+		}
+		isDragOver = false;
+	}
+
+	function handleModelDrop(event: DragEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		isDragOver = false;
+
+		const json = event.dataTransfer?.getData("application/model-ref");
+		if (!json) return;
+
+		try {
+			const model = JSON.parse(json) as ModelInfo;
+			if (model.unique_id) {
+				bindEntityToModel(entity.id, model);
+			}
+		} catch (error) {
+			console.warn("Could not bind dropped model:", error);
+		}
+	}
+
 	// Get visible tags (max 3, +N more if overflow)
 	const { visibleTags, hiddenCount } = $derived.by(() => {
 		const tags = entity.tags || [];
@@ -131,20 +174,21 @@
 
 	// Bound model reference (prefers new `model_ref`, falls back to legacy `dbt_model`)
 	const boundModelRef = $derived(readModelRef(entity));
-	const selectedModelIds = $derived(
-		boundModelRef ? [boundModelRef, ...(entity.additional_models || [])] : [],
-	);
-
-	function handleModelSelect(model: ModelInfo) {
-		bindEntityToModel(entity.id, model);
-	}
 </script>
 
 <div
 	class="bg-white border-b border-gray-200 px-4 py-2 flex items-center gap-3 hover:bg-gray-50 transition-colors cursor-pointer group"
+	class:ring-2={isDragOver}
+	class:ring-primary-300={isDragOver}
+	class:bg-primary-50={isDragOver}
+	class:border-primary-400={isDragOver}
 	role="row"
 	onclick={handleRowClick}
 	onkeydown={(e) => e.key === "Enter" && handleRowClick()}
+	ondragenter={handleModelDragEnter}
+	ondragover={handleModelDragOver}
+	ondragleave={handleModelDragLeave}
+	ondrop={handleModelDrop}
 	tabindex="0"
 >
 	<!-- Checkbox (always visible for selection) -->
@@ -255,13 +299,6 @@
 			</div>
 		{/if}
 	</div>
-
-	{#if $frameworkModels.length > 0}
-		<ModelBindingPicker
-			selectedModelIds={selectedModelIds}
-			onSelect={handleModelSelect}
-		/>
-	{/if}
 
 	<!-- Right side action hint (visible on hover) -->
 	<div class="flex-shrink-0 text-gray-400 group-hover:text-gray-600 transition-colors">

--- a/frontend/src/lib/components/EntityRow.svelte
+++ b/frontend/src/lib/components/EntityRow.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import Icon from "@iconify/svelte";
-	import type { Entity } from "$lib/types";
-	import { entityDetailModal, entitySelection, modelingStyle } from "$lib/stores";
+	import type { Entity, ModelInfo } from "$lib/types";
+	import { entityDetailModal, entitySelection, modelingStyle, frameworkModels } from "$lib/stores";
 	import DomainBadge from "./DomainBadge.svelte";
+	import ModelBindingPicker from "./ModelBindingPicker.svelte";
 	import { readModelRef } from "$lib/utils/entity-compat";
+	import { bindEntityToModel } from "$lib/utils/entity-binding";
 
 	type Props = {
 		entity: Entity;
@@ -129,6 +131,13 @@
 
 	// Bound model reference (prefers new `model_ref`, falls back to legacy `dbt_model`)
 	const boundModelRef = $derived(readModelRef(entity));
+	const selectedModelIds = $derived(
+		boundModelRef ? [boundModelRef, ...(entity.additional_models || [])] : [],
+	);
+
+	function handleModelSelect(model: ModelInfo) {
+		bindEntityToModel(entity.id, model);
+	}
 </script>
 
 <div
@@ -246,6 +255,13 @@
 			</div>
 		{/if}
 	</div>
+
+	{#if $frameworkModels.length > 0}
+		<ModelBindingPicker
+			selectedModelIds={selectedModelIds}
+			onSelect={handleModelSelect}
+		/>
+	{/if}
 
 	<!-- Right side action hint (visible on hover) -->
 	<div class="flex-shrink-0 text-gray-400 group-hover:text-gray-600 transition-colors">

--- a/frontend/src/lib/components/EntityRow.test.ts
+++ b/frontend/src/lib/components/EntityRow.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { fireEvent, render, cleanup, screen } from '@testing-library/svelte';
 import EntityRow from './EntityRow.svelte';
 import type { Entity, ModelInfo } from '$lib/types';
-import { frameworkModels, nodes } from '$lib/stores';
+import { entityDetailModal, nodes } from '$lib/stores';
 import { get } from 'svelte/store';
 
 const baseEntity: Entity = {
@@ -14,8 +14,8 @@ const baseEntity: Entity = {
 describe('EntityRow — dbt build status badge', () => {
 	afterEach(() => {
 		cleanup();
-		frameworkModels.set([]);
 		nodes.set([]);
+		entityDetailModal.set({ open: false, entityId: null });
 	});
 
 	it('renders a dbt badge with tooltip showing the resolved model name for a bound entity', () => {
@@ -47,7 +47,7 @@ describe('EntityRow — dbt build status badge', () => {
 		expect(badge).toBeFalsy();
 	});
 
-	it('binds an entity from the row action without opening the detail modal', async () => {
+	it('binds an entity by dropping a Sidebar model without opening the detail modal', async () => {
 		const model: ModelInfo = {
 			unique_id: 'model.project.booking',
 			name: 'booking',
@@ -55,7 +55,6 @@ describe('EntityRow — dbt build status badge', () => {
 			table: 'booking',
 			columns: [],
 		};
-		frameworkModels.set([model]);
 		nodes.set([{
 			id: 'booking',
 			type: 'entity',
@@ -64,10 +63,18 @@ describe('EntityRow — dbt build status badge', () => {
 		} as any]);
 
 		render(EntityRow, { props: { entity: baseEntity } });
-		await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
-		await fireEvent.click(screen.getByRole('button', { name: 'booking' }));
+		const row = screen.getByRole('row');
+		const dataTransfer = {
+			getData: (type: string) =>
+				type === 'application/model-ref' ? JSON.stringify(model) : '',
+		};
+
+		await fireEvent.dragEnter(row, { dataTransfer });
+		expect(row).toHaveClass('ring-2');
+		await fireEvent.drop(row, { dataTransfer });
 
 		expect((get(nodes)[0].data as any).model_ref).toBe('model.project.booking');
-		expect(screen.queryByText('Entity X Details')).not.toBeInTheDocument();
+		expect(get(entityDetailModal)).toEqual({ open: false, entityId: null });
+		expect(screen.queryByRole('button', { name: 'Bind model' })).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/lib/components/EntityRow.test.ts
+++ b/frontend/src/lib/components/EntityRow.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/svelte';
+import { fireEvent, render, cleanup, screen } from '@testing-library/svelte';
 import EntityRow from './EntityRow.svelte';
-import type { Entity } from '$lib/types';
+import type { Entity, ModelInfo } from '$lib/types';
+import { frameworkModels, nodes } from '$lib/stores';
+import { get } from 'svelte/store';
 
 const baseEntity: Entity = {
 	id: 'booking',
@@ -12,6 +14,8 @@ const baseEntity: Entity = {
 describe('EntityRow — dbt build status badge', () => {
 	afterEach(() => {
 		cleanup();
+		frameworkModels.set([]);
+		nodes.set([]);
 	});
 
 	it('renders a dbt badge with tooltip showing the resolved model name for a bound entity', () => {
@@ -41,5 +45,29 @@ describe('EntityRow — dbt build status badge', () => {
 
 		const badge = document.querySelector('[title*="Built with dbt"]');
 		expect(badge).toBeFalsy();
+	});
+
+	it('binds an entity from the row action without opening the detail modal', async () => {
+		const model: ModelInfo = {
+			unique_id: 'model.project.booking',
+			name: 'booking',
+			schema: 'analytics',
+			table: 'booking',
+			columns: [],
+		};
+		frameworkModels.set([model]);
+		nodes.set([{
+			id: 'booking',
+			type: 'entity',
+			position: { x: 0, y: 0 },
+			data: { label: 'Booking' },
+		} as any]);
+
+		render(EntityRow, { props: { entity: baseEntity } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
+		await fireEvent.click(screen.getByRole('button', { name: 'booking' }));
+
+		expect((get(nodes)[0].data as any).model_ref).toBe('model.project.booking');
+		expect(screen.queryByText('Entity X Details')).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/lib/components/ModelBindingPicker.svelte
+++ b/frontend/src/lib/components/ModelBindingPicker.svelte
@@ -19,6 +19,7 @@
 	let isOpen = $state(false);
 	let searchTerm = $state('');
 	let containerRef = $state<HTMLDivElement>();
+	let triggerRef = $state<HTMLButtonElement>();
 	let searchInput = $state<HTMLInputElement>();
 
 	let filteredGroups = $derived.by(() => {
@@ -54,11 +55,11 @@
 		}
 
 		if (isOpen) {
-			document.addEventListener('click', handleClickOutside);
+			document.addEventListener('click', handleClickOutside, true);
 			queueMicrotask(() => searchInput?.focus());
 		}
 
-		return () => document.removeEventListener('click', handleClickOutside);
+		return () => document.removeEventListener('click', handleClickOutside, true);
 	});
 
 	function openPicker() {
@@ -67,18 +68,30 @@
 		if (!isOpen) searchTerm = '';
 	}
 
+	function closePicker() {
+		isOpen = false;
+		searchTerm = '';
+		triggerRef?.focus();
+	}
+
 	function selectModel(model: ModelInfo) {
 		if (selectedModelIds.includes(model.unique_id)) return;
 		onSelect(model);
-		isOpen = false;
-		searchTerm = '';
+		closePicker();
 	}
 
 	function handleSearchKeydown(event: KeyboardEvent) {
 		if (event.key === 'Escape') {
 			event.preventDefault();
-			isOpen = false;
-			searchTerm = '';
+			closePicker();
+		}
+	}
+
+	function handleContainerKeydown(event: KeyboardEvent) {
+		event.stopPropagation();
+		if (event.key === 'Escape' && isOpen) {
+			event.preventDefault();
+			closePicker();
 		}
 	}
 </script>
@@ -88,10 +101,11 @@
 	bind:this={containerRef}
 	role="presentation"
 	onclick={(event) => event.stopPropagation()}
-	onkeydown={(event) => event.stopPropagation()}
+	onkeydown={handleContainerKeydown}
 >
 	<button
 		type="button"
+		bind:this={triggerRef}
 		class="inline-flex items-center gap-1.5 rounded-lg border border-primary-200 bg-primary-50/80 px-3 py-1.5 text-xs font-semibold text-primary-700 shadow-3xs transition-colors hover:border-primary-300 hover:bg-primary-100 disabled:cursor-not-allowed disabled:opacity-50"
 		onclick={openPicker}
 		disabled={disabled}

--- a/frontend/src/lib/components/ModelBindingPicker.svelte
+++ b/frontend/src/lib/components/ModelBindingPicker.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+	import { frameworkModels } from '$lib/stores';
+	import type { ModelInfo } from '$lib/types';
+	import { getModelFolder } from '$lib/utils';
+
+	type Props = {
+		selectedModelIds?: string[];
+		onSelect: (model: ModelInfo) => void;
+		disabled?: boolean;
+	};
+
+	let {
+		selectedModelIds = [],
+		onSelect,
+		disabled = false,
+	}: Props = $props();
+
+	let isOpen = $state(false);
+	let searchTerm = $state('');
+	let containerRef = $state<HTMLDivElement>();
+	let searchInput = $state<HTMLInputElement>();
+
+	let filteredGroups = $derived.by(() => {
+		const query = searchTerm.trim().toLowerCase();
+		const groups = new Map<string, ModelInfo[]>();
+
+		for (const model of $frameworkModels) {
+			const matches =
+				!query ||
+				model.name.toLowerCase().includes(query) ||
+				model.unique_id.toLowerCase().includes(query);
+			if (!matches) continue;
+
+			const group = getModelFolder(model) ?? 'Uncategorized';
+			const models = groups.get(group) ?? [];
+			models.push(model);
+			groups.set(group, models);
+		}
+
+		return Array.from(groups.entries())
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([label, models]) => ({
+				label,
+				models: models.sort((left, right) => left.name.localeCompare(right.name)),
+			}));
+	});
+
+	$effect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (containerRef && !containerRef.contains(event.target as Node)) {
+				isOpen = false;
+			}
+		}
+
+		if (isOpen) {
+			document.addEventListener('click', handleClickOutside);
+			queueMicrotask(() => searchInput?.focus());
+		}
+
+		return () => document.removeEventListener('click', handleClickOutside);
+	});
+
+	function openPicker() {
+		if (disabled) return;
+		isOpen = !isOpen;
+		if (!isOpen) searchTerm = '';
+	}
+
+	function selectModel(model: ModelInfo) {
+		if (selectedModelIds.includes(model.unique_id)) return;
+		onSelect(model);
+		isOpen = false;
+		searchTerm = '';
+	}
+
+	function handleSearchKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			isOpen = false;
+			searchTerm = '';
+		}
+	}
+</script>
+
+<div
+	class="relative"
+	bind:this={containerRef}
+	role="presentation"
+	onclick={(event) => event.stopPropagation()}
+	onkeydown={(event) => event.stopPropagation()}
+>
+	<button
+		type="button"
+		class="inline-flex items-center gap-1.5 rounded-lg border border-primary-200 bg-primary-50/80 px-3 py-1.5 text-xs font-semibold text-primary-700 shadow-3xs transition-colors hover:border-primary-300 hover:bg-primary-100 disabled:cursor-not-allowed disabled:opacity-50"
+		onclick={openPicker}
+		disabled={disabled}
+		aria-label="Bind model"
+		aria-expanded={isOpen}
+		aria-haspopup="dialog"
+	>
+		<Icon icon="lucide:link" class="h-3.5 w-3.5" />
+		<span>Bind model</span>
+		<Icon icon="lucide:chevron-down" class="h-3 w-3 transition-transform {isOpen ? 'rotate-180' : ''}" />
+	</button>
+
+	{#if isOpen}
+		<div
+			class="absolute right-0 top-full z-50 mt-1.5 w-80 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl ring-1 ring-black/5"
+			role="dialog"
+			aria-label="Select model to bind"
+		>
+			<div class="border-b border-gray-100 p-2">
+				<div class="relative">
+					<Icon icon="lucide:search" class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+					<input
+						bind:this={searchInput}
+						type="search"
+						value={searchTerm}
+						oninput={(event) => (searchTerm = (event.target as HTMLInputElement).value)}
+						onkeydown={handleSearchKeydown}
+						class="w-full rounded-md border border-gray-200 py-1.5 pl-8 pr-2 text-xs text-gray-900 outline-none transition-colors focus:border-primary-400 focus:ring-2 focus:ring-primary-500/20"
+						placeholder="Search models..."
+						aria-label="Search models"
+					/>
+				</div>
+			</div>
+
+			<div class="max-h-72 overflow-y-auto py-1">
+				{#if filteredGroups.length === 0}
+					<div class="px-3 py-6 text-center text-xs text-gray-500">
+						No models match your search.
+					</div>
+				{:else}
+					{#each filteredGroups as group}
+						<div class="border-b border-gray-100 last:border-b-0">
+							<div class="bg-gray-50/80 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+								{group.label}
+							</div>
+							{#each group.models as model}
+								{@const isSelected = selectedModelIds.includes(model.unique_id)}
+								<button
+									type="button"
+									class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-xs transition-colors {isSelected
+										? 'cursor-not-allowed bg-gray-50 text-gray-400'
+										: 'text-gray-800 hover:bg-primary-50 hover:text-primary-700'}"
+									onclick={() => selectModel(model)}
+									disabled={isSelected}
+									aria-label={`${model.name}${isSelected ? ' Already bound' : ''}`}
+								>
+									<span class="min-w-0">
+										<span class="block truncate font-medium">{model.name}</span>
+										<span class="block truncate font-mono text-[10px] text-gray-400">{model.unique_id}</span>
+									</span>
+									{#if isSelected}
+										<span class="flex shrink-0 items-center gap-1 text-[10px] font-semibold text-gray-400">
+											<Icon icon="lucide:check" class="h-3.5 w-3.5" />
+											Already bound
+										</span>
+									{:else}
+										<Icon icon="lucide:plus" class="h-3.5 w-3.5 shrink-0 text-primary-500" />
+									{/if}
+								</button>
+							{/each}
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/ModelBindingPicker.test.ts
+++ b/frontend/src/lib/components/ModelBindingPicker.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, cleanup } from '@testing-library/svelte';
+import { frameworkModels } from '$lib/stores';
+import type { ModelInfo } from '$lib/types';
+import ModelBindingPicker from './ModelBindingPicker.svelte';
+
+const models: ModelInfo[] = [
+	{
+		unique_id: 'model.project.customers',
+		name: 'customers',
+		schema: 'analytics',
+		table: 'customers',
+		columns: [],
+		file_path: 'models/3/core/customers.sql',
+	},
+	{
+		unique_id: 'model.project.orders',
+		name: 'orders',
+		schema: 'analytics',
+		table: 'orders',
+		columns: [],
+		file_path: 'models/3/core/orders.sql',
+	},
+];
+
+describe('ModelBindingPicker', () => {
+	afterEach(() => {
+		cleanup();
+		frameworkModels.set([]);
+	});
+
+	it('filters models and emits the selected model', async () => {
+		frameworkModels.set(models);
+		const onSelect = (model: ModelInfo) => selected.push(model);
+		const selected: ModelInfo[] = [];
+
+		render(ModelBindingPicker, { props: { onSelect } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
+
+		const search = screen.getByRole('searchbox', { name: 'Search models' });
+		await fireEvent.input(search, { target: { value: 'orders' } });
+
+		expect(screen.queryByRole('button', { name: /customers/ })).not.toBeInTheDocument();
+		await fireEvent.click(screen.getByRole('button', { name: /orders/ }));
+
+		expect(selected).toEqual([models[1]]);
+	});
+
+	it('marks already-bound models and does not emit them again', async () => {
+		frameworkModels.set(models);
+		const onSelect = (model: ModelInfo) => selected.push(model);
+		const selected: ModelInfo[] = [];
+
+		render(ModelBindingPicker, {
+			props: { onSelect, selectedModelIds: ['model.project.customers'] },
+		});
+		await fireEvent.click(screen.getByRole('button', { name: 'Bind model' }));
+
+		const selectedModel = screen.getByRole('button', { name: /customers.*Already bound/i });
+		expect(selectedModel).toBeDisabled();
+		expect(screen.getByText('core')).toBeInTheDocument();
+		expect(selected).toEqual([]);
+	});
+});

--- a/frontend/src/lib/components/Tooltip.svelte
+++ b/frontend/src/lib/components/Tooltip.svelte
@@ -10,8 +10,37 @@
     let { text, position = 'top', children }: Props = $props();
 
     let showTooltip = $state(false);
+    let anchorElement = $state<HTMLDivElement>();
+    let tooltipTop = $state(0);
+    let tooltipLeft = $state(0);
+
+    function updateTooltipPosition() {
+        if (!anchorElement) return;
+
+        const rect = anchorElement.getBoundingClientRect();
+        switch (position) {
+            case 'bottom':
+                tooltipTop = rect.bottom + 8;
+                tooltipLeft = rect.left + rect.width / 2;
+                break;
+            case 'left':
+                tooltipTop = rect.top + rect.height / 2;
+                tooltipLeft = rect.left - 8;
+                break;
+            case 'right':
+                tooltipTop = rect.top + rect.height / 2;
+                tooltipLeft = rect.right + 8;
+                break;
+            case 'top':
+            default:
+                tooltipTop = rect.top - 8;
+                tooltipLeft = rect.left + rect.width / 2;
+                break;
+        }
+    }
 
     function handleMouseEnter() {
+        updateTooltipPosition();
         showTooltip = true;
     }
 
@@ -19,11 +48,23 @@
         showTooltip = false;
     }
 
+    $effect(() => {
+        if (!showTooltip) return;
+
+        window.addEventListener('scroll', updateTooltipPosition, true);
+        window.addEventListener('resize', updateTooltipPosition);
+
+        return () => {
+            window.removeEventListener('scroll', updateTooltipPosition, true);
+            window.removeEventListener('resize', updateTooltipPosition);
+        };
+    });
+
     const positionClasses: Record<TooltipPosition, string> = {
-        top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
-        bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
-        left: 'right-full top-1/2 -translate-y-1/2 mr-2',
-        right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+        top: '-translate-x-1/2 -translate-y-full',
+        bottom: '-translate-x-1/2',
+        left: '-translate-x-full -translate-y-1/2',
+        right: '-translate-y-1/2',
     };
 
     const arrowClasses: Record<TooltipPosition, string> = {
@@ -38,6 +79,7 @@
 </script>
 
 <div
+    bind:this={anchorElement}
     class="relative inline-flex items-center"
     onmouseenter={handleMouseEnter}
     onmouseleave={handleMouseLeave}
@@ -46,7 +88,8 @@
     {@render children?.()}
     {#if showTooltip}
         <div
-            class="absolute z-50 px-3 py-2 text-xs font-normal text-white bg-gray-800 rounded-lg shadow-lg whitespace-normal w-80 max-w-lg pointer-events-none {positionClasses[currentPosition]}"
+            class="fixed z-[100] w-max max-w-[calc(100vw-1rem)] px-3 py-2 text-xs font-normal leading-4 text-white bg-gray-800 rounded-lg shadow-lg whitespace-normal break-words pointer-events-none {positionClasses[currentPosition]}"
+            style={`top: ${tooltipTop}px; left: ${tooltipLeft}px;`}
             role="tooltip"
         >
             {text}

--- a/frontend/src/lib/utils/entity-binding.test.ts
+++ b/frontend/src/lib/utils/entity-binding.test.ts
@@ -24,7 +24,7 @@ function entityNode(data: Record<string, unknown>): Node {
 describe('bindModelToNode', () => {
 	it('sets the primary model and copies metadata for an unbound entity', () => {
 		const result = bindModelToNode(
-			entityNode({ label: 'Customers', description: '' }),
+			entityNode({ label: 'Customers', description: '', tags: ['pii', 'core'] }),
 			model,
 			{ dimensionPrefixes: [], factPrefixes: [] },
 		);
@@ -33,6 +33,7 @@ describe('bindModelToNode', () => {
 		expect(result.node.data).toMatchObject({
 			model_ref: 'model.project.customers',
 			description: 'Customer records',
+			ui_tags: ['pii', 'core'],
 		});
 	});
 

--- a/frontend/src/lib/utils/entity-binding.test.ts
+++ b/frontend/src/lib/utils/entity-binding.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelInfo } from '$lib/types';
+import type { Node } from '@xyflow/svelte';
+import { bindModelToNode } from './entity-binding';
+
+const model: ModelInfo = {
+	unique_id: 'model.project.customers',
+	name: 'customers',
+	schema: 'analytics',
+	table: 'customers',
+	columns: [],
+	description: 'Customer records',
+};
+
+function entityNode(data: Record<string, unknown>): Node {
+	return {
+		id: 'customers',
+		type: 'entity',
+		position: { x: 0, y: 0 },
+		data,
+	} as Node;
+}
+
+describe('bindModelToNode', () => {
+	it('sets the primary model and copies metadata for an unbound entity', () => {
+		const result = bindModelToNode(
+			entityNode({ label: 'Customers', description: '' }),
+			model,
+			{ dimensionPrefixes: [], factPrefixes: [] },
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.node.data).toMatchObject({
+			model_ref: 'model.project.customers',
+			description: 'Customer records',
+		});
+	});
+
+	it('adds a unique additional model without changing the primary binding', () => {
+		const result = bindModelToNode(
+			entityNode({
+				label: 'Customers',
+				model_ref: 'model.project.customers',
+				additional_models: ['model.project.customers_history'],
+			}),
+			{
+				...model,
+				unique_id: 'model.project.customers_snapshot',
+				name: 'customers_snapshot',
+			},
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.node.data).toMatchObject({
+			model_ref: 'model.project.customers',
+			additional_models: [
+				'model.project.customers_history',
+				'model.project.customers_snapshot',
+			],
+		});
+	});
+
+	it('does not duplicate an already-bound model or mutate the node', () => {
+		const node = entityNode({
+			label: 'Customers',
+			model_ref: 'model.project.customers',
+			additional_models: ['model.project.customers_history'],
+		});
+
+		const result = bindModelToNode(node, {
+			...model,
+			unique_id: 'model.project.customers_history',
+			name: 'customers_history',
+		});
+
+		expect(result.changed).toBe(false);
+		expect(result.node).toBe(node);
+		expect(result.node.data.additional_models).toEqual([
+			'model.project.customers_history',
+		]);
+	});
+
+	it('infers a dimensional entity type from configured prefixes', () => {
+		const result = bindModelToNode(
+			entityNode({ label: 'Customers' }),
+			{ ...model, name: 'dim_customers' },
+			{ dimensionPrefixes: ['dim_'], factPrefixes: ['fct_'] },
+		);
+
+		expect(result.node.data.entity_type).toBe('dimension');
+	});
+});

--- a/frontend/src/lib/utils/entity-binding.ts
+++ b/frontend/src/lib/utils/entity-binding.ts
@@ -1,0 +1,90 @@
+import type { Node } from '@xyflow/svelte';
+import type { EntityData, ModelInfo } from '$lib/types';
+import { classifyModelTypeFromPrefixes } from '$lib/utils';
+import { readModelRef } from './entity-compat';
+import { get } from 'svelte/store';
+import { factPrefixes, dimensionPrefixes, nodes as nodesStore, pushHistory } from '$lib/stores';
+
+export type EntityBindingOptions = {
+	dimensionPrefixes?: string[];
+	factPrefixes?: string[];
+};
+
+export type EntityBindingResult = {
+	node: Node;
+	changed: boolean;
+};
+
+/**
+ * Apply the existing canvas binding semantics to one entity node.
+ *
+ * An unbound entity receives a primary model. A bound entity receives a new
+ * unique additional model. The input node is returned unchanged for duplicate
+ * selections so callers can avoid unnecessary saves.
+ */
+export function bindModelToNode(
+	node: Node,
+	model: ModelInfo,
+	options: EntityBindingOptions = {},
+): EntityBindingResult {
+	const data = node.data as unknown as EntityData;
+	const primaryModel = readModelRef(data);
+	const additionalModels = Array.isArray(data.additional_models) ? data.additional_models : [];
+	const allBoundModels = primaryModel ? [primaryModel, ...additionalModels] : additionalModels;
+
+	if (!model.unique_id || allBoundModels.includes(model.unique_id)) {
+		return { node, changed: false };
+	}
+
+	const nextData: EntityData = {
+		...data,
+		...(primaryModel
+			? { additional_models: [...additionalModels, model.unique_id] }
+			: {
+					model_ref: model.unique_id,
+					...(data.description?.trim()
+						? {}
+						: model.description?.trim()
+							? { description: model.description }
+							: {}),
+					...inferEntityType(model, options),
+				}),
+	};
+
+	return {
+		node: { ...node, data: nextData as unknown as Record<string, unknown> },
+		changed: true,
+	};
+}
+
+function inferEntityType(
+	model: ModelInfo,
+	options: EntityBindingOptions,
+): Pick<EntityData, 'entity_type'> {
+	const inferred = classifyModelTypeFromPrefixes(
+		model.name,
+		options.dimensionPrefixes ?? [],
+		options.factPrefixes ?? [],
+	);
+	return inferred ? { entity_type: inferred } : {};
+}
+
+/**
+ * Bind a model to an entity in the shared node store and create one undo step.
+ * Autosave observes the store mutation through the existing layout service.
+ */
+export function bindEntityToModel(entityId: string, model: ModelInfo): boolean {
+	const currentNodes = get(nodesStore);
+	const target = currentNodes.find((node) => node.id === entityId && node.type === 'entity');
+	if (!target) return false;
+
+	const result = bindModelToNode(target, model, {
+		dimensionPrefixes: get(dimensionPrefixes),
+		factPrefixes: get(factPrefixes),
+	});
+	if (!result.changed) return false;
+
+	nodesStore.set(currentNodes.map((node) => (node.id === entityId ? result.node : node)));
+	pushHistory();
+	return true;
+}

--- a/frontend/src/lib/utils/entity-binding.ts
+++ b/frontend/src/lib/utils/entity-binding.ts
@@ -42,6 +42,7 @@ export function bindModelToNode(
 			? { additional_models: [...additionalModels, model.unique_id] }
 			: {
 					model_ref: model.unique_id,
+					...migrateUserTags(data),
 					...(data.description?.trim()
 						? {}
 						: model.description?.trim()
@@ -55,6 +56,13 @@ export function bindModelToNode(
 		node: { ...node, data: nextData as unknown as Record<string, unknown> },
 		changed: true,
 	};
+}
+
+function migrateUserTags(data: EntityData): Pick<EntityData, 'ui_tags'> {
+	const existingUiTags = Array.isArray(data.ui_tags) ? data.ui_tags : [];
+	const existingTags = Array.isArray(data.tags) ? data.tags : [];
+	const uiTags = Array.from(new Set([...existingUiTags, ...existingTags]));
+	return uiTags.length > 0 ? { ui_tags: uiTags } : {};
 }
 
 function inferEntityType(

--- a/frontend/tests/bus-matrix.spec.ts
+++ b/frontend/tests/bus-matrix.spec.ts
@@ -51,11 +51,11 @@ test.describe('Bus Matrix Counts and Sorting', () => {
         await page.goto('/bus-matrix');
         await page.waitForLoadState('networkidle');
 
-        // Customer Dimension is connected to 2 facts (fct_orders + fct_sales)
-        await expect(page.locator('[aria-label="2 connected facts"]').first()).toBeVisible();
+        // Customer Dimension shows 2 related facts (fct_orders + fct_sales)
+        await expect(page.locator('[aria-label="2 related facts"]').first()).toBeVisible();
 
-        // Date Dimension is connected to 1 fact (fct_orders only)
-        await expect(page.locator('[aria-label="1 connected facts"]').first()).toBeVisible();
+        // Date Dimension shows 1 related fact (fct_orders only)
+        await expect(page.locator('[aria-label="1 related facts"]').first()).toBeVisible();
 
         // Apply fact filter for Orders Fact only
         await page.locator('select#fact-filter').selectOption({ label: 'Orders Fact' });
@@ -63,12 +63,12 @@ test.describe('Bus Matrix Counts and Sorting', () => {
 
         // After filtering to Orders Fact only, Customer Dimension shows count 1
         // (dim_customer was connected to fct_orders + fct_sales, but only fct_orders is now visible)
-        const filteredBadges = page.locator('[aria-label="1 connected facts"]');
+        const filteredBadges = page.locator('[aria-label="1 related facts"]');
         await expect(filteredBadges.first()).toBeVisible();
 
-        // Date Dimension still shows 1 (only connected to fct_orders which is still visible)
-        // Product Dimension shows 1 (connected to fct_orders + fct_sales but only fct_orders visible)
-        const countBadges = await page.locator('[aria-label*="connected facts"]').count();
+        // Date Dimension still shows 1 related fact (only connected to fct_orders which is still visible)
+        // Product Dimension shows 1 related fact (connected to fct_orders + fct_sales but only fct_orders visible)
+        const countBadges = await page.locator('[aria-label*="related facts"]').count();
         expect(countBadges).toBeGreaterThan(0);
     });
 
@@ -145,8 +145,8 @@ test.describe('Bus Matrix Counts and Sorting', () => {
         await page.waitForTimeout(200);
 
         // fct_a and fct_b each have 1 dimension connection (dim_high connects to both)
-        // Count badges should show connected dimensions
-        await expect(page.locator('[aria-label="1 connected dimensions"]').first()).toBeVisible();
+        // Count badges should show related dimensions
+        await expect(page.locator('[aria-label="1 related dimensions"]').first()).toBeVisible();
     });
 });
 

--- a/frontend/tests/merged-fields.spec.ts
+++ b/frontend/tests/merged-fields.spec.ts
@@ -85,12 +85,12 @@ test.describe('Merged dbt + drafted fields', () => {
 		await page.waitForSelector('[data-testid="app-ready"]', { timeout: 30000 });
 
 		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
-		await expect(page.getByRole('heading', { name: /Clean Customer E2E Details/i })).toBeVisible({
+		await expect(page.getByRole('heading', { name: /Clean Customer E2E/i })).toBeVisible({
 			timeout: 15000,
 		});
 
 		const dialog = page.getByRole('dialog').filter({
-			has: page.getByRole('heading', { name: /Clean Customer E2E Details/i }),
+			has: page.getByRole('heading', { name: /Clean Customer E2E/i }),
 		});
 
 		await expect(dialog.getByPlaceholder('attribute_name')).toHaveCount(7);
@@ -109,12 +109,12 @@ test.describe('Merged dbt + drafted fields', () => {
 		await expect(dialog).toBeHidden({ timeout: 10000 });
 
 		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
-		await expect(page.getByRole('heading', { name: /Clean Customer E2E Details/i })).toBeVisible({
+		await expect(page.getByRole('heading', { name: /Clean Customer E2E/i })).toBeVisible({
 			timeout: 15000,
 		});
 
 		const dialog2 = page.getByRole('dialog').filter({
-			has: page.getByRole('heading', { name: /Clean Customer E2E Details/i }),
+			has: page.getByRole('heading', { name: /Clean Customer E2E/i }),
 		});
 		await expect(dialog2.getByTestId('merged-field-row-pending_col')).toBeVisible();
 
@@ -168,12 +168,12 @@ models:
 		await page.waitForSelector('[data-testid="app-ready"]', { timeout: 30000 });
 
 		await page.getByRole('row', { name: /Clean Customer E2E/i }).click();
-		await expect(page.getByRole('heading', { name: /Clean Customer E2E Details/i })).toBeVisible({
+		await expect(page.getByRole('heading', { name: /Clean Customer E2E/i })).toBeVisible({
 			timeout: 15000,
 		});
 
 		const dialog = page.getByRole('dialog').filter({
-			has: page.getByRole('heading', { name: /Clean Customer E2E Details/i }),
+			has: page.getByRole('heading', { name: /Clean Customer E2E/i }),
 		});
 
 		const idRow = dialog.getByTestId('merged-field-row-id');


### PR DESCRIPTION
## Summary

- Users can bind a dbt model to an entity directly from the entity details.
- Users can search and select models, including adding multiple models to one entity.
- Users can drag a model from the sidebar onto an entity without opening the details view.
- Bound model names are now easier to identify.
- Usage counts in the Bus Matrix now explain what they represent.

