### PR TITLE
feat: implement relationship removal on entity deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-08-18
+
+### Fixed
+- **Entity deletion cleans up relationships**: deleting an entity now removes all
+  relationships connected to it instead of leaving dangling edges in the data model.
+
 
 ## [0.23.0] - 2026-08-18
 

--- a/frontend/src/lib/components/EntityDetailModal.svelte
+++ b/frontend/src/lib/components/EntityDetailModal.svelte
@@ -805,6 +805,13 @@
 	function confirmDelete() {
 		if (!currentEntity) return;
 
+		// Remove all relationships that reference the deleted entity.
+		edges.update((edgeList) =>
+			edgeList.filter(
+				(edge) => edge.source !== currentEntity.id && edge.target !== currentEntity.id
+			)
+		);
+
 		// Remove node from store
 		nodes.update((n) => n.filter((node) => node.id !== currentEntity.id));
 

--- a/frontend/src/lib/components/EntityDetailModal.test.ts
+++ b/frontend/src/lib/components/EntityDetailModal.test.ts
@@ -499,6 +499,32 @@ describe('EntityDetailModal — Relationships section', () => {
     expect(goto).toHaveBeenCalledWith('/entity-list/node-ir');
   });
 
+  it('removes relationships when deleting an entity', async () => {
+    setupEntityWithRelationship();
+    edges.update((edgeList) => [
+      ...edgeList,
+      {
+        id: 'e-lead-ir',
+        source: 'node-lead',
+        target: 'node-ir',
+        type: 'custom',
+      },
+      {
+        id: 'e-unrelated',
+        source: 'node-ir',
+        target: 'node-other',
+        type: 'custom',
+      },
+    ] as any);
+    await renderModal();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete Entity' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete', exact: true }));
+
+    expect(get(nodes).map((node) => node.id)).toEqual(['node-ir']);
+    expect(get(edges).map((edge) => edge.id)).toEqual(['e-unrelated']);
+  });
+
   it('does not render the Relationships section when the entity has no edges', async () => {
     nodes.set([
       { id: 'node-lead', type: 'entity', position: { x: 0, y: 0 }, data: { label: 'Lead' } },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trellis-datamodel"
-version = "0.23.0"
+version = "0.23.1"
 description = "Visual data model editor for dbt and Bruin projects"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Ensure deleting an entity from the Entity Detail modal also removes all connected relationships.
- Add regression coverage for incoming, outgoing, and unrelated relationships.

## Motivation

Prevents orphaned relationships from remaining in `data_model.yml` after an entity is deleted.

## Breaking Changes

None.

## Tests

- Linter diagnostics passed.
- Unit test added but not executed because the environment could not start `zsh`.